### PR TITLE
github workflow: update action

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -66,7 +66,7 @@ jobs:
 
       # Upload the built PDF and HTML files as a single artifact
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Build Artifacts
           path: |


### PR DESCRIPTION
Avoid CI warning that node.js 16 is deprecated.

See https://github.com/riscv/riscv-cheri/actions/runs/7714759013: `Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.`