### PR TITLE
Invert subset/superset for CBLD

### DIFF
--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -22,7 +22,7 @@ include::wavedrom/cbld.adoc[]
 
 Description::
 Copy `cs2` to `cd` and set the tag to 1 if `cs1.tag` is set, `cs1` is not
-sealed, `cs1` 's permissions and bounds are equal or a superset of `cs2` 's,
+sealed, `cs2` 's permissions and bounds are equal to or a subset of `cs1` 's,
 `cs2` 's bounds are not malformed (see
 xref:section_cap_malformed[xrefstyle=short]), and all reserved bits in `cs2` 's
 metadata are 0. <<CBLD>> is typically used alongside <<SCHI>> to build


### PR DESCRIPTION
Very minor but I think this way round is easier to thing about (you can only build a subset of the authorising cap), and more importantly it matches the sense of SCSS.