### PR TITLE
C.SC and C.SCSP imm should be 64-bit aligned (RV32)

### DIFF
--- a/src/insns/wavedrom/c-sp-store-cap.adoc
+++ b/src/insns/wavedrom/c-sp-store-cap.adoc
@@ -3,7 +3,7 @@
 {reg: [
   {bits: 2, name: 'op',     type: 8, attr: ['2','C2=10']},
   {bits: 5, name: 'cs2',    type: 4, attr: ['5','src']},
-  {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:2|7:6]','offset[5:4|9:6]']},
+  {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:3|8:6]','offset[5:4|9:6]']},
   {bits: 3, name: 'funct3', type: 8, attr: ['3', 'cap rv32: C.SCSP=111', 'cap rv64: C.SCSP=101']},
 ], config: {bits: 16}}
 ....
@@ -13,7 +13,7 @@
 {reg: [
   {bits: 2, name: 'op',     type: 8, attr: ['2', 'C0=00']},
   {bits: 3, name: 'cs2\'',  type: 3, attr: ['3', 'src']},
-  {bits: 2, name: 'imm',    type: 2, attr: ['2', 'offset[2|6]','offset[7:6]']},
+  {bits: 2, name: 'imm',    type: 2, attr: ['2', 'offset[7:6]','offset[7:6]']},
   {bits: 3, name: 'cs1\'',  type: 3, attr: ['3', 'base']},
   {bits: 3, name: 'imm',    types:3, attr: ['3', 'offset[5:3]','offset[5:4|8]']},
   {bits: 3, name: 'funct3', type: 8, attr: ['3', 'cap rv32: C.SC=111','cap rv64: C.SC=101']},


### PR DESCRIPTION
C.SC and C.SCSP (RV32) store a 64-bit capability and should encode a 64-bit aligned offset.

C.LC (RV32) encodes `offset[7:3]`
C.LCSP (RV32) encodes `offset[8:3]`

C.SC (RV32) should likewise encode `offset[7:3]`
C.SCSP (RV32) should likewise encode `offset[8:3]`

This would match the RV64 RVC encodings which encode a 128-bit aligned offset for C.LC, CLCSP, C.SC, C.SCSP.