### PR TITLE
Fix issue 90

### DIFF
--- a/src/csv/CHERI_CSR.csv
+++ b/src/csv/CHERI_CSR.csv
@@ -8,11 +8,11 @@ direct write if address didn't change","✔","","✔","","✔","✔","Sdext","De
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
-Vector range check ^*^ if vectored mode is programmed.","✔","","","","✔","✔","None","Machine Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
-"mscratchc","0x760","mscratch","0x340","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","None","Machine Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
+Vector range check ^*^ if vectored mode is programmed.","✔","","","","✔","✔","M-mode","Machine Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
+"mscratchc","0x760","mscratch","0x340","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","M-mode","Machine Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
 "mepcc","0x761","mepc","0x341","M","MRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
-direct write if address didn't change","✔","","✔","","✔","✔","None","Machine Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
+direct write if address didn't change","✔","","✔","","✔","✔","M-mode","Machine Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
 "stvecc","0x505","stvec","0x105","S","SRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
@@ -26,7 +26,7 @@ direct write if address didn't change","✔","","✔","","✔","✔","S-mode","S
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","","","✔","✔","Zcmt","Jump Vector Table Capability","","","","","","","","","","","","","","","","","","","","",""
 "dddc","0x7bc","","","D","DRW","tag=0, otherwise undefined","","","","✔","","","✔","","Sdext","Debug Default Data Capabilty (saved/restored on debug mode entry/exit)","","","","","","","","","","","","","","","","","","","","",""
-"mtdc","0x74c","","","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","None","Machine Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
+"mtdc","0x74c","","","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","M-mode","Machine Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
 "stdc","0x163","","","S","SRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","S-mode","Supervisor Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
 "ddc","0x416","","","U","URW","<<infinite-cap>>","","","","✔","","","✔","","none","User Default Data Capability","","","","","","","","","","","","","","","","","","","","",""
 "dinfc","0x7bd","","","D","DRW","<<infinite-cap>>","","","","","","✔","✔","✔","Sdext","Source of <<infinite-cap>> capability in debug mode, writes are ignored","","","","","","","","","","","","","","","","","","","","",""

--- a/src/csv/CHERI_CSR.csv
+++ b/src/csv/CHERI_CSR.csv
@@ -29,4 +29,4 @@ direct write if address didn't change","✔","","","","✔","✔","Zcmt","Jump V
 "mtdc","0x74c","","","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","None","Machine Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
 "stdc","0x163","","","S","SRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","S-mode","Supervisor Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
 "ddc","0x416","","","U","URW","<<infinite-cap>>","","","","✔","","","✔","","none","User Default Data Capability","","","","","","","","","","","","","","","","","","","","",""
-"dinfc","0x7bc","","","D","DRW","<<infinite-cap>>","","","","","","✔","✔","✔","Sdext","Source of <<infinite-cap>> capability in debug mode, writes are ignored","","","","","","","","","","","","","","","","","","","","",""
+"dinfc","0x7bd","","","D","DRW","<<infinite-cap>>","","","","","","✔","✔","✔","Sdext","Source of <<infinite-cap>> capability in debug mode, writes are ignored","","","","","","","","","","","","","","","","","","","","",""

--- a/src/csv/CHERI_CSR.csv
+++ b/src/csv/CHERI_CSR.csv
@@ -1,18 +1,18 @@
 "Extended CSR","CLEN Address","Alias","XLEN Address","Mode","Permissions","Reset Value","Action on XLEN write","Action on CLEN write","Executable Vector","Data Pointer","Unseal On Execution","Store full metadata","Zcheri_legacy","Zcheri_purecap","Prerequisites","Description","","","","","","","","","","","","","","","","","","","","",""
-"dpcc","0x7b9","dpc","0x7b1","D","DRW, <<asr_perm>>","tag=0, otherwise undefined","Apply <<section_invalid_addr_conv>>.
+"dpcc","0x7b9","dpc","0x7b1","D","DRW","tag=0, otherwise undefined","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","✔","","✔","✔","Sdext","Debug Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
-"dscratch0c","0x7ba","dscratch0","0x7b2","D","DRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","Sdext","Debug Scratch Capability 0","","","","","","","","","","","","","","","","","","","","",""
-"dscratch1c","0x7bb","dscratch1","0x7b3","D","DRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","Sdext","Debug Scratch Capability 1","","","","","","","","","","","","","","","","","","","","",""
+"dscratch0c","0x7ba","dscratch0","0x7b2","D","DRW","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","Sdext","Debug Scratch Capability 0","","","","","","","","","","","","","","","","","","","","",""
+"dscratch1c","0x7bb","dscratch1","0x7b3","D","DRW","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","Sdext","Debug Scratch Capability 1","","","","","","","","","","","","","","","","","","","","",""
 "mtvecc","0x765","mtvec","0x305","M","MRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
-Vector range check ^*^ if vectored mode is programmed.","✔","","","","✔","✔","M-mode","Machine Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
-"mscratchc","0x760","mscratch","0x340","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","M-mode","Machine Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
+Vector range check ^*^ if vectored mode is programmed.","✔","","","","✔","✔","None","Machine Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
+"mscratchc","0x760","mscratch","0x340","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","✔","✔","✔","None","Machine Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
 "mepcc","0x761","mepc","0x341","M","MRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
-direct write if address didn't change","✔","","✔","","✔","✔","M-mode","Machine Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
+direct write if address didn't change","✔","","✔","","✔","✔","None","Machine Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
 "stvecc","0x505","stvec","0x105","S","SRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
@@ -25,9 +25,8 @@ direct write if address didn't change","✔","","✔","","✔","✔","S-mode","S
 "jvtc","0x417","jvt","0x017","U","URW","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","","","✔","✔","Zcmt","Jump Vector Table Capability","","","","","","","","","","","","","","","","","","","","",""
-"dddc","0x7bc","","","D","DRW, <<asr_perm>>","tag=0, otherwise undefined","","","","✔","","","✔","","Sdext","Debug Default Data Capabilty (saved/restored on debug mode entry/exit)","","","","","","","","","","","","","","","","","","","","",""
-"mtdc","0x74c","","","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","M-mode","Machine Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
+"dddc","0x7bc","","","D","DRW","tag=0, otherwise undefined","","","","✔","","","✔","","Sdext","Debug Default Data Capabilty (saved/restored on debug mode entry/exit)","","","","","","","","","","","","","","","","","","","","",""
+"mtdc","0x74c","","","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","None","Machine Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
 "stdc","0x163","","","S","SRW, <<asr_perm>>","tag=0, otherwise undefined","","","","","","","✔","","S-mode","Supervisor Trap Data Capability (scratch register)","","","","","","","","","","","","","","","","","","","","",""
 "ddc","0x416","","","U","URW","<<infinite-cap>>","","","","✔","","","✔","","none","User Default Data Capability","","","","","","","","","","","","","","","","","","","","",""
-"pcc","0xcb0","","","U","URO","<<infinite-cap>>
-(address = boot address)","","","✔","","","","✔","✔","none","User Program Counter Capability (to allow reading in legacy mode)","","","","","","","","","","","","","","","","","","","","",""
+"dinfc","0x7bc","","","D","DRW","<<infinite-cap>>","","","","","","✔","✔","✔","Sdext","Source of <<infinite-cap>> capability in debug mode, writes are ignored","","","","","","","","","","","","","","","","","","","","",""

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -5,6 +5,9 @@ This section describes changes to integrate the Sdext ISA and
 {cheri_base_ext_name}. It must be implemented to make external debug compatible
 with {cheri_base_ext_name}. Modifications to Sdext are kept to a minimum.
 
+WARNING: This section is preliminary as no-one has yet built debug support
+ for CHERI-RISC-V so change is likely.
+
 === Debug Mode
 
 When executing code due to an abstract command, the hart stays in debug mode
@@ -59,7 +62,7 @@ Upon entry to debug mode, cite:[riscv-debug-spec], does not specify how to
 update the PC, and says PC relative instructions may be illegal. This concept
 is extended to include any instruction which reads or updates <<pcc>>, which refers to
 all jumps, conditional branches and <<AUIPC>>. The exception is <<MODESW>>
-which _is_ supported if {cheri_mode_ext_name} is implemented, see <<dfinc>>
+which _is_ supported if {cheri_mode_ext_name} is implemented, see <<dinfc>>
 for details.
 
 As a result, the value of <<pcc>> is UNSPECIFIED in debug mode according

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -11,6 +11,25 @@ When executing code due to an abstract command, the hart stays in debug mode
 and the rules outlined in Section 4.1 of cite:[riscv-debug-spec]
 apply.
 
+==== CHERI Mode when in Debug Mode
+
+When entering debug mode, the CHERI mode is always the same, and may be
+switchable depending on which extensions have been implemented.
+
+If {cheri_mode_ext_name} is implemented:
+
+* the core enters Legacy Mode when entering debug mode,
+ and the mode can be switched using <<MODESW>>.
+
+If {cheri_legacy_ext_name} and not {cheri_mode_ext_name} are implemented:
+
+* the core enters Capability Mode when entering debug mode,
+ and the mode cannot be switched to Legacy Mode.
+
+If {cheri_base_ext_name} only is implemented:
+
+* the core is always in Capability Mode.
+
 === Core Debug Registers
 
 {cheri_base_ext_name} removes debug CSRs that are designated to hold addresses

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -1,5 +1,5 @@
 [#section_debug_integration]
-== Integrating Zcheri_purecap with Sdext
+=== Integrating Zcheri_purecap with Sdext
 
 This section describes changes to integrate the Sdext ISA and
 {cheri_base_ext_name}. It must be implemented to make external debug compatible
@@ -8,22 +8,13 @@ with {cheri_base_ext_name}. Modifications to Sdext are kept to a minimum.
 WARNING: This section is preliminary as no-one has yet built debug support
  for CHERI-RISC-V so change is likely.
 
-=== Debug Mode
+==== Debug Mode
 
 When executing code due to an abstract command, the hart stays in debug mode
 and the rules outlined in Section 4.1 of cite:[riscv-debug-spec]
 apply.
 
-==== CHERI Mode when in Debug Mode
-
-When entering debug mode, the core always enters Capability Mode.
-
-If {cheri_mode_ext_name} is implemented:
-
-. the mode can be switched using <<MODESW>>.
-. the current mode can be observed in <<dinfc>>.M.
-
-=== Core Debug Registers
+==== Core Debug Registers
 
 {cheri_base_ext_name} removes debug CSRs that are designated to hold addresses
 and replaces them with analogous CSRs able to hold capabilities. The removed
@@ -130,11 +121,11 @@ The <<dinfc>> register is a CLEN-bit plus tag bit CSR only accessible in debug m
 
 The reset value is the <<infinite-cap>> capability.
 
-If {cheri_mode_ext_name} is implemented:
+If {cheri_mode_ext_name} (see xref:chapter-Zcheri-mode) is implemented:
 
 . the core enters Capability Mode when entering debug mode
 .. therefore <<dinfc>>.M is set whenever entering debug mode for any reason.
-. the mode can be switched using <<MODESW>>, and the result observed in <<dinfc>>.M.
+. the mode can be optionally switched using <<MODESW>>, and the result observed in <<dinfc>>.M.
 
 <<dinfc>> is read/write but with no writeable fields, and so writes are
 ignored.

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -48,11 +48,15 @@ include::img/dpccreg.edn[]
 
 Upon entry to debug mode, cite:[riscv-debug-spec], does not specify how to
 update the PC, and says PC relative instructions may be illegal. This concept
-is extended to include any instruction which updates <<pcc>>.
+is extended to include any instruction which updates <<pcc>>, which refers to
+all jumps, conditional branches and <<AUIPC>>. The exception is <<MODESW>>
+which _is_ supported if {cheri_mode_ext_name} is implemented, see <<dfinc>>
+for details.
 
-As a result, the value of <<pcc>> is UNSPECIFIED in debug mode, and has no
-architectural effect if PC relative instructions are illegal. Therefore
-<<asr_perm>> is implicitly granted for access to all CSRs in debug mode.
+As a result, the value of <<pcc>> is UNSPECIFIED in debug mode according
+to this specification. The <<pcc>> metadata has no architectural effect in debug
+mode. Therefore <<asr_perm>> is implicitly granted for access to all CSRs and
+no PCC faults are possible.
 
 <<dpcc>> (and consequently <<dpc>>) are updated with the
 capability in <<pcc>> whose address field is set to the address of the next
@@ -111,8 +115,17 @@ include::img/dscratch1creg.edn[]
 ==== Debug Infinite Capability Register (dinfc)
 
 The <<dinfc>> register is a CLEN-bit plus tag bit CSR only accessible in debug mode.
-It returns the value of the <<infinite-cap>> capability. It is read/write but with no
-writeable fields, so writes are ignored.
+
+The reset value is the <<infinite-cap>> capability. The M field (if
+{cheri_mode_ext_name} is implemented) represents the current mode and
+will be only updated if <<MODESW>> is executed.
+
+<<dinfc>> is read/write but with no writeable fields, and so writes are
+ignored.
+
+NOTE: A future version of this specification may add writeable fields to allow creation
+ of other capabilities, if, for example, a future extension requires multiple formats for
+ the <<infinite-cap>> capability.
 
 .Debug infinite capability register
 include::img/dinfcreg.edn[]

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -50,15 +50,14 @@ Upon entry to debug mode, cite:[riscv-debug-spec], does not specify how to
 update the PC, and says PC relative instructions may be illegal. This concept
 is extended to include any instruction which updates <<pcc>>.
 
+As a result, the value of <<pcc>> is UNSPECIFIED in debug mode, and has no
+architectural effect if PC relative instructions are illegal. Therefore
+<<asr_perm>> is implicitly granted for access to all CSRs in debug mode.
+
 <<dpcc>> (and consequently <<dpc>>) are updated with the
 capability in <<pcc>> whose address field is set to the address of the next
-instruction to be executed as described in cite:[riscv-debug-spec].
-
-Additionally, the <<pcc>> is updated as follows:
-
-* All metadata is set to the <<infinite-cap>> capability
-  ** The <<pcc>> may be used as a source of the <<infinite-cap>> capability in
-debug mode to allow other capabilities to be created and written into memory.
+instruction to be executed as described in cite:[riscv-debug-spec] upon
+debug mode entry.
 
 When leaving debug mode, the capability in <<dpcc>> is unsealed and written
 into <<pcc>>.  A debugger may write <<dpcc>> to change where the hart resumes
@@ -107,3 +106,13 @@ The <<dscratch1c>> register is a CLEN-bit plus tag bit extension to
 
 .Debug scratch 1 capability register
 include::img/dscratch1creg.edn[]
+
+[#dinfc,reftext="dinfc"]
+==== Debug Infinite Capability Register (dinfc)
+
+The <<dinfc>> register is a CLEN-bit plus tag bit CSR only accessible in debug mode.
+It returns the value of the <<infinite-cap>> capability. It is read/write but with no
+writeable fields, so writes are ignored.
+
+.Debug infinite capability register
+include::img/dinfcreg.edn[]

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -13,22 +13,12 @@ apply.
 
 ==== CHERI Mode when in Debug Mode
 
-When entering debug mode, the CHERI mode is always the same, and may be
-switchable depending on which extensions have been implemented.
+When entering debug mode, the core always enters Capability Mode.
 
 If {cheri_mode_ext_name} is implemented:
 
-* the core enters Legacy Mode when entering debug mode,
- and the mode can be switched using <<MODESW>>.
-
-If {cheri_legacy_ext_name} and not {cheri_mode_ext_name} are implemented:
-
-* the core enters Capability Mode when entering debug mode,
- and the mode cannot be switched to Legacy Mode.
-
-If {cheri_base_ext_name} only is implemented:
-
-* the core is always in Capability Mode.
+. the mode can be switched using <<MODESW>>.
+. the current mode can be observed in <<dinfc>>.M.
 
 === Core Debug Registers
 
@@ -135,9 +125,13 @@ include::img/dscratch1creg.edn[]
 
 The <<dinfc>> register is a CLEN-bit plus tag bit CSR only accessible in debug mode.
 
-The reset value is the <<infinite-cap>> capability. The M field (if
-{cheri_mode_ext_name} is implemented) represents the current mode and
-will be only updated if <<MODESW>> is executed.
+The reset value is the <<infinite-cap>> capability.
+
+If {cheri_mode_ext_name} is implemented:
+
+. the core enters Capability Mode when entering debug mode
+.. therefore <<dinfc>>.M is set whenever entering debug mode for any reason.
+. the mode can be switched using <<MODESW>>, and the result observed in <<dinfc>>.M.
 
 <<dinfc>> is read/write but with no writeable fields, and so writes are
 ignored.

--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -67,7 +67,7 @@ include::img/dpccreg.edn[]
 
 Upon entry to debug mode, cite:[riscv-debug-spec], does not specify how to
 update the PC, and says PC relative instructions may be illegal. This concept
-is extended to include any instruction which updates <<pcc>>, which refers to
+is extended to include any instruction which reads or updates <<pcc>>, which refers to
 all jumps, conditional branches and <<AUIPC>>. The exception is <<MODESW>>
 which _is_ supported if {cheri_mode_ext_name} is implemented, see <<dfinc>>
 for details.

--- a/src/img/dinfcreg.edn
+++ b/src/img/dinfcreg.edn
@@ -1,0 +1,15 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
+(def row-height 40)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1"])})
+
+(draw-box "dinfc (Metadata)" {:span 32})
+(draw-box "dinfc (Address)"  {:span 32})
+
+(draw-box "XLENMAX" {:span 32 :borders {}})
+----

--- a/src/insns/jal_32bit.adoc
+++ b/src/insns/jal_32bit.adoc
@@ -38,6 +38,8 @@ address is not within the bounds of the <<pcc>>. In this case, _CHERI jump or
 branch fault_ is reported in the TYPE field and Length Violation is reported in
 the CAUSE field of <<mtval>> or <<stval>>.
 
+include::pcrel_debug_warning.adoc[]
+
 Prerequisites for Capability Mode::
 {cheri_base_ext_name}
 

--- a/src/insns/modesw_16bit.adoc
+++ b/src/insns/modesw_16bit.adoc
@@ -20,16 +20,10 @@ Expansions::
 Encoding::
 include::wavedrom/modesw_16bit.adoc[]
 
-Capability Mode Description::
-Directly switch to Legacy Mode.
-
-Legacy Mode Description::
-Directly switch to Capability Mode.
+include::modesw_common.adoc[]
 
 Exceptions::
 None
-
-include::pcrel_debug_warning.adoc[]
 
 Prerequisites::
 {c_cheri_mode_ext_names}

--- a/src/insns/modesw_32bit.adoc
+++ b/src/insns/modesw_32bit.adoc
@@ -16,6 +16,9 @@ include::wavedrom/modesw_32bit.adoc[]
 
 include::modesw_common.adoc[]
 
+NOTE: Support of MODESW is optional in debug mode. If it is supported then
+ it updates <<dinfc>>.M instead of <<pcc>>.M to show the currrent mode.
+
 Prerequisites::
 {cheri_mode_ext_name}
 

--- a/src/insns/modesw_32bit.adoc
+++ b/src/insns/modesw_32bit.adoc
@@ -14,12 +14,7 @@ Mnemonics::
 Encoding::
 include::wavedrom/modesw_32bit.adoc[]
 
-Description::
-Toggle the hart's current CHERI execution mode in <<pcc>>. If the current mode in
-<<pcc>> is Legacy, then the mode bit (M) in <<pcc>> is set to Capability. If the
-current mode is Capability, then the mode bit (M) in <<pcc>> is set to Legacy.
-
-include::pcrel_debug_warning.adoc[]
+include::modesw_common.adoc[]
 
 Prerequisites::
 {cheri_mode_ext_name}

--- a/src/insns/modesw_common.adoc
+++ b/src/insns/modesw_common.adoc
@@ -2,7 +2,7 @@
 Description::
 Toggle the hart's current CHERI execution mode in <<pcc>>. If the current mode in
 <<pcc>> is Legacy, then the mode bit (M) in <<pcc>> is set to Capability. If the
-current mode is Capability, then the mode bit (M) in <<pcc>> is set to Legacy.+
+current mode is Capability, then the mode bit (M) in <<pcc>> is set to Legacy.
 +
 In debug mode MODESW can still be used to change the operating mode, and the current
 mode is shown in the M bit of <<dinfc>>.

--- a/src/insns/modesw_common.adoc
+++ b/src/insns/modesw_common.adoc
@@ -1,0 +1,8 @@
+
+Description::
+Toggle the hart's current CHERI execution mode in <<pcc>>. If the current mode in
+<<pcc>> is Legacy, then the mode bit (M) in <<pcc>> is set to Capability. If the
+current mode is Capability, then the mode bit (M) in <<pcc>> is set to Legacy.+
++
+In debug mode MODESW can still be used to change the operating mode, and the current
+mode is shown in the M bit of <<dinfc>>.

--- a/src/insns/pcrel_debug_warning.adoc
+++ b/src/insns/pcrel_debug_warning.adoc
@@ -1,4 +1,4 @@
 NOTE: The instructions on this page are either PC relative or may update the
 <<pcc>>. Therefore an implementation may make them illegal in debug mode. If
-not then the value of the <<pcc>> in debug mode is UNSPECIFIED by this
+they are supported then the value of the <<pcc>> in debug mode is UNSPECIFIED by this
 document.

--- a/src/insns/pcrel_debug_warning.adoc
+++ b/src/insns/pcrel_debug_warning.adoc
@@ -1,4 +1,4 @@
 NOTE: The instructions on this page are either PC relative or may update the
 <<pcc>>. Therefore an implementation may make them illegal in debug mode. If
-not then the value of the <<pcc>> in debug mode is UNSPECIFIED by this 
+not then the value of the <<pcc>> in debug mode is UNSPECIFIED by this
 document.

--- a/src/insns/pcrel_debug_warning.adoc
+++ b/src/insns/pcrel_debug_warning.adoc
@@ -1,2 +1,4 @@
 NOTE: The instructions on this page are either PC relative or may update the
-<<pcc>>. Therefore an implementation may make them illegal in debug mode.
+<<pcc>>. Therefore an implementation may make them illegal in debug mode. If
+not then the value of the <<pcc>> in debug mode is UNSPECIFIED by this 
+document.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -43,13 +43,17 @@ Register *c0* is hardwired with all bits, including the capability metadata and
 tag, equal to 0. In other words, *c0* is hardwired to the <<null-cap>>
 capability.
 
+[#pcc,reftext="pcc"]
+==== PCC - The Program Counter Capability
+
 An authorising capability with appropriate permissions is required to execute
 instructions in {cheri_base_ext_name}. Therefore, the unprivileged program
 counter (*pc*) register is extended so that it is able to hold a capability.
 The extended register is called the program counter capability (<<pcc>>). The
-<<pcc>> address field is effectively the *pc* in the base RISC-V ISA that the
+<<pcc>> address field is effectively the *pc* in the base RISC-V ISA so that the
 hardware automatically increments as instructions are executed. The <<pcc>>'s
-metadata and tag are reset to the <<infinite-cap>> capability metadata and tag.
+metadata and tag are reset to the <<infinite-cap>> capability metadata and tag
+with the address field set to the core boot address.
 
 The hardware performs the following checks on <<pcc>> for each instruction
 executed in addition to the checks already required by the base RISC-V ISA. A
@@ -64,6 +68,16 @@ NOTE: Operations that update <<pcc>>, such as changing privilege or executing
 jump instructions, unseal capabilities prior to writing. Therefore,
 implementations do not need to check that that <<pcc>> is unsealed when
 executing each instruction. However, this property has not yet been formally verified and may not hold if additional CHERI extensions beyond {cheri_base_ext_name} are implemented.
+
+NOTE: It is common for implementations to not allow executing *pc* relative
+instructions, such as <<AUIPC>> or <<JAL>>, in debug mode.
+
+.Program Counter Capability
+[#pcc-format]
+include::img/pccreg.edn[]
+
+<<pcc>> is an executable
+vector, so it need not be able to hold all possible invalid addresses.
 
 [#section_cap_instructions]
 === Capability Instructions
@@ -1033,24 +1047,6 @@ xref:mtval-cheri-causes[xrefstyle=short] respectively.
 
 Unlike machine and supervisor level CSRs, {cheri_base_ext_name} does not require
 <<pcc>> to grant <<asr_perm>> to access unprivileged CSRs.
-
-[#pcc,reftext="pcc"]
-==== Program Counter Capability (pcc)
-
-The <<pcc>> is made visible in a CSR. This provides access to an
-<<infinite-cap>> capability while in debug mode without executing <<AUIPC>>.
-
-<<pcc>> resets to the <<infinite-cap>> capability with the address field set to the core boot address.
-
-NOTE: It is common for implementations to not allow executing *pc* relative
-instructions, such as <<AUIPC>> or <<JAL>>, in debug mode.
-
-.Program Counter Capability
-[#pcc-format]
-include::img/pccreg.edn[]
-
-As shown in xref:CSR_exevectors[xrefstyle=short], <<pcc>> is an executable
-vector, so it need not be able to hold all possible invalid addresses.
 
 === CHERI Exception handling
 

--- a/src/riscv-mode-integration.adoc
+++ b/src/riscv-mode-integration.adoc
@@ -1,3 +1,4 @@
+[#chapter-Zcheri-mode]
 == "Zcheri_mode" Extension for CHERI Execution Mode
 
 {cheri_mode_ext_name} is an optional extension to {cheri_legacy_ext_name}.
@@ -71,5 +72,11 @@ endif::[]
 In addition to the changes described in
 xref:section_debug_integration[xrefstyle=short] and
 xref:section_legacy_debug_integration[xrefstyle=short], {cheri_mode_ext_name}
-allows <<MODESW>> to act as an illegal instruction when it is executed
-while in debug mode.
+optionally allows <<MODESW>> to execute in debug mode.
+
+When entering debug mode, the core always enters Capability Mode.
+
+If {cheri_mode_ext_name} is implemented:
+
+. the mode can be optionally switched using <<MODESW>>.
+. the current mode can always be observed in <<dinfc>>.M.

--- a/src/scripts/generate_tables.py
+++ b/src/scripts/generate_tables.py
@@ -660,7 +660,7 @@ class csr_alias_action(table):
         return row[self.header.index("Alias")] != ""
 
 class csr_perms(table):
-    cols = ["Extended CSR", "Zcheri_legacy", "Zcheri_purecap", "Prerequisites", "CLEN Address", "Permissions", "Reset Value"]
+    cols = ["Extended CSR", "Zcheri_legacy", "Zcheri_purecap", "Prerequisites", "CLEN Address", "Permissions", "Reset Value", "Description"]
     indices = []
 
     def __init__(self, filename, header):

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -130,7 +130,7 @@ xref:CSR_metadata[xrefstyle=short] shows which CLEN-wide CSRs store all CLEN+1 b
 
 .All CLEN-wide CSRs
 [#extended_CSRs]
-[width="100%",options=header,cols="2,1,1,1,1,3,2"]
+[width="100%",options=header,cols="2,1,1,1,1,2,2,4"]
 |==============================================================================
 include::generated/csr_permission_table_body.adoc[]
 |==============================================================================


### PR DESCRIPTION
Changes are:

1. pcc is no longer accessible as a CSR
2. the pcc value is UNSPECIFIED in debug mode, and ASR permission is implicitly granted
3. add dinfc CSR as a debug mode only source of infinity
4. remove ASR permission from all debug mode CSRs as it's implicitly granted
5. remove "M-mode" as a prerequisite for (e.g.) MTVECC as M-mode must always be present