### PR TITLE
Deploy GitHub pages on every commit to main

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -28,11 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      pages:
-        description: Deploy HTML to Github pages?
-        required: false
-        type: boolean
-        default: false
   pull_request:
   push:
     branches:
@@ -54,11 +49,16 @@ jobs:
         run: docker pull riscvintl/riscv-docs-base-container-image:latest
 
       # Override VERSION and REVMARK for manual workflow dispatch
-      - name: Update environment variables
+      - name: Update environment variables for releases
         run: |
           echo "VERSION=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
           echo "REVMARK=${{ github.event.inputs.revision_mark }}" >> "$GITHUB_ENV"
         if: github.event_name == 'workflow_dispatch'
+
+      - name: Update environment variables for push events
+        run: |
+          echo "EXTRA_ASCIIDOC_OPTIONS=-a github_commit_sha=$GITHUB_SHA" >> "$GITHUB_ENV"
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
       # Build PDF and HTML.
       - name: Build Files
@@ -77,13 +77,13 @@ jobs:
       # Upload GitHub pages artefacts.
       - name: Make gitlab pages directory
         run: mkdir dist && cp build/*.html dist/index.html
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'push'
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: dist
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' || github.event_name == 'push'
 
       # Create Release
       - name: Create Release
@@ -103,7 +103,7 @@ jobs:
 
   # Deploy HTML to Github pages.
   deploy:
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 
     needs: build
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,7 @@ GEN_SRC = $(GEN_DIR)/both_mode_insns_table_body.adoc               \
 
 # AsciiDoctor command
 ASCIIDOC          = asciidoctor-pdf
+EXTRA_ASCIIDOC_OPTIONS ?=
 
 ASCIIDOC_OPTIONS  = --trace                                          \
                     -a compress                                      \
@@ -96,7 +97,7 @@ ASCIIDOC_OPTIONS  = --trace                                          \
                     -a cheri_v9_annotations=''                       \
                     -a pdf-fontsdir=docs-resources/fonts             \
                     -a pdf-theme=docs-resources/themes/riscv-pdf.yml \
-                    --failure-level=ERROR
+                    --failure-level=ERROR $(EXTRA_ASCIIDOC_OPTIONS)
 ASCIIDOC_REQUIRES = --require=asciidoctor-bibtex       \
                     --require=asciidoctor-diagram      \
                     --require=asciidoctor-mathematical

--- a/src/riscv-cheri.adoc
+++ b/src/riscv-cheri.adoc
@@ -90,6 +90,12 @@ endif::[]
 // Preface
 ///////////////////////////////////////////////////////////////////////////////
 
+ifdef::github_commit_sha[]
+[IMPORTANT]
+This document is a specification snapshot built from https://github.com/riscv/riscv-cheri/commit/{github_commit_sha} and is not a versioned release.
+The latest versioned PDF release can be downloaded from https://github.com/riscv/riscv-cheri/releases.
+endif::[]
+
 [WARNING]
 .This document is in the link:http://riscv.org/spec-state[Development state]
 ====


### PR DESCRIPTION
This adds a note to the generated HTML that this page is a snapshot and the PDF should be treated as the latest source. Automatically deploying each commit to https://riscv.github.io/riscv-cheri/ makes it easier to read the latest snapshot version of the spec without requiring a new release.

Fixes: https://github.com/riscv/riscv-cheri/issues/74