### PR TITLE
Fix malformed check to avoid 65-bit top overflow

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -594,8 +594,8 @@ capability because its bounds cannot be correctly decoded. The following check
 indicates whether a capability is malformed.
 
 ```
-malformedMSB =  (E == CAP_MAX_E     && B != 0)
-             || (E == CAP_MAX_E - 1 && B[MW - 1]        != 0)
+malformedMSB =  (E == CAP_MAX_E     && B         != 0)
+             || (E == CAP_MAX_E - 1 && B[MW - 1] != 0)
 malformedLSB =  (E  < 0)
 malformed    =  !EF && (malformedMSB || malformedLSB)
 ```

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -594,7 +594,7 @@ capability because its bounds cannot be correctly decoded. The following check
 indicates whether a capability is malformed.
 
 ```
-malformedMSB =  (E == CAP_MAX_E     && B[MW - 1:MW - 2] != 0)
+malformedMSB =  (E == CAP_MAX_E     && B != 0)
              || (E == CAP_MAX_E - 1 && B[MW - 1]        != 0)
 malformedLSB =  (E  < 0)
 malformed    =  !EF && (malformedMSB || malformedLSB)

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -489,7 +489,7 @@ That is, invert the most significant bit of _t_ if the decoded length of the
 capability is larger than E.
 
 [#section_cap_malformed]
-==== Malformed Capability Bounds
+===== Malformed Capability Bounds
 
 A capability is _malformed_ if its encoding does not describe a valid
 capability because its bounds cannot be correctly decoded. The following check


### PR DESCRIPTION
Hopefully addresses https://github.com/riscv/riscv-cheri/issues/149, but I'd like to do some more checking before this gets merged!