### PR TITLE
Merge from templates repo

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -66,7 +66,7 @@ jobs:
 
       # Upload the built PDF and HTML files as a single artifact
       - name: Upload Build Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Build Artifacts
           path: |

--- a/readme.adoc
+++ b/readme.adoc
@@ -19,7 +19,7 @@ For guidelines on how to contribute, refer to the link:CONTRIBUTING.md[CONTRIBUT
 To build the document, you'll need the following tools installed on your system:
 
 * Make
-* asciiDoctor-pdf, asciidoctor-bibtex, asciidoctor-diagram and asciidoctor-mathematical
+* asciiDoctor-pdf, asciidoctor-bibtex, asciidoctor-diagram, and asciidoctor-mathematical
 * Docker
 * Python3
 

--- a/src/riscv-cheri.adoc
+++ b/src/riscv-cheri.adoc
@@ -13,7 +13,8 @@ Authors: Hesham Almatary, Andres Amaya Garcia, John Baldwin, David Chisnall, Jes
 :colophon:
 :appendix-caption: Appendix
 :imagesdir: {imagesdir}
-:title-logo-image: image:risc-v_logo.png[pdfwidth=3.25in,align=center]
+:title-logo-image: image:risc-v_logo.png["RISC-V International Logo",pdfwidth=3.25in,align=center]
+// Settings:
 :experimental:
 :reproducible:
 :imagesoutdir: {imagesoutdir}


### PR DESCRIPTION
Since the initial commit was squashed, this uses --allow-unrelated-histories to bring back the templates history.

See #77 