### PR TITLE
Added exceptions to compressed jump instructions

### DIFF
--- a/src/insns/cj_j_16bit.adoc
+++ b/src/insns/cj_j_16bit.adoc
@@ -33,7 +33,9 @@ Set the next PC following the standard `jal` definition.
  *There is no difference in Capability Mode or Legacy Mode execution for this instruction.*
 
 Exceptions::
-CHERI Length Violation
+See <<CJAL>>, <<JAL>>
+
+include::pcrel_debug_warning.adoc[]
 
 Prerequisites for C.CJ::
 {c_cheri_base_ext_names}

--- a/src/insns/cjal_jal_16bit.adoc
+++ b/src/insns/cjal_jal_16bit.adoc
@@ -29,6 +29,11 @@ include::wavedrom/c-cjal-format-ls.adoc[]
 
 include::cjal_jal_common.adoc[]
 
+Exceptions::
+See <<CJAL>>, <<JAL>>
+
+include::pcrel_debug_warning.adoc[]
+
 Prerequisites for C.CJAL::
 {c_cheri_base_ext_names}
 

--- a/src/insns/cjalr_jalr_16bit.adoc
+++ b/src/insns/cjalr_jalr_16bit.adoc
@@ -29,6 +29,11 @@ include::wavedrom/c-cjalr-format-ls.adoc[]
 
 include::cjalr_jalr_common.adoc[]
 
+Exceptions::
+See <<CJALR>>, <<JALR>>
+
+include::pcrel_debug_warning.adoc[]
+
 Prerequisites C.CJALR::
 {c_cheri_base_ext_names}
 

--- a/src/insns/cjr_jr_16bit.adoc
+++ b/src/insns/cjr_jr_16bit.adoc
@@ -1,13 +1,14 @@
 <<<
 //[#insns-cjr_jr-16bit,reftext="Conditional branches (C.CJR, C.JR), 16-bit encodings"]
 
+[#C_JR,reftext="C.JR"]
+==== C.JR
+
+See <<C.CJR>>.
+
 [#C_CJR,reftext="C.CJR"]
 ==== C.CJR
 
-See <<C.JR>>.
-
-[#C_JR,reftext="C.JR"]
-==== C.JR
 
 Synopsis::
 Register based jumps without link, 16-bit encodings
@@ -35,7 +36,7 @@ Set the next PC according to the standard `jalr` definition.
  Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.
 
 Exceptions::
- See <<CJALR>>, <<JALR>>
+See <<CJALR>>, <<JALR>>
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/insns/wavedrom/c-cjalr-format-ls.adoc
+++ b/src/insns/wavedrom/c-cjalr-format-ls.adoc
@@ -4,8 +4,8 @@
 ....
 {reg: [
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
-  {bits: 5, name: 'rs2',     type: 4, attr: ['5','0']},
-  {bits: 5, name: 'rs1',     type: 4, attr: ['5','src!=0']},
+  {bits: 5, name: 'cs2/rs2',     type: 4, attr: ['5','0']},
+  {bits: 5, name: 'cs1/rs1',     type: 4, attr: ['5','src!=0']},
   {bits: 4, name: 'funct4',  type: 8, attr: ['4', 'cap: C.CJALR=1001', 'leg: C.JALR=1001']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-cr-format-ls.adoc
+++ b/src/insns/wavedrom/c-cr-format-ls.adoc
@@ -4,8 +4,8 @@
 ....
 {reg: [
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
-  {bits: 5, name: 'rs2',     type: 4, attr: ['5','0']},
-  {bits: 5, name: 'rs1',     type: 4, attr: ['5','src!=0']},
+  {bits: 5, name: 'cs2/rs2',     type: 4, attr: ['5','0']},
+  {bits: 5, name: 'cs1/rs1',     type: 4, attr: ['5','src!=0']},
   {bits: 4, name: 'funct4',  type: 8, attr: ['4','cap: C.CJR=1000', 'leg: C.JR=1000']},
 ], config: {bits: 16}}
 ....


### PR DESCRIPTION
Some of the compressed jump instructions did not declare that they threw exceptions. I added the references to respective {c}jal{r} instructions. Also I changed the order of c.cjr and c.jr to stay consistent with the rest of the spec.