### PR TITLE
Remove XLENMAX

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -10,6 +10,10 @@ change dynamically at run-time depending on the values written to CSRs, so we
 define capability behavior in terms of MXLEN, which is the value of XLEN used
 in machine mode and the widest XLEN the implementation supports.
 
+NOTE: {cheri_base_ext_name} assumes a version of the privileged architecture
+which defines MXLEN as constant and requires higher privilege modes to have at
+least the same XLEN as lower privilege modes; these changes are present in the
+current draft and expected to be part of privileged architecture 1.13.
 
 {cheri_base_ext_name} defines capabilities of size CLEN corresponding to 2 *
 MXLEN without including the tag bit. The value of CLEN is always calculated

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -7,12 +7,13 @@ space. There are two primary ISA variants, RV32I and RV64I, which provide
 32-bit and 64-bit address spaces respectively. The term XLEN refers to the
 width of an integer register in bits (either 32 or 64). The value of XLEN may
 change dynamically at run-time depending on the values written to CSRs, so we
-define XLENMAX to be widest XLEN that the implementation supports.
+define capability behavior in terms of MXLEN, which is the value of XLEN used
+in machine mode and the widest XLEN the implementation supports.
 
 
 {cheri_base_ext_name} defines capabilities of size CLEN corresponding to 2 *
-XLENMAX without including the tag bit. The value of CLEN is always calculated
-based on XLENMAX regardless of the effective XLEN value.
+MXLEN without including the tag bit. The value of CLEN is always calculated
+based on MXLEN regardless of the effective XLEN value.
 
 === Components of a Capability
 
@@ -77,32 +78,32 @@ Access System Registers Permission (ASR):: Allow access to privileged CSRs.
 [#cap_permissions_encoding]
 ===== Permission Encoding
 
-The bit width of the permissions field depends on the value of XLENMAX as shown
+The bit width of the permissions field depends on the value of MXLEN as shown
 in xref:perms_bit_width[xrefstyle=short]. A {cap_rv32_perms_width}-bit vector
-encodes the permissions when XLENMAX=32. For this case, the legal encodings of
+encodes the permissions when MXLEN=32. For this case, the legal encodings of
 permissions are listed in xref:cap_perms_encoding32[xrefstyle=short]. Certain
 combinations of permissions are impractical. For example, <<c_perm>> is
 superfluous when the capability does not grant either <<r_perm>> or <<w_perm>>.
 Therefore, it is only possible to encode a subset of all combinations.
 
-.Permissions widths depending on XLENMAX
+.Permissions widths depending on MXLEN
 [#perms_bit_width,options=header,align="center",width="75%",cols="^1,^3,5"]
 |==============================================================================
-^| XLENMAX ^| Permissions width      ^| Comment
+^| MXLEN   ^| Permissions width      ^| Comment
 ^| 32      ^| {cap_rv32_perms_width} ^| Encodes some combinations of 5 permission bits and the Mode bits
 ^| 64      ^| {cap_rv64_perms_width} ^| Separate bits for each permission, and the Mode bit is not included
 |==============================================================================
 
-NOTE: While XLENMAX=32 currently uses the same number of bits for permission encodings, it also includes the mode bit of {cheri_legacy_ext_name} which is separate for XLENMAX=64.
+NOTE: While MXLEN=32 currently uses the same number of bits for permission encodings, it also includes the mode bit of {cheri_legacy_ext_name} which is separate for MXLEN=64.
 
-For XLENMAX=32, the permissions encoding is split into four quadrants.
+For MXLEN=32, the permissions encoding is split into four quadrants.
 The quadrant is taken from bits [4:3] of the permissions encoding.
 The meaning for bits [2:0] are shown in <<cap_perms_encoding32>> for each quadrant.
 
 Quadrants 2 and 3 are arranged to implicitly grant future permissions which may be added with the existing allocated encodings.
 Quadrant 0 does the opposite - the encodings are allocated _not_ to implicitly add future permissions, and so granting future permissions will require new encodings.
 
-.Encoding of architectural permissions for XLENMAX=32
+.Encoding of architectural permissions for MXLEN=32
 [#cap_perms_encoding32,width="100%",options=header,cols="^2,^1,^1,^1,^1,^1,^2,4",align="center"]
 |==============================================================================
 | Encoding[2:0] | R | W | C | X | ASR | Mode | Notes
@@ -133,7 +134,7 @@ Quadrant 0 does the opposite - the encodings are allocated _not_ to implicitly a
 | 7       | ✔ | ✔ | ✔ |   |     | N/A | Data & Cap RW
 |==============================================================================
 
-NOTE: When XLENMAX=32 there are many reserved permission encodings (see
+NOTE: When MXLEN=32 there are many reserved permission encodings (see
 xref:cap_perms_encoding32[xrefstyle=short]). It is not possible for a tagged
 capability to have one of these values since <<ACPERM>> will never create it. It is
 possible for untagged capabilities to have reserved values. <<GCPERM>> will interpret
@@ -141,13 +142,13 @@ reserved values as if it were 0b00000 (no permissions). Future extensions may as
 meanings to the reserved bit patterns, in which case <<GCPERM>> is allowed to report a
 non-zero value.
 
-A {cap_rv64_perms_width}-bit vector encodes the permissions when XLENMAX=64. In
+A {cap_rv64_perms_width}-bit vector encodes the permissions when MXLEN=64. In
 this case, there is a bit per permission as shown in
 xref:cap_perms_encoding64[xrefstyle=short]. A permission is granted if its
 corresponding bit is set, otherwise the capability does not grant that
 permission.
 
-.Encoding of architectural permissions for XLENMAX=64
+.Encoding of architectural permissions for MXLEN=64
 [#cap_perms_encoding64,align="center",options=header,cols="^10%,90%",width="55%"]
 |==============================================================================
 | Bit | Name
@@ -173,10 +174,10 @@ example, a program may decide to use an SDP bit to indicate the "ownership" of
 objects. Therefore, a capability grants permission to free the memory it
 references if that SDP bit is set because it "owns" that object.
 
-.SDP widths depending on XLENMAX
+.SDP widths depending on MXLEN
 [#sdp_bit_width,options=header,align="center",width="55%"]
 |==============================================================================
-^| XLENMAX ^| SDP width
+^| MXLEN   ^| SDP width
 ^| 32      ^| {cap_rv32_sdp_width}
 ^| 64      ^| {cap_rv64_sdp_width}
 |==============================================================================
@@ -219,7 +220,7 @@ to the caller function.
 ==== Bounds
 
 ifdef::cheri_v9_annotations[]
-NOTE: *CHERI v9 Note:* The bounds mantissa width is different in XLENMAX=32.
+NOTE: *CHERI v9 Note:* The bounds mantissa width is different in MXLEN=32.
 Also, the old IE bit is renamed to Exponent Format (EF); the function of IE
 is the inverse of EF i.e. IE=0 has the same effect as EF=1.
 
@@ -252,33 +253,33 @@ into the capability's address
     ** The exponent is zero if EF=1
 
 The bit width of T and B are defined in terms of the mantissa width (MW) which
-is set depending on the value of XLENMAX as shown in
+is set depending on the value of MXLEN as shown in
 xref:mantissa_bit_width[xrefstyle=short].
 
-.Mantissa width (MW) values depending on XLENMAX
+.Mantissa width (MW) values depending on MXLEN
 [#mantissa_bit_width,options=header,align="center",width="55%"]
 |==============================================================================
-^| XLENMAX ^| MW
+^| MXLEN   ^| MW
 ^| 32      ^| {cap_rv32_mw_width}
 ^| 64      ^| {cap_rv64_mw_width}
 |==============================================================================
 
 The exponent E indicates the position of T and B within the capability's
 address as described in xref:section_cap_encoding[xrefstyle=short]. The bit
-width of the exponent (EW) is set depending on the value of XLENMAX. The
+width of the exponent (EW) is set depending on the value of MXLEN. The
 maximum value of the exponent is calculated as follows:
 
 ```
-CAP_MAX_E = XLENMAX - MW + 2
+CAP_MAX_E = MXLEN - MW + 2
 ```
 
 The possible values for EW and CAP_MAX_E are shown in
 xref:exp_bit_width[xrefstyle=short].
 
-.Exponent widths and CAP_MAX_E depending on XLENMAX
+.Exponent widths and CAP_MAX_E depending on MXLEN
 [#exp_bit_width,options=header,align="center",width="55%"]
 |==============================================================================
-^| XLENMAX ^| EW                   ^| CAP_MAX_E
+^| MXLEN   ^| EW                   ^| CAP_MAX_E
 ^| 32      ^| {cap_rv32_exp_width} ^| 24
 ^| 64      ^| {cap_rv64_exp_width} ^| 52
 |==============================================================================
@@ -288,12 +289,12 @@ when the tag is set (see xref:section_cap_malformed[xrefstyle=short]).
 
 ==== Address
 
-XLENMAX integer value that encodes the byte-address of a memory location.
+MXLEN integer value that encodes the byte-address of a memory location.
 
-.Address widths depending on XLENMAX
+.Address widths depending on MXLEN
 [#address_bit_width,options=header,align="center",width="55%"]
 |==============================================================================
-^| XLENMAX ^| Address width
+^| MXLEN   ^| Address width
 ^| 32      ^| {cap_rv32_addr_width}
 ^| 64      ^| {cap_rv64_addr_width}
 |==============================================================================
@@ -314,14 +315,14 @@ endif::[]
 
 The components of a capability are encoded as shown in
 xref:cap_encoding_xlen32[xrefstyle=short] and
-xref:cap_encoding_xlen64[xrefstyle=short] when XLENMAX=32 and XLENMAX=64
+xref:cap_encoding_xlen64[xrefstyle=short] when MXLEN=32 and MXLEN=64
 respectively.
 
-.Capability encoding when XLENMAX=32
+.Capability encoding when MXLEN=32
 [#cap_encoding_xlen32]
 include::img/cap-encoding-xlen32.edn[]
 
-.Capability encoding when XLENMAX=64
+.Capability encoding when MXLEN=64
 [#cap_encoding_xlen64]
 include::img/cap-encoding-xlen64.edn[]
 
@@ -346,7 +347,7 @@ inverted to ensure that the <<null-cap>> capability is encoded as zero without t
 need for CHERI v9's in-memory format. +
 When EF=1, the exponent E=0, so the address bits a[MW - 1:0] are replaced
 with T and B to form the top and base addresses respectively. +
-When EF=0, the exponent `E=CAP_MAX_E - ( (XLENMAX == 32) ? { T8, TE, BE } : { TE, BE } )`,
+When EF=0, the exponent `E=CAP_MAX_E - ( (MXLEN == 32) ? { T8, TE, BE } : { TE, BE } )`,
 so the address bits a[E + MW - 1:E] are replaced with T and B to form the top
 and base addresses respectively. E is computed by subtracting from the maximum
 possible exponent CAP_MAX_E which can be efficiently implemented in hardware
@@ -357,17 +358,17 @@ bitwise shift left by E.
 endif::[]
 
 ```
-EW        = (XLENMAX == 32) ? 5 : 6
-CAP_MAX_E = XLENMAX - MW + 2
+EW        = (MXLEN == 32) ? 5 : 6
+CAP_MAX_E = MXLEN - MW + 2
 
 If EF = 1:
     E               = 0
     T[EW / 2 - 1:0] = TE
     B[EW / 2 - 1:0] = BE
     LCout           = (T[MW - 3:0] < B[MW - 3:0]) ? 1 : 0
-    LMSB            = (XLENMAX == 32) ? T8 : 0
+    LMSB            = (MXLEN == 32) ? T8 : 0
 else:
-    E               = CAP_MAX_E - ( (XLENMAX == 32) ? { T8, TE, BE } : { TE, BE } )
+    E               = CAP_MAX_E - ( (MXLEN == 32) ? { T8, TE, BE } : { TE, BE } )
     T[EW / 2 - 1:0] = 0
     B[EW / 2 - 1:0] = 0
     LCout           = (T[MW - 3:EW / 2] < B[MW - 3:EW / 2]) ? 1 : 0
@@ -383,8 +384,8 @@ T[MW - 1:MW - 2] = B[MW - 1:MW - 2] + LCout + LMSB
 Decoding the bounds:
 
 ```
-top:    t = { a[XLENMAX - 1:E + MW] + ct, T[MW - 1:0]    , {E{1'b0}} }
-base:   b = { a[XLENMAX - 1:E + MW] + cb, B[MW - 1:0]    , {E{1'b0}} }
+top:    t = { a[MXLEN - 1:E + MW] + ct, T[MW - 1:0]    , {E{1'b0}} }
+base:   b = { a[MXLEN - 1:E + MW] + cb, B[MW - 1:0]    , {E{1'b0}} }
 ```
 The corrections c~t~ and c~b~ are calculated as as shown below using the
 definitions in xref:cap_encoding_ct[xrefstyle=short] and
@@ -427,7 +428,7 @@ The EF bit selects between two cases:
 
 1. EF = 1: The exponent is 0 for regions less than 2^MW-2^ bytes long
 2. EF = 0: The exponent is _internal_ with E stored in the lower bits of T and
-B along with T~8~ when XLENMAX=32. E is chosen so that the most significant
+B along with T~8~ when MXLEN=32. E is chosen so that the most significant
 non-zero bit of the length of the region aligns with T[MW - 2] in the decoded
 top. Therefore, the most significant two bits of T can be derived from B using
 the equality `T = B + L`, where L[MW - 2] is known from the values of EF and E
@@ -450,15 +451,15 @@ out-of-bounds while still allowing the bounds to be correctly decoded.
 image::cap-bounds-map.png[width=80%,align=center]
 
 A capability whose bounds cover the entire address space has 0 base and top
-equals 2^XLENMAX^, i.e. _t_ is a XLENMAX + 1 bit value. However, _b_ is a
-XLENMAX bit value and the size mismatch introduces additional complications
+equals 2^MXLEN^, i.e. _t_ is a MXLEN + 1 bit value. However, _b_ is a
+MXLEN bit value and the size mismatch introduces additional complications
 when decoding, so the following condition is required to correct _t_ for
 capabilities whose <<section_cap_representable_check>> wraps the edge of the address
 space:
 
 ```
-if ( (E < (CAP_MAX_E - 1)) & (t[XLENMAX: XLENMAX - 1] - b[XLENMAX - 1] > 1) )
-    t[XLENMAX] = !t[XLENMAX]
+if ( (E < (CAP_MAX_E - 1)) & (t[MXLEN: MXLEN - 1] - b[MXLEN - 1] > 1) )
+    t[MXLEN] = !t[MXLEN]
 ```
 That is, invert the most significant bit of _t_ if the decoded length of the
 capability is larger than E.
@@ -475,9 +476,9 @@ the difference between in-memory and architectural format.
 endif::[]
 
 The <<null-cap>> capability is represented with 0 in all fields. This implies
-that it has no permissions and its exponent E is CAP_MAX_E (52 for XLENMAX=64,
-24 for XLENMAX=32), so its bounds cover the entire address space such that the
-expanded base is 0 and top is 2^XLENMAX^.
+that it has no permissions and its exponent E is CAP_MAX_E (52 for MXLEN=64,
+24 for MXLEN=32), so its bounds cover the entire address space such that the
+expanded base is 0 and top is 2^MXLEN^.
 
 .Field values of the NULL capability
 [#null-cap,reftext="NULL",options=header,align=center,width="55%",cols="1,1,3"]
@@ -488,7 +489,7 @@ expanded base is 0 and top is 2^XLENMAX^.
 | AP      | zeros | Grants no permissions
 | S       | zero  | Unsealed
 | EF      | zero  | Internal exponent format
-| T~8~    | zeros | Top address bit (XLENMAX=32 only)
+| T~8~    | zeros | Top address bit (MXLEN=32 only)
 | T       | zeros | Top address bits
 | T~E~    | zeros | Exponent bits
 | B       | zeros | Base address bits
@@ -517,7 +518,7 @@ or 'root' capability.
 | AP (RV32) | See xref:cap_perms_encoding32[xrefstyle=short] | Grants all permissions
 | S       | zero  | Unsealed
 | EF      | zero  | Internal exponent format
-| T~8~    | zeros | Top address bit (XLENMAX=32 only)
+| T~8~    | zeros | Top address bit (MXLEN=32 only)
 | T       | zeros | Top address bits
 | T~E~    | zeros | Exponent bits
 | B       | zeros | Base address bits
@@ -558,8 +559,8 @@ bounds are formed of two or three sections:
 [#comp_addr_bounds,options=header,align="center"]
 |==============================================================================
 | Configuration  | Upper section | Middle Section | Lower section
-| EF=0           | address[XLENMAX-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
-| EF=1, i.e. E=0 | address[XLENMAX-1:MW] + ct   2+| T[MW - 1:0]
+| EF=0           | address[MXLEN-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
+| EF=1, i.e. E=0 | address[MXLEN-1:MW] + ct   2+| T[MW - 1:0]
 |==============================================================================
 
 The _representable range_ defines the range of addresses which do not corrupt

--- a/src/img/ddcreg.edn
+++ b/src/img/ddcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "ddc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/dddcreg.edn
+++ b/src/img/dddcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "dddc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/dinfcreg.edn
+++ b/src/img/dinfcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "dinfc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/dpccreg.edn
+++ b/src/img/dpccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "dpcc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/dscratch0creg.edn
+++ b/src/img/dscratch0creg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "dscratch0c (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/dscratch1creg.edn
+++ b/src/img/dscratch1creg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "dscratch1c (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/jvtcreg.edn
+++ b/src/img/jvtcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "jvtc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/mepccreg.edn
+++ b/src/img/mepccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "mepcc (Address, WARL)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/mscratchcreg.edn
+++ b/src/img/mscratchcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "mscratchc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/mtdcreg.edn
+++ b/src/img/mtdcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "mtdc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/mtveccreg.edn
+++ b/src/img/mtveccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -15,10 +15,10 @@
 
 (draw-box "" {:span 2 :borders {}})
 
-(draw-box "BASE [XLENMAX-1:2] (WARL)" {:span 24})
+(draw-box "BASE [MXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)"               {:span 8})
 
 (draw-box ""          {:span 2 :borders {}})
-(draw-box "XLENMAX-2" {:span 24 :borders {}})
+(draw-box "MXLEN-2" {:span 24 :borders {}})
 (draw-box "2"         {:span 8 :borders {}})
 ----

--- a/src/img/pccreg.edn
+++ b/src/img/pccreg.edn
@@ -6,10 +6,10 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
 
 (draw-box "pcc (Metadata, WARL)" {:span 32})
 (draw-box "pcc (Address, WARL)"  {:span 32})
 
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/sepccreg.edn
+++ b/src/img/sepccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "sepcc (Address, WARL)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/sscratchcreg.edn
+++ b/src/img/sscratchcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "sscratchc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/stdcreg.edn
+++ b/src/img/stdcreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -18,5 +18,5 @@
 (draw-box "stdc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX" {:span 32 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/stveccreg.edn
+++ b/src/img/stveccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLENMAX-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
@@ -15,10 +15,10 @@
 
 (draw-box "" {:span 2 :borders {}})
 
-(draw-box "BASE [XLENMAX-1:2] (WARL)" {:span 24})
+(draw-box "BASE [MXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)"               {:span 8})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "XLENMAX-2" {:span 24 :borders {}})
+(draw-box "MXLEN-2" {:span 24 :borders {}})
 (draw-box "2"         {:span 8 :borders {}})
 ----

--- a/src/insns/acperm_32bit.adoc
+++ b/src/insns/acperm_32bit.adoc
@@ -30,7 +30,7 @@ resulting bit field -- the capability grants a permission if the corresponding
 bit is set in the bit field -- and write the output capability to `cd` . The
 output capability has its tag set to 0 if `cs1` is sealed.
 +
-The AP field is not able to encode all combinations of permissions when XLENMAX=32, therefore removing a permission may yield a capability which cannot be encoded.
+The AP field is not able to encode all combinations of permissions when MXLEN=32, therefore removing a permission may yield a capability which cannot be encoded.
 Valid combinations are shown in <<cap_perms_encoding32>>.
 If removing permissions would result in architectural permissions which cannot be encoded, additional architectural permissions will be removed until an encodable subset of the requested permissions has been found.
 For example, with executable capabilities, where <<x_perm>> is set, clearing <<x_perm>> also clears <<asr_perm>> and the Mode becomes irrelevant.

--- a/src/insns/gchi_32bit.adoc
+++ b/src/insns/gchi_32bit.adoc
@@ -19,7 +19,7 @@ Encoding::
 include::wavedrom/gchi.adoc[]
 
 Description::
-Copy the metadata (bits [CLEN-1:XLENMAX]) of capability `cs1` into `rd`.
+Copy the metadata (bits [CLEN-1:MXLEN]) of capability `cs1` into `rd`.
 
 Prerequisites::
 {cheri_base_ext_name}

--- a/src/insns/gclen_32bit.adoc
+++ b/src/insns/gclen_32bit.adoc
@@ -23,8 +23,8 @@ Calculate the length of `cs1` 's bounds and write the result in `rd`. The length
 is defined as the difference between the decoded bounds' top and base addresses
 i.e. `top - base`. It is not required that the input capability `cs1`  has its
 tag set to 1. <<GCLEN>> outputs 0 if `cs1` 's bounds are malformed (see
-xref:section_cap_malformed[xrefstyle=short]), and 2^XLENMAX^-1 if the length of
-`cs1` is 2^XLENMAX^.
+xref:section_cap_malformed[xrefstyle=short]), and 2^MXLEN^-1 if the length of
+`cs1` is 2^MXLEN^.
 
 Prerequisites::
 {cheri_base_ext_name}

--- a/src/insns/gcperm_32bit.adoc
+++ b/src/insns/gcperm_32bit.adoc
@@ -24,7 +24,7 @@ per permission, as shown below, and write the result to `rd`. A bit set to 1
 in the bit field indicates that `cs1` grants the corresponding permission.
 +
 If the AP field is a reserved value then all architectural permission bits in
-`rd` are set to 0. This is only possible for XLENMAX=32 and the reserved values
+`rd` are set to 0. This is only possible for MXLEN=32 and the reserved values
 are shown in <<cap_perms_encoding32>>.
 
 include::../img/acperm_bit_field.edn[]

--- a/src/insns/schi_32bit.adoc
+++ b/src/insns/schi_32bit.adoc
@@ -20,7 +20,7 @@ include::wavedrom/schi.adoc[]
 
 Description::
 Copy `cs1`  to `cd` , replace the capability metadata (i.e. bits
-[CLEN-1:XLENMAX]) with `rs2`  and set `cd.tag` to 0.
+[CLEN-1:MXLEN]) with `rs2`  and set `cd.tag` to 0.
 
 Prerequisites::
 {cheri_base_ext_name}

--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -135,7 +135,7 @@ backwards compatibility
     ** The PTE bits introduce a dependency between exceptions and the stored
 tag bit
 * There is debate on whether different permission encodings are needed for
-XLENMAX=32 and XLENMAX=64
+MXLEN=32 and MXLEN=64
 
 ==== Pending Extensions
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -13,6 +13,8 @@ components of the base integer RISC-V ISAs.
 NOTE: The changes described in this specification also ensure that
 {cheri_base_ext_name} is compatible with RV32E.
 
+NOTE: RV128 is not currently supported by any CHERI extension.
+
 === Memory
 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
@@ -26,7 +28,7 @@ The memory address space is circular, so the byte at address
 2^XLEN^ - 1 is adjacent to the byte at address zero. A capability's
 <<section_cap_representable_check>> described in xref:section_cap_encoding[xrefstyle=short] is
 also circular, so address 0 is within the <<section_cap_representable_check>> of a capability
-where address 2^XLENMAX^ - 1 is within the bounds.
+where address 2^MXLEN^ - 1 is within the bounds.
 
 [#section_riscv_programmers_model]
 === Programmer's Model for Zcheri_purecap
@@ -109,8 +111,8 @@ tag is set and 0 otherwise
 permission fields of the input capability
 * <<GCBASE>>: outputs the expanded base address of the input capability
 * <<GCLEN>>: outputs the length of the input capability. Length is defined as
-`top - base`. The output is 2^XLENMAX^-1 when the capability's length is
-2^XLENMAX^
+`top - base`. The output is 2^MXLEN^-1 when the capability's length is
+2^MXLEN^
 * <<CRAM>>: outputs the nearest bounds alignment that a valid capability can
 represent
 * <<GCHI>>: outputs the compressed capability metadata
@@ -403,31 +405,6 @@ include::generated/csr_renamed_purecap_mode_u_table_body.adoc[]
 otherwise add new functions. <<pcc>> must grant <<asr_perm>> to access M-mode
 CSRs regardless of the RISC-V privilege mode.
 
-==== Machine ISA Register (misa)
-
-The *misa* register operates as described in cite:[riscv-priv-spec] except for
-the MXL (Machine XLEN) field. The MXL field encodes the native base integer ISA
-width as shown in xref:misa_mxl_field[xrefstyle=short]. Only 1 and 2 are
-supported values for MXL and the field must be read-only in implementations
-supporting {cheri_base_ext_name}. The effective XLEN in M-mode, MXLEN, is given
-by the setting of MXL, or has a fixed value if *misa* is zero.
-
-.Encoding of MXL field in *misa*
-[#misa_mxl_field]
-[float="center",align="center",cols="1,1",options="header",width=20%]
-|==============================================================================
-^| MXL | XLEN
-^| 1   | 32
-^| 2   | 64
-^| 3   | [line-through]#128#
-|==============================================================================
-
-NOTE: RV128 is not currently supported by any CHERI extension
-
-NOTE: A further CHERI extension, {cheri_legacy_ext_name}, optionally makes
-MXL writeable, so implementations that support multiple base ISAs must support
-both {cheri_base_ext_name} and {cheri_legacy_ext_name}.
-
 [#mstatus,reftext="mstatus"]
 ==== Machine Status Registers (mstatus and mstatush)
 
@@ -437,11 +414,10 @@ value of XLEN for S-mode and U-mode, respectively, and the MBE, SBE, and UBE
 fields that control the memory system endianness for M-mode, S-mode,
 and U-mode, respectively.
 
-The encoding of the SXL and UXL fields is the same as the MXL field of *misa*,
-shown in xref:misa_mxl_field[xrefstyle=short]. Only 1 and 2 are supported
-values for SXL and UXL and the fields must be read-only in implementations
-supporting {cheri_base_ext_name}. The effective XLEN in S-mode and U-mode are
-termed SXLEN and UXLEN, respectively.
+The encoding of the SXL and UXL fields is the same as the MXL field of *misa*.
+Only 1 and 2 are supported values for SXL and UXL and the fields must be
+read-only in implementations supporting {cheri_base_ext_name}. The effective
+XLEN in S-mode and U-mode are termed SXLEN and UXLEN, respectively.
 
 The MBE, SBE, and UBE fields determine whether explicit loads and stores
 performed from M-mode, S-mode, or U-mode, respectively, are little endian

--- a/src/riscv-legacy-integration.adoc
+++ b/src/riscv-legacy-integration.adoc
@@ -49,7 +49,7 @@ Setting both registers to <<infinite-cap>> ensures that:
 
 * All permissions are granted
 * The bounds authorise accesses to the entire address space i.e base is 0 and
-top is 2^XLENMAX^
+top is 2^MXLEN^
 
 [#section-cheri-execution-mode]
 === CHERI Execution Mode Encoding
@@ -66,7 +66,7 @@ mode is given by the M bit of the <<pcc>> and the CRE bits in <<mseccfg>>,
 CRE=1 for the current privilege level
 * The mode is Legacy when the effective CRE=0 for the current privilege level or the M bit of the <<pcc>> is 0
 
-.Capability encoding when XLENMAX=64 and {cheri_legacy_ext_name} is supported
+.Capability encoding when MXLEN=64 and {cheri_legacy_ext_name} is supported
 [#cap_encoding_xlen64_mode]
 include::img/cap-encoding-xlen64-mode.edn[]
 
@@ -196,7 +196,7 @@ When <<CSRRW>> is executed on an extended CSR in Legacy Mode:
 field.
     ** The tag and metadata are updated as specified in <<extended_CSR_writing>>.
 * Only XLEN bits are read from the capability address field, which are extended
-to XLENMAX bits according to cite:[riscv-priv-spec] _(3.1.6.2. Base ISA Control in
+to MXLEN bits according to cite:[riscv-priv-spec] _(3.1.6.2. Base ISA Control in
 mstatus Register)_ and are then written to the destination *x* register.
 
 When <<CSRRW>> is executed on an extended CSR in Capability Mode:
@@ -293,7 +293,7 @@ instruction exceptions
 The mode bit in <<pcc>> is treated as if it was zero while CHERI register access is disabled.
 
 CHERI register access is disabled if XLEN in the current mode is less than
-XLENMAX, if the endianness in the current mode is not the reset value of
+MXLEN, if the endianness in the current mode is not the reset value of
 <<mstatus>>.MBE, or if CRE active at the current mode (<<mseccfg>>.CRE for M-mode, <<menvcfg>>.CRE for
 S-mode or <<senvcfg>>.CRE for U-mode) is 0.
 
@@ -338,43 +338,27 @@ xref:legacy-csrnames-added[xrefstyle=short].
 include::generated/csr_added_legacy_table_body.adoc[]
 |===
 
-==== Machine ISA Register (misa)
-
-{cheri_legacy_ext_name} eliminates some restrictions for MXL imposed in
-{cheri_base_ext_name} to allow implementations supporting multiple base ISAs.
-Namely, the MXL field, that encodes the native base integer ISA width as shown
-in xref:misa_mxl_field[xrefstyle=short], may be writable.
-
-Setting the MXL field to a value that is not XLENMAX disables most CHERI
-features and instructions as described in
-xref:section_cheri_disable[xrefstyle=short].
-
 ==== Machine Status Registers (mstatus and mstatush)
 
 {cheri_legacy_ext_name} eliminates some restrictions for SXL and UXL imposed in
 {cheri_base_ext_name} to allow implementations supporting multiple base ISAs.
 Namely, the SXL and UXL fields may be writable.
 
-{cheri_legacy_ext_name} requires that lower-privilege modes have XLEN settings
-less than or equal to the next-higher privilege mode. WARL field behaviour
-restricts programming so that it is not possible to program MXL, SXL or UXL
-to violate this rule.
-
-Setting the SXL or UXL field to a value that is not XLENMAX disables most
+Setting the SXL or UXL field to a value that is not MXLEN disables most
 CHERI features and instructions, as described in
 xref:section_cheri_disable[xrefstyle=short], while in that privilege mode.
 
 NOTE: If CHERI register access must be disabled in a mode for security reasons,
 software should set CRE to 0 regardless of the SXL and UXL fields.
 
-Whenever XLEN in any mode is set to a value less than XLENMAX, standard RISC-V
+Whenever XLEN in any mode is set to a value less than MXLEN, standard RISC-V
 rules from cite:[riscv-unpriv-spec] are followed. This means that all operations
 must ignore source operand register bits above the configured XLEN, and must
-sign-extend results to fill the entire widest supported XLEN in the destination
-register. Similarly, *pc* bits above XLEN are ignored, and when the *pc* is
-written, it is sign-extended to fill XLENMAX. The integer writing rule from CHERI
-is followed, so that every register write also zeroes the metadata and tag of
-the destination register.
+sign-extend results to fill all MXLEN bits in the destination register.
+Similarly, *pc* bits above XLEN are ignored, and when the *pc* is written, it
+is sign-extended to fill MXLEN. The integer writing rule from CHERI is
+followed, so that every register write also zeroes the metadata and tag of the
+destination register.
 
 However, CHERI operations and security checks will continue using the entire
 hardware register (i.e. CLEN bits) to correctly decode capability bounds.

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -86,7 +86,7 @@ include::generated/csr_alias_action_table_body.adoc[]
 
 ^*^ The vector range check is to ensure that vectored entry to the handler
  in within bounds of the capability written to `Xtvecc`. The check on writing
- must include the lowest (0 offset) and highest possible offset (e.g. 64 * XLENMAX bits where HICAUSE=16).
+ must include the lowest (0 offset) and highest possible offset (e.g. 64 * MXLEN bits where HICAUSE=16).
 
 NOTE: _XLEN writing_ is only available if {cheri_legacy_ext_name} is implemented.
 


### PR DESCRIPTION
As of riscv/riscv-isa-manual@86ff22d6 MXLEN is read-only and reflects the widest XLEN of the machine, so use that instead.

As of riscv/riscv-isa-manual@0d7621d9 MXLEN >= SXLEN >= UXLEN is required by the base privileged architecture, so it does not need to be restated here.

Resolves #67.