### PR TITLE
Fix broken variable resolution in title

### DIFF
--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -1,6 +1,6 @@
 == Extension summary
 
-=== {lr_sc_bh_ext_name}
+=== Zabhlrsc
 
 {lr_sc_bh_ext_name} is a separate extension independent of CHERI, but is required for CHERI software.
 


### PR DESCRIPTION
Adoc has trouble resolving variables in titles. This change fixes that in one instance which was throwing a build warning