### PR TITLE
Support building HTML output

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -8,7 +8,7 @@ on:
         description: 'Release version, e.g. X.Y.Z:'
         required: true
         type: string
-      revision_mark: 
+      revision_mark:
           description: 'Set revision mark as Draft, Release or Stable:'
           required: true
           type: string
@@ -45,29 +45,33 @@ jobs:
 
     # Step 3: Build Files
     - name: Build Files
-      run: make
+      run: make all
       env:
         VERSION: v${{ github.event.inputs.version }}
         REVMARK: ${{ github.event.inputs.revision_mark }}
 
-    # Step 4: Upload the built PDF files as a single artifact
+    # Step 4: Upload the built PDF and HTML files as a single artifact
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Build Artifacts
-        path: ${{ github.workspace }}/build/*.pdf
+        path: |
+          ${{ github.workspace }}/build/*.pdf
+          ${{ github.workspace }}/build/*.html
         retention-days: 30
-      
+
     # Create Release
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
-        files: ${{ github.workspace }}/build/*.pdf
+        files: |
+          ${{ github.workspace }}/build/*.pdf
+          ${{ github.workspace }}/build/*.html
         tag_name: v${{ github.event.inputs.version }}
         name: Release ${{ github.event.inputs.version }}
         draft: ${{ github.event.inputs.draft }}
         prerelease: ${{ github.event.inputs.prerelease }}
       env:
         GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
-      if: github.event_name == 'workflow_dispatch' 
+      if: github.event_name == 'workflow_dispatch'
       # This condition ensures this step only runs for workflow_dispatch events.


### PR DESCRIPTION
Add support for building the HTML version of the specification. By default `make` will still only build the PDF version; `make pdf` or `make html` will build one or the other, and `make all` will build both. `make all` is run in CI.

I also deduplicated the asciidoc commands a bit, and fixed ctrl-c for the docker builds.

See #8