### PR TITLE
Deploy to Github pages on release

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      pages:
+        description: 'Deploy HTML to Github pages?'
+        required: false
+        type: boolean
+        default: false
   pull_request:
   push:
     branches:
@@ -33,40 +38,51 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    # Step 1: Checkout the repository
+    # Checkout the repository
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
         submodules: 'recursive'
 
-    # Step 2: Pull the latest RISC-V Docs container image
+    # Pull the latest RISC-V Docs container image
     - name: Pull Container
       run: docker pull riscvintl/riscv-docs-base-container-image:latest
 
-    # Step 3: Build Files
+    # Build PDF and HTML.
     - name: Build Files
       run: make all
       env:
         VERSION: v${{ github.event.inputs.version }}
         REVMARK: ${{ github.event.inputs.revision_mark }}
 
-    # Step 4: Upload the built PDF and HTML files as a single artifact
+    # Upload the built PDF and HTML files as a single artifact
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v3
       with:
         name: Build Artifacts
         path: |
-          ${{ github.workspace }}/build/*.pdf
-          ${{ github.workspace }}/build/*.html
+          build/*.pdf
+          build/*.html
         retention-days: 30
+
+    # Upload gitlab pages artefact.
+    - name: Make gitlab pages directory
+      run: mkdir dist && cp build/*.html dist/index.html
+      if: github.event_name == 'workflow_dispatch'
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: dist
+      if: github.event_name == 'workflow_dispatch'
 
     # Create Release
     - name: Create Release
       uses: softprops/action-gh-release@v1
       with:
         files: |
-          ${{ github.workspace }}/build/*.pdf
-          ${{ github.workspace }}/build/*.html
+          build/*.pdf
+          build/*.html
         tag_name: v${{ github.event.inputs.version }}
         name: Release ${{ github.event.inputs.version }}
         draft: ${{ github.event.inputs.draft }}
@@ -75,3 +91,23 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GHTOKEN }}
       if: github.event_name == 'workflow_dispatch'
       # This condition ensures this step only runs for workflow_dispatch events.
+
+  # Deploy HTML to Github pages.
+  deploy:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.pages
+
+    needs: build
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
When a manual workflow is triggered this will also deploy the HTML to Github pages (if the relevant option is selected).

Fixes #8 