### PR TITLE
Clarify csrr[s|c]i write behavior when imm=0

### DIFF
--- a/src/insns/csrr_32bit.adoc
+++ b/src/insns/csrr_32bit.adoc
@@ -63,18 +63,18 @@ xref:extended_CSR_writing[xrefstyle=short] for the action taken on writing an XL
 +
 If `cd` is `c0` (or `rd` is `x0`), then <<CSRRWI>> shall not read the CSR and
 and shall not cause any of the side effects that might occur on a CSR read. If
-`rs1` is `x0`, then <<CSRRS>>, <<CSRRC>>, <<CSRRSI>> and <<CSRRCI>> will not
-write to the CSR at all, and so shall not cause any of the side effects that
-might otherwise occur on a CSR write.
+`rs1` is `x0` for <<CSRRS>> and <<CSRRC>>, or `imm` is 0 for <<CSRRSI>> and
+<<CSRRCI>>, then the instruction will not write to the CSR at all, and so shall
+not cause any of the side effects that might otherwise occur on a CSR write.
 +
 The assembler pseudoinstruction to read a capability CSR at its CLEN alias,
 `csrr rd, csr`, is encoded as `csrrs cd, csr, c0`.
 +
 Access to XLEN-wide CSRs from other extensions is as specified by RISC-V.
 
-NOTE: If `rs1` is `x0` and the CSR accessed is a capability, then <<CSRRS>>,
-<<CSRRC>>, <<CSRRSI>> and <<CSRRCI>> do not write so no representability check
-is needed in this case.
+NOTE: If the CSR accessed is a capability, and `rs1` is `x0` for <<CSRRS>> and
+<<CSRRC>>, or `imm` is 0 for <<CSRRSI>> and <<CSRRCI>>, then the CSR is not
+written so no representability check is needed in this case.
 
 Permissions::
 All non-user mode accessible CSRs require <<asr_perm>>, including existing RISC-V CSRs.


### PR DESCRIPTION
Fixes https://github.com/riscv/riscv-cheri/issues/118