### PR TITLE
Make permission bit order consistent

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -121,8 +121,8 @@ permissions are granted as follows:
 
 * <<c_perm>>: bit 0 is set
 * <<w_perm>>: bit 1 is set
-* <<x_perm>>: bit 3 is set
 * <<r_perm>>: bits 3 or 2 are set
+* <<x_perm>>: bit 3 is set
 * <<asr_perm>>: bits 3 and 2 are set
 
 A {cap_rv64_perms_width}-bit vector encodes the permissions when XLENMAX=64. In

--- a/src/img/candperms_bit_field.edn
+++ b/src/img/candperms_bit_field.edn
@@ -13,9 +13,9 @@
 (draw-box "Reserved" {:span 11})
 (draw-box "ASR"  {:span 1})
 (draw-box "X"    {:span 1})
-(draw-box "C"    {:span 1})
-(draw-box "W"    {:span 1})
 (draw-box "R"    {:span 1})
+(draw-box "W"    {:span 1})
+(draw-box "C"    {:span 1})
 
 (draw-box "XLEN-SDPLEN-16" {:span 12 :borders {}})
 (draw-box "SDPLEN" {:span 4 :borders {}})


### PR DESCRIPTION
Use the same ordering for permission bits in the RV64 encoding as in CAndPerms etc.

Fixes #25