### PR TITLE
MODESW, CBO.* - Specify all bits of funct5 fields

### DIFF
--- a/src/insns/cbo.clean.adoc
+++ b/src/insns/cbo.clean.adoc
@@ -17,7 +17,7 @@ Encoding::
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','MISC-MEM=0001111'],  type: 8},
-  {bits: 5,  name: 'funct5',    attr: ['5','CBO=0000'],     type: 2},
+  {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'cs1/rs1',   attr: ['5','base'], type: 4},
   {bits: 12, name: 'funct12',   attr: ['12','CBO.CLEAN=00.001'],   type: 3},

--- a/src/insns/cbo.flush.adoc
+++ b/src/insns/cbo.flush.adoc
@@ -17,7 +17,7 @@ Encoding::
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','MISC-MEM=0001111'],  type: 8},
-  {bits: 5,  name: 'funct5',    attr: ['5','CBO=0000'],     type: 2},
+  {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'cs1/rs1',   attr: ['5','base'],     type: 4},
   {bits: 12, name: 'funct12',   attr: ['12','cap: CBO.FLUSH=00.0010'],   type: 3},

--- a/src/insns/cbo.inval.adoc
+++ b/src/insns/cbo.inval.adoc
@@ -17,7 +17,7 @@ Encoding::
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','MISC-MEM=0001111'],  type: 8},
-  {bits: 5,  name: 'funct5',    attr: ['5','CBO=0000'],     type: 2},
+  {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'cs1/rs1',   attr: ['5','base'],     type: 4},
   {bits: 12, name: 'funct12',   attr: ['12','CBO.INVAL=00.0000'],   type: 3},

--- a/src/insns/cbo.zero.adoc
+++ b/src/insns/cbo.zero.adoc
@@ -17,7 +17,7 @@ Encoding::
 ....
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7','MISC-MEM=0001111'],  type: 8},
-  {bits: 5,  name: 'funct5',    attr: ['5','CBO=0000'],     type: 2},
+  {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'cs1/rs1',   attr: ['5','base'],     type: 4},
   {bits: 12, name: 'funct12',   attr: ['12','CBO.ZERO=00.0100'],   type: 3},

--- a/src/insns/wavedrom/modesw_32bit.adoc
+++ b/src/insns/wavedrom/modesw_32bit.adoc
@@ -3,7 +3,7 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',  attr: ['7', 'OP=0110011'], type: 8},
-  {bits: 5,  name: 'funct5',  attr: ['5', 'CMS=000'], type: 2},
+  {bits: 5,  name: 'funct5',  attr: ['5', 'CMS=00000'], type: 2},
   {bits: 3,  name: 'funct3',  attr: ['3', 'CMS=001'], type: 8},
   {bits: 5,  name: 'funct5',  attr: ['5', 'CMS=00000'], type: 4},
   {bits: 5,  name: 'funct5',  attr: ['5', 'CMS=00000'], type: 3},


### PR DESCRIPTION
Reported here - https://github.com/riscv/riscv-cheri/issues/151

 These full `CBO.*` encodings are consistent with https://github.com/riscvarchive/riscv-CMOs/blob/master/specifications/cmobase-v1.0.1.pdf
 
 The `MODESW` encoding matches the expected encoding - `0x12001033`