### PR TITLE
Fix CSR menmonic operand order in specification

### DIFF
--- a/src/insns/csrr_32bit.adoc
+++ b/src/insns/csrr_32bit.adoc
@@ -31,18 +31,18 @@ Synopsis::
 CSR access (CSRRWI, CSRRS, CSRRSI, CSRRC, CSRRCI) 32-bit encodings
 
 Mnemonics for accessing capability CSRs at CLEN-wide aliases::
-`csrrs  cd, rs1, csr` +
-`csrrc  cd, rs1, csr` +
-`csrrwi cd, imm, csr` +
-`csrrsi cd, imm, csr` +
-`csrrci cd, imm, csr`
+`csrrs  cd, csr, rs1` +
+`csrrc  cd, csr, rs1` +
+`csrrwi cd, csr, imm` +
+`csrrsi cd, csr, imm` +
+`csrrci cd, csr, imm`
 
 Mnemonics for accessing XLEN-wide CSRs or capability CSRs at XLEN-wide aliases::
-`csrrs  rd, rs1, csr` +
-`csrrc  rd, rs1, csr` +
-`csrrwi rd, imm, csr` +
-`csrrsi rd, imm, csr` +
-`csrrci rd, imm, csr`
+`csrrs  rd, csr, rs1` +
+`csrrc  rd, csr, rs1` +
+`csrrwi rd, csr, imm` +
+`csrrsi rd, csr, imm` +
+`csrrci rd, csr, imm`
 
 Encoding::
 include::wavedrom/csr-instr.adoc[]

--- a/src/insns/csrrw_32bit.adoc
+++ b/src/insns/csrrw_32bit.adoc
@@ -13,10 +13,10 @@ Synopsis::
 CSR access (CSRRW) 32-bit encodings
 
 Mnemonics for accessing capability CSRs at CLEN-wide aliases::
-`csrrw cd, cs1, csr`
+`csrrw cd, csr, cs1`
 
 Mnemonics for accessing XLEN-wide CSRs or capability CSRs at XLEN-wide aliases::
-`csrrw rd, rs1, csr`
+`csrrw rd, csr, rs1`
 
 Encoding::
 include::wavedrom/csrw-instr.adoc[]


### PR DESCRIPTION
This PR:
* Updates the mnemonic operand ordering for CSR instruction to match existing Zicsr extension.