### PR TITLE
fix C.MODESW encoding so it doesn't overlap C.SUBW

### DIFF
--- a/src/insns/wavedrom/modesw_16bit.adoc
+++ b/src/insns/wavedrom/modesw_16bit.adoc
@@ -5,7 +5,7 @@
 {reg:[
     { bits: 2, name: 0x1, attr: ['2', 'C1=1'] },
     { bits: 3, name: 0x7, attr: ['3', 'C.MODESW'] },
-    { bits: 2, name: 0x0, attr: ['2', 'FUNCT2'] },
+    { bits: 2, name: 0x3, attr: ['2', 'FUNCT2'] },
     { bits: 3, name: 0x0, attr: ['3', 'FUNCT3'] },
     { bits: 3, name: 0x7, attr: ['3', 'FUNCT3'] },
     { bits: 3, name: 0x4, attr: ['3', 'FUNCT3'] },


### PR DESCRIPTION
I've changed this to the intended encoding, which is already in riscv-opcodes.
The previous one was a typo and conflicted with c.subw