### PR TITLE
fixed prerequisite rules for 16-bit fp dp load/store

### DIFF
--- a/src/insns/load_16bit_fp_dp.adoc
+++ b/src/insns/load_16bit_fp_dp.adoc
@@ -52,10 +52,12 @@ Standard floating point stack pointer relative load instructions, authorised by 
 include::load_exceptions.adoc[]
 
 Prerequisites for C.CFLD, C.CFLDSP (RV32 only)::
-{c_cheri_base_ext_names}, and Zcd or D
+{cheri_base_ext_name}, C and D
+{cheri_base_ext_name}, Zca and Zcd
 
 Prerequisites for C.FLD, C.FLDSP::
-{c_cheri_legacy_ext_names}, and Zcd or D
+{cheri_base_ext_name}, C and D
+{cheri_base_ext_name}, Zca and Zcd
 
 Operation (after expansion to 32-bit encodings)::
  See <<FLD>>

--- a/src/insns/load_16bit_fp_dp.adoc
+++ b/src/insns/load_16bit_fp_dp.adoc
@@ -52,11 +52,11 @@ Standard floating point stack pointer relative load instructions, authorised by 
 include::load_exceptions.adoc[]
 
 Prerequisites for C.CFLD, C.CFLDSP (RV32 only)::
-{cheri_base_ext_name}, C and D
+{cheri_base_ext_name}, C and D; or +
 {cheri_base_ext_name}, Zca and Zcd
 
 Prerequisites for C.FLD, C.FLDSP::
-{cheri_base_ext_name}, C and D
+{cheri_base_ext_name}, C and D; or +
 {cheri_base_ext_name}, Zca and Zcd
 
 Operation (after expansion to 32-bit encodings)::

--- a/src/insns/store_16bit_fp_dp.adoc
+++ b/src/insns/store_16bit_fp_dp.adoc
@@ -52,10 +52,12 @@ Standard floating point stack pointer relative store instructions, authorised by
 include::store_exceptions.adoc[]
 
 Prerequisites for C.CFSD, C.CFSDSP (RV32 only)::
-{c_cheri_base_ext_names}, and Zcd or D
+{cheri_base_ext_name}, C and D
+{cheri_base_ext_name}, Zca and Zcd
 
 Prerequisites for C.FSD, C.FSDSP::
-{c_cheri_legacy_ext_names}, and Zcd or D
+{cheri_legacy_ext_name}, C and D
+{cheri_legacy_ext_name}, Zca and Zcd
 
 Operation (after expansion to 32-bit encodings)::
  See <<CFSD>>, <<FSD>>

--- a/src/insns/store_16bit_fp_dp.adoc
+++ b/src/insns/store_16bit_fp_dp.adoc
@@ -52,11 +52,11 @@ Standard floating point stack pointer relative store instructions, authorised by
 include::store_exceptions.adoc[]
 
 Prerequisites for C.CFSD, C.CFSDSP (RV32 only)::
-{cheri_base_ext_name}, C and D
+{cheri_base_ext_name}, C and D; or +
 {cheri_base_ext_name}, Zca and Zcd
 
 Prerequisites for C.FSD, C.FSDSP::
-{cheri_legacy_ext_name}, C and D
+{cheri_legacy_ext_name}, C and D; or +
 {cheri_legacy_ext_name}, Zca and Zcd
 
 Operation (after expansion to 32-bit encodings)::


### PR DESCRIPTION
Hopefully the correct fix for https://github.com/riscv/riscv-cheri/issues/29 this time