### PR TITLE
Clarify CJALR operation order

### DIFF
--- a/src/insns/cjalr_jalr_32bit.adoc
+++ b/src/insns/cjalr_jalr_32bit.adoc
@@ -6,7 +6,7 @@
 See <<JALR>>
 
 [#JALR,reftext="JALR"]
-==== CJAL, JALR
+==== CJALR, JALR
 
 Synopsis::
 Jump and link register
@@ -50,7 +50,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         |      | ✔     | `cs1` has tag set to 0
 | Seal violation        |      | ✔     | `cs1` is sealed and the immediate is not 0
 | Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>
-| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds
+| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds. This check uses the address after it has undergone xref:section_invalid_addr_conv[xrefstyle=short] but with the original bounds.
 |==============================================================================
 
 include::pcrel_debug_warning.adoc[]


### PR DESCRIPTION
Clarify that length violations are checked on the address after it has undergone invalid address conversion.

Also fix a typo in the title.

Fixes #9