### PR TITLE
Specify value of mode bit in null/infinite caps

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -459,10 +459,11 @@ or 'root' capability.
 | B       | zeros | Base address bits
 | B~E~    | zeros | Exponent bits
 | Address | zeros | Capability address
+| Reserved| zeros | All reserved fields
 |==============================================================================
 
 .Field values of the Infinite capability
-[#infinite-cap,reftext="Infinity"]
+[#infinite-cap,reftext="Infinite"]
 [options=header,width="100%",align=center,width="55%",cols="1,1,3"]
 |==============================================================================
 | Field   | Value | Comment
@@ -476,6 +477,7 @@ or 'root' capability.
 | B       | zeros | Base address bits
 | B~E~    | zeros | Exponent bits
 | Address | zeros | Capability address
+| Reserved| zeros | All reserved fields
 |==============================================================================
 
 [#section_cap_representable_check]
@@ -520,4 +522,3 @@ bits!
 
 Capabilities with malformed bounds are always invalid anywhere in the system
 i.e. their tags are always 0.
-

--- a/src/riscv-mode-integration.adoc
+++ b/src/riscv-mode-integration.adoc
@@ -32,6 +32,8 @@ include::img/cap-encoding-xlen64-mode.edn[]
 not grant <<x_perm>>. In this case, the M bit is superfluous, so the encoding
 may be used to support additional features in future extensions.
 
+The M bit is 0 in both the <<null-cap>> and <<infinite-cap>> capabilities.
+
 [#section_mode_cap_instructions]
 === Zcheri_mode Instructions
 


### PR DESCRIPTION
* Specify that M is 0 in both the infinite and null caps.
* Add 'Reserved' row to null/infinite cap table
* Change ref text for <<infinite-cap>> from "Infinity" to "Infinite" since that's how it is referred to elsewhere.

Fixes #13