### PR TITLE
Add newline between includes to fix chapter headers

### DIFF
--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -29,27 +29,41 @@ include::insns/cmove_32bit.adoc[]
 include::insns/modeswitch_32bit.adoc[]
 
 include::insns/cincoffset_32bit.adoc[]
+
 include::insns/csetaddr_32bit.adoc[]
+
 include::insns/candperm_32bit.adoc[]
+
 include::insns/csetmode_32bit.adoc[]
+
 include::insns/csethigh_32bit.adoc[]
+
 include::insns/csetequalexact_32bit.adoc[]
+
 include::insns/cseal_32bit.adoc[]
 
 include::insns/ctestsubset_32bit.adoc[]
+
 include::insns/cbuildcap_32bit.adoc[]
 
 include::insns/cgettag_32bit.adoc[]
+
 include::insns/cgetperm_32bit.adoc[]
+
 include::insns/cgethigh_32bit.adoc[]
+
 include::insns/cgetbase_32bit.adoc[]
+
 include::insns/cgetlen_32bit.adoc[]
 
 include::insns/csetbounds_32bit.adoc[]
+
 include::insns/csetboundsinexact_32bit.adoc[]
+
 include::insns/cram_32bit.adoc[]
 
 include::insns/load_32bit_cap.adoc[]
+
 include::insns/store_32bit_cap.adoc[]
 
 <<<
@@ -60,36 +74,44 @@ include::insns/auipcc_32bit.adoc[]
 include::insns/condbr_32bit.adoc[]
 
 include::insns/cjalr_jalr_32bit.adoc[]
+
 include::insns/cjal_jal_32bit.adoc[]
 
 include::insns/load_32bit.adoc[]
+
 include::insns/store_32bit.adoc[]
 
 include::insns/mret_sret.adoc[]
+
 include::insns/dret.adoc[]
 
 <<<
 === "A" Standard Extension for Atomic Instructions
 
 include::insns/amo_32bit.adoc[]
+
 include::insns/amoswap_32bit_cap.adoc[]
 
 include::insns/load_res_32bit.adoc[]
+
 include::insns/load_res_cap_32bit.adoc[]
 
 include::insns/store_cond_32bit.adoc[]
+
 include::insns/store_cond_cap_32bit.adoc[]
 
 <<<
 === "Zicsr", Control and Status Register (CSR) Instructions
 
 include::insns/csrrw_32bit.adoc[]
+
 include::insns/csrr_32bit.adoc[]
 
 <<<
 === "Zfh", "Zfhmin", "F" and "D" Standard Extension for Floating-Point
 
 include::insns/load_32bit_fp.adoc[]
+
 include::insns/store_32bit_fp.adoc[]
 
 <<<
@@ -100,45 +122,65 @@ include::insns/condbr_16bit.adoc[]
 include::insns/cmove_cmv_16bit.adoc[]
 
 include::insns/addi16sp_16bit.adoc[]
+
 include::insns/addi4spn_16bit.adoc[]
 
 include::insns/modeswitch_16bit.adoc[]
 
 include::insns/cjalr_jalr_16bit.adoc[]
+
 include::insns/cjr_jr_16bit.adoc[]
+
 include::insns/cjal_jal_16bit.adoc[]
+
 include::insns/cj_j_16bit.adoc[]
 
 include::insns/load_16bit.adoc[]
+
 include::insns/load_16bit_sprel.adoc[]
+
 include::insns/load_16bit_fp_sp.adoc[]
+
 include::insns/load_16bit_fp_dp.adoc[]
+
 include::insns/load_16bit_cap_sprel.adoc[]
 
 include::insns/store_16bit.adoc[]
+
 include::insns/store_16bit_sprel.adoc[]
+
 include::insns/store_16bit_fp_sp.adoc[]
+
 include::insns/store_16bit_fp_dp.adoc[]
+
 include::insns/store_16bit_cap_sprel.adoc[]
 
 <<<
 === "Zicbom", "Zicbop", "Zicboz" Standard Extensions for Base Cache Management Operations
 
 include::insns/cbo.clean.adoc[]
+
 include::insns/cbo.flush.adoc[]
+
 include::insns/cbo.inval.adoc[]
+
 include::insns/cbo.zero.adoc[]
 
 include::insns/prefetch.i.adoc[]
+
 include::insns/prefetch.r.adoc[]
+
 include::insns/prefetch.w.adoc[]
 
 <<<
 === "Zba" Extension for Bit Manipulation Instructions
 
 include::insns/sh123add_32bit.adoc[]
+
 include::insns/sh123adduw_32bit.adoc[]
+
 include::insns/sh4add_32bit.adoc[]
+
 include::insns/sh4adduw_32bit.adoc[]
 
 <<<
@@ -174,10 +216,15 @@ The double move instructions (<<CM.MVSA01>>, <<CM.MVA01S>>) are redefined in cap
 All instructions are defined in cite:[riscv-code-size-spec].
 
 include::insns/zcmp_cmpush.adoc[]
+
 include::insns/zcmp_cmpop.adoc[]
+
 include::insns/zcmp_cmpopret.adoc[]
+
 include::insns/zcmp_cmpopretz.adoc[]
+
 include::insns/zcmp_cmvsa01.adoc[]
+
 include::insns/zcmp_cmva01s.adoc[]
 
 
@@ -211,6 +258,7 @@ All instruction fetches from the jump vector table are checked against <<jvtc>>.
 See <<CM.CJALT>>, <<CM.JALT>>, <<CM.CJT>>, <<CM.JT>>.
 
 include::insns/zcmt_cmjalt.adoc[]
+
 include::insns/zcmt_cmjt.adoc[]
 
 <<<
@@ -224,30 +272,53 @@ include::cheri-vector.adoc[]
 include::cheri-vectorcap-ext.adoc[]
 
 include::insns/cvle_ew.adoc[]
+
 include::insns/cvse_ew.adoc[]
+
 include::insns/cvlm.adoc[]
+
 include::insns/cvsm.adoc[]
+
 include::insns/cvlse_ew.adoc[]
+
 include::insns/cvsse_ew.adoc[]
+
 include::insns/cvluxei_ew.adoc[]
+
 include::insns/cvsuxei_ew.adoc[]
+
 include::insns/cvloxei_ew.adoc[]
+
 include::insns/cvsoxei_ew.adoc[]
+
 include::insns/cvle_ew_ff.adoc[]
+
 include::insns/cvlseg_nf_e_ew.adoc[]
+
 include::insns/cvsseg_nf_e_ew.adoc[]
+
 include::insns/cvlseg_nf_e_ew_ff.adoc[]
+
 include::insns/cvlsseg_nf_e_ew.adoc[]
+
 include::insns/cvssseg_nf_e_ew.adoc[]
+
 include::insns/cvluxseg_nf_ei_ew.adoc[]
+
 include::insns/cvsuxseg_nf_ei_ew.adoc[]
+
 include::insns/cvloxseg_nf_ei_ew.adoc[]
+
 include::insns/cvsoxseg_nf_ei_ew.adoc[]
+
 include::insns/cvl_nr_re_ew.adoc[]
+
 include::insns/cvs_nr_r.adoc[]
 
 include::insns/cvlce_ew.adoc[]
+
 include::insns/cvsce_ew.adoc[]
+
 // Should whole vector register load capability be supported?
 // Should whole vector register store capability be supported?
 include::insns/cvmv_nr_r.adoc[]

--- a/src/riscv-cheri.adoc
+++ b/src/riscv-cheri.adoc
@@ -114,13 +114,21 @@ include::contributors.adoc[]
 ///////////////////////////////////////////////////////////////////////////////
 
 include::introduction.adoc[]
+
 include::cap-description.adoc[]
+
 include::riscv-integration.adoc[]
+
 include::debug-integration.adoc[]
+
 include::cheri-pte-ext.adoc[]
+
 include::riscv-legacy-integration.adoc[]
+
 include::riscv-mode-integration.adoc[]
+
 include::instructions.adoc[]
+
 include::tables.adoc[]
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -129,4 +137,5 @@ include::tables.adoc[]
 
 // The index must precede the bibliography
 include::index.adoc[]
+
 include::bibliography.adoc[]


### PR DESCRIPTION
Fixes this kind of problem in the generated PDF/HTML: https://riscv.github.io/riscv-cheri/#menvcfg_pte

(Section header for the Zcheri_legacy chapter got inlined as text in the previous section)