### PR TITLE
Remove sole reference to embedded exponent

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -225,7 +225,7 @@ address
 into the capability's address
 * *EF:* Exponent format flag indicating the encoding for T, B and E
     ** The exponent is stored in T and B if EF=0, so it is 'internal'
-    ** The exponent is zero if EF=1, so it is 'embedded'
+    ** The exponent is zero if EF=1
 
 The bit width of T and B are defined in terms of the mantissa width (MW) which
 is set depending on the value of XLENMAX as shown in
@@ -505,7 +505,7 @@ bounds are formed of two or three sections:
 * Upper bits from the address
 * Middle bits from T and B decoded from the metadata
 * Lower bits are set to zero
-** This is only if there is an embedded exponent (EF=0)
+** This is only if there is an internal exponent (EF=0)
 
 .Composition of address bounds
 [#comp_addr_bounds,options=header,align="center"]


### PR DESCRIPTION
"Embedded" and "internal" have very similar meanings in English so it's pretty confusing for them to mean opposite things in CHERI. Fortunately there was only one reference to "embedded" so it's easy enough to remove it.