### PR TITLE
Change CSR/jump/branch invalid address handling

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -491,7 +491,8 @@ That is, invert the most significant bit of _t_ if the decoded length of the
 capability is larger than E.
 
 NOTE: A capability has infinite bounds if E=CAP_MAX_E and it is not
-malformed (see xref:section_cap_malformed[xrefstyle=short]).
+malformed (see xref:section_cap_malformed[xrefstyle=short]); this check is
+equivalent to _b_=0 and _t_&#8804;2^MXLEN^.
 
 [#section_cap_malformed]
 ===== Malformed Capability Bounds

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -475,7 +475,8 @@ while still allowing the bounds to be correctly decoded.
 .Memory address bounds encoded within a capability
 image::cap-bounds-map.png[width=80%,align=center]
 
-A capability whose bounds cover the entire address space has 0 base and top
+A capability has _infinite_ bounds if its bounds cover the entire address space
+such that the base address is 0 and top
 equals 2^MXLEN^, i.e. _t_ is a MXLEN + 1 bit value. However, _b_ is a
 MXLEN bit value and the size mismatch introduces additional complications
 when decoding, so the following condition is required to correct _t_ for

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -476,8 +476,8 @@ while still allowing the bounds to be correctly decoded.
 image::cap-bounds-map.png[width=80%,align=center]
 
 A capability has _infinite_ bounds if its bounds cover the entire address space
-such that the base address is 0 and top
-equals 2^MXLEN^, i.e. _t_ is a MXLEN + 1 bit value. However, _b_ is a
+such that the base address _b_=0 and the top address _t_&#8804;2^MXLEN^,
+i.e. _t_ is a MXLEN + 1 bit value. However, _b_ is a
 MXLEN bit value and the size mismatch introduces additional complications
 when decoding, so the following condition is required to correct _t_ for
 capabilities whose <<section_cap_representable_check>> wraps the edge of the address
@@ -489,6 +489,9 @@ if ( (E < (CAP_MAX_E - 1)) & (t[MXLEN: MXLEN - 1] - b[MXLEN - 1] > 1) )
 ```
 That is, invert the most significant bit of _t_ if the decoded length of the
 capability is larger than E.
+
+NOTE: A capability has infinite bounds if E=CAP_MAX_E and it is not
+malformed (see xref:section_cap_malformed[xrefstyle=short]).
 
 [#section_cap_malformed]
 ===== Malformed Capability Bounds

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -476,7 +476,7 @@ while still allowing the bounds to be correctly decoded.
 image::cap-bounds-map.png[width=80%,align=center]
 
 A capability has _infinite_ bounds if its bounds cover the entire address space
-such that the base address _b_=0 and the top address _t_&#8804;2^MXLEN^,
+such that the base address _b_=0 and the top address _t_&#8805;2^MXLEN^,
 i.e. _t_ is a MXLEN + 1 bit value. However, _b_ is a
 MXLEN bit value and the size mismatch introduces additional complications
 when decoding, so the following condition is required to correct _t_ for
@@ -492,7 +492,7 @@ capability is larger than E.
 
 NOTE: A capability has infinite bounds if E=CAP_MAX_E and it is not
 malformed (see xref:section_cap_malformed[xrefstyle=short]); this check is
-equivalent to _b_=0 and _t_&#8804;2^MXLEN^.
+equivalent to _b_=0 and _t_&#8805;2^MXLEN^.
 
 [#section_cap_malformed]
 ===== Malformed Capability Bounds

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1087,7 +1087,7 @@ and the bounds encoding depends on the address value, so implementations must
 not convert invalid addresses to other arbitrary invalid addresses in an
 unrestricted manner.
 The following procedure must be used instead when writing a capability A to
-a CSR:
+a CSR that cannot hold all invalid addresses:
 
 . If A's address cannot be held, then convert it to another address that the
 register can hold.
@@ -1097,7 +1097,8 @@ xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0.
 <<mtvecc>>, <<mepcc>>, etc.
 
 The following procedure must be used instead when jumping or branching to a
-capability A. Note that A is the <<pcc>> when executing direct jumps and branches
+capability A if the <<pcc>> cannot hold all invalid invalid addresses. Note
+that A is the <<pcc>> when executing direct jumps and branches
 or the CHERI execution mode is Legacy (see
 xref:section_cheri_legacy_ext[xrefstyle=short]):
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -679,7 +679,7 @@ _Reserved_
 |Priority |Exc.Code |Description
 |_Highest_ |3 |Instruction address breakpoint
 | .>|*{cheri_excep_mcause}* .<|*Prior to instruction address translation:* +
-*CHERI fault due to PCC checks (tag, execute permission and bounds)*
+*CHERI fault due to PCC checks (tag, execute permission, invalid address and bounds)*
 | .>|12, 1 .<|During instruction address translation: +
 First encountered page fault or access fault
 | .>|1 .<|With physical address for instruction: +
@@ -697,11 +697,11 @@ Load/store/AMO address breakpoint
 
 | .>| *{cheri_excep_mcause}* .<| *CHERI faults due to:* +
 *PCC <<asr_perm>> clear* +
-*Branch/jump target address checks (tag, execute permissions and bounds)*
+*Branch/jump target address checks (tag, execute permissions, invalid address and bounds)*
 
 | .>|*{cheri_excep_mcause}* .<|*Prior to address translation for an explicit memory access:* +
 *Load/store/AMO capability address misaligned* +
-*CHERI fault due to capability checks (tag, permissions and bounds)*
+*CHERI fault due to capability checks (tag, permissions, invalid address and bounds)*
 | .>|4,6 .<|Optionally: +
 Load/store/AMO address misaligned
 | .>|13, 15, 5, 7 .<|During address translation for an explicit memory access: +
@@ -763,7 +763,8 @@ xref:mtval-cheri-causes[xrefstyle=short] respectively.
 | 1                | Seal violation
 | 2                | Permission violation
 | 3                | Length violation
-| 4-15             | Reserved
+| 4                | Invalid address violation
+| 5-15             | Reserved
 |==============================================================================
 
 [#supervisor-level-csrs-section]
@@ -1078,23 +1079,39 @@ memory addresses must match for the address to be valid:
 * For Sv48, bits [63:48] must equal bit 47
 * For Sv57, bits [63:57] must equal bit 56
 
-RISC-V permits that some CSRs holding addresses, such as <<mtvec>> and <<mepc>>
-(see xref:CSR_exevectors[xrefstyle=short]) and consequently <<pcc>>, need not be able to hold all possible
-invalid addresses. Prior to writing these registers, implementations may convert an
-invalid address into some other invalid address that the register is capable of
-holding. However, these registers hold capabilities in {cheri_base_ext_name}
-and the bounds encoding depends on the address value, so implementations must
-not convert invalid addresses to other arbitrary invalid addresses in an
-unrestricted manner.
-The following procedure must be used instead when writing a capability A to
-a CSR that cannot hold all invalid addresses:
+RISC-V permits that CSRs holding addresses, such as <<mtvec>> and <<mepc>>
+(see xref:CSR_exevectors[xrefstyle=short]) as well as <<pcc>>, need not
+hold all possible invalid addresses. Implementations may convert an invalid
+address into some other invalid address that the register is capable of holding.
+Therefore, implementations often support area and power optimizations by
+compressing invalid addresses in a lossy fashion.
+
+NOTE: Compressing invalid addresses allows implementations to reduce the number
+of flops required to hold some CSRs, such as <<mtvec>>. In CHERI, invalid
+addresses may also be used to reduce the number of bits to compare during a
+bounds check, for example, to 40 bits if using Sv39.
+
+However, the bounds encoding of capabilities in {cheri_base_ext_name} depends
+on the address value, so implementations must not convert invalid addresses to
+other arbitrary invalid address in an unrestricted manner. The remainder of
+this section describes how invalid address handling must be supported in
+{cheri_base_ext_name} when accessing CSRs, branching and jumping, and
+accessing memory.
+
+===== Accessing CSRs
+
+The following procedure must be used instead when executing instructions, such
+as <<CSRRW>>, that write a capability A to a CSR that cannot hold all invalid
+addresses:
 
 . If A's address is invalid and A does not have infinite bounds (see
 xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0.
 . Write the final (potentially modified) version of capability A to the CSR e.g.
 <<mtvecc>>, <<mepcc>>, etc.
 
-The following procedure must be used instead when jumping or branching to a
+===== Branches and Jumps
+
+The following procedure must be used when jumping or branching to a
 capability A if the <<pcc>> cannot hold all invalid addresses. Note
 that A is the <<pcc>> when executing direct jumps and branches
 or the CHERI execution mode is Legacy (see
@@ -1103,13 +1120,15 @@ xref:section_cheri_legacy_ext[xrefstyle=short]):
 . Calculate the effective target address T of the jump or branch as required by
 the instruction's behavior.
 . If T is invalid and A does not have infinite bounds (see
-xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0. The
-instruction gives rise to a CHERI
-fault; _CHERI jump or branch fault_ is reported in the TYPE field and Tag
-Violation is reported in the CAUSE field of <<mtval>> or <<stval>>.
-. If T is invalid and A has infinite bounds (see xref:section_cap_encoding[xrefstyle=short]),
-then A's tag is unchanged and T is written into A's address field. The hart
-will raise an instruction access fault as is usual in RISC-V.
+xref:section_cap_encoding[xrefstyle=short]), then the instruction gives rise to
+a CHERI fault; the _CHERI jump or branch_ fault is reported in the TYPE field
+and invalid address violation is reported in the CAUSE field of <<mtval>> or
+<<stval>>.
+. If T is invalid and A has infinite bounds (see
+xref:section_cap_encoding[xrefstyle=short]), then A's tag is unchanged and T is
+written into A's address field. Attempting to execute the instruction at
+address T gives rise to an instruction access fault as is usual in RISC-V.
+. Otherwise T is valid and the instruction behaves as normal.
 
 NOTE: RISC-V harts that do not support {cheri_base_ext_name} normally raise an
 instruction access fault after jumping or branching to an invalid address.
@@ -1117,3 +1136,18 @@ Therefore, {cheri_base_ext_name} aims to preserve that behavior to ensure that
 harts supporting {cheri_base_ext_name} and {cheri_legacy_ext_name} are fully
 compatible with RISC-V harts provided that <<pcc>> and <<ddc>> are set to the
 <<infinite-cap>> capability.
+
+===== Memory Accesses
+
+The following procedure must be used while loading or storing to memory with a
+capability A when the implementation supports invalid address optimizations:
+
+. Calculate the effective address T of the memory access as required by the
+instruction's behavior.
+. If T is invalid and A does not have infinite bounds (see
+xref:section_cap_encoding[xrefstyle=short]), then the instruction gives rise to
+a CHERI fault; the _CHERI data_ fault is reported in the TYPE field and invalid
+address violation is reported in the CAUSE field of <<mtval>> or <<stval>>.
+. If T is invalid and A has infinite bounds (see xref:section_cap_encoding[xrefstyle=short]),
+the hart will raise an access fault as is usual in RISC-V.
+. Otherwise T is valid and the instruction behaves as normal.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1108,7 +1108,7 @@ accessing memory.
 
 ===== Accessing CSRs
 
-The following procedure must be used instead when executing instructions, such
+The following procedure must be used when executing instructions, such
 as <<CSRRW>>, that write a capability A to a CSR that cannot hold all invalid
 addresses:
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1088,7 +1088,7 @@ memory addresses must match for the address to be valid:
 * For Sv57, bits [63:57] must equal bit 56
 
 RISC-V permits that CSRs holding addresses, such as <<mtvec>> and <<mepc>>
-(see xref:CSR_exevectors[xrefstyle=short]) as well as <<pcc>>, need not
+(see xref:CSR_exevectors[xrefstyle=short]) as well as pc, need not
 hold all possible invalid addresses. Implementations may convert an invalid
 address into some other invalid address that the register is capable of holding.
 Therefore, implementations often support area and power optimizations by

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1089,15 +1089,13 @@ unrestricted manner.
 The following procedure must be used instead when writing a capability A to
 a CSR that cannot hold all invalid addresses:
 
-. If A's address cannot be held, then convert it to another address that the
-register can hold.
 . If A's address is invalid and A does not have infinite bounds (see
 xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0.
 . Write the final (potentially modified) version of capability A to the CSR e.g.
 <<mtvecc>>, <<mepcc>>, etc.
 
 The following procedure must be used instead when jumping or branching to a
-capability A if the <<pcc>> cannot hold all invalid invalid addresses. Note
+capability A if the <<pcc>> cannot hold all invalid addresses. Note
 that A is the <<pcc>> when executing direct jumps and branches
 or the CHERI execution mode is Legacy (see
 xref:section_cheri_legacy_ext[xrefstyle=short]):

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1111,11 +1111,15 @@ xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0.
 
 ===== Branches and Jumps
 
-The following procedure must be used when jumping or branching to a
-capability A if the <<pcc>> cannot hold all invalid addresses. Note
-that A is the <<pcc>> when executing direct jumps and branches
-or the CHERI execution mode is Legacy (see
-xref:section_cheri_legacy_ext[xrefstyle=short]):
+Control transfer instructions jump or branch to a capability A which can be:
+
+* <<pcc>> for branches, direct jumps and any branch when the CHERI execution
+mode is Legacy (see xref:section_cheri_legacy_ext[xrefstyle=short]).
+* The capability in the *c* input register of a jump when the CHERI execution
+mode is Capability (see xref:section_cheri_legacy_ext[xrefstyle=short]).
+
+The following procedure must be used when jumping or branching to the target
+capability A if the <<pcc>> cannot hold all invalid addresses:
 
 . Calculate the effective target address T of the jump or branch as required by
 the instruction's behavior.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1092,7 +1092,7 @@ a CSR:
 . If A's address cannot be held, then convert it to another address that the
 register can hold.
 . If A's address is invalid and A's bounds do not equal the bounds of the
-Infinite capability, then A's tag is set to 0.
+<<infinite-cap>> capability, then A's tag is set to 0.
 . Write the final (potentially modified) version of capability A to the CSR e.g.
 <<mtvecc>>, <<mepcc>>, etc.
 
@@ -1102,11 +1102,11 @@ or the CHERI execution mode is Legacy (see xref:section_zcheri_legacy[xrefstyle=
 
 . Calculate the effective target address T of the jump or branch as required by
 the instruction's behavior.
-. If T is invalid and A's bounds do not equal the bounds of the Infinite
+. If T is invalid and A's bounds do not equal the bounds of the <<infinite-cap>>
 capability, then A's tag is set to 0. The instruction gives rise to a CHERI
 fault; _CHERI jump or branch fault_ is reported in the TYPE field and Tag
 Violation is reported in the CAUSE field of <<mtval>> or <<stval>>.
-. If T is invalid and A's bounds equal the bounds of the Infinite capability,
+. If T is invalid and A's bounds equal the bounds of the <<infinite-cap>> capability,
 then A's tag is unchanged and T is written into A's address field. The hart
 will raise an instruction access fault as is usual in RISC-V.
 
@@ -1115,4 +1115,4 @@ instruction access fault after jumping or branching to an invalid address.
 Therefore, {cheri_base_ext_name} aims to preserve that behavior to ensure that
 harts supporting {cheri_base_ext_name} and {cheri_legacy_ext_name} are fully
 compatible with RISC-V harts provided that <<pcc>> and <<ddc>> are set to the
-Infinite capability.
+<<infinite-cap>> capability.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1078,27 +1078,41 @@ memory addresses must match for the address to be valid:
 * For Sv48, bits [63:48] must equal bit 47
 * For Sv57, bits [63:57] must equal bit 56
 
-RISC-V permits that some CSRs, such as <<mtvec>> and <<mepc>> (see
-xref:CSR_exevectors[xrefstyle=short]), need not be able to hold all possible
-invalid addresses. Prior to writing these CSRs, implementations may convert an
+RISC-V permits that some CSRs holding addresses, such as <<mtvec>> and <<mepc>>
+(see xref:CSR_exevectors[xrefstyle=short]) and consequently <<pcc>>, need not be able to hold all possible
+invalid addresses. Prior to writing these registers, implementations may convert an
 invalid address into some other invalid address that the register is capable of
 holding. However, these registers hold capabilities in {cheri_base_ext_name}
 and the bounds encoding depends on the address value, so implementations must
 not convert invalid addresses to other arbitrary invalid addresses in an
 unrestricted manner.
 The following procedure must be used instead when writing a capability A to
-these CSRs:
+a CSR:
 
-. If A's address cannot be held then convert it to another address that the CSR can
-hold
-. If conversion _was_ required, then A's tag is cleared if A is
-sealed or if the new address is not representable -- this is equivalent to the
-semantics of <<SCADDR>>
+. If A's address cannot be held, then convert it to another address that the
+register can hold.
+. If A's address is invalid and A's bounds do not equal the bounds of the
+Infinite capability, then A's tag is set to 0.
 . Write the final (potentially modified) version of capability A to the CSR e.g.
 <<mtvecc>>, <<mepcc>>, etc.
 
-This implies that sealed capabilities will always get their tags cleared when
-written to these CSRs unless the specification explicitly states that the CSR
-behaves otherwise (see <<mepcc>> and <<sepcc>>). Also note that <<pcc>> can
-be written with a <<JALR>> instruction in Capability Mode which automatically unseal the capability _before_
-the invalid address conversion above.
+The following procedure must be used instead when jumping or branching to a
+capability A. Note that A is the <<pcc>> when executing direct jumps and branches
+or the CHERI execution mode is Legacy (see xref:section_zcheri_legacy[xrefstyle=short]):
+
+. Calculate the effective target address T of the jump or branch as required by
+the instruction's behavior.
+. If T is invalid and A's bounds do not equal the bounds of the Infinite
+capability, then A's tag is set to 0. The instruction gives rise to a CHERI
+fault; _CHERI jump or branch fault_ is reported in the TYPE field and Tag
+Violation is reported in the CAUSE field of <<mtval>> or <<stval>>.
+. If T is invalid and A's bounds equal the bounds of the Infinite capability,
+then A's tag is unchanged and T is written into A's address field. The hart
+will raise an instruction access fault as is usual in RISC-V.
+
+NOTE: RISC-V harts that do not support {cheri_base_ext_name} normally raise an
+instruction access fault after jumping or branching to an invalid address.
+Therefore, {cheri_base_ext_name} aims to preserve that behavior to ensure that
+harts supporting {cheri_base_ext_name} and {cheri_legacy_ext_name} are fully
+compatible with RISC-V harts provided that <<pcc>> and <<ddc>> are set to the
+Infinite capability.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -712,7 +712,7 @@ Load/store/AMO access fault
 Load/store/AMO address misaligned
 |===
 
-NOTE: the full details of the CHERI exceptions are in xref:cheri_exception_combs_descriptions[xrefstyle=short].
+NOTE: The full details of the CHERI exceptions are in xref:cheri_exception_combs_descriptions[xrefstyle=short].
 
 [#medeleg,reftext="medeleg"]
 ==== Machine Trap Delegation Register (medeleg)
@@ -746,7 +746,7 @@ shown in xref:mtval-cheri-type[xrefstyle=short] and
 xref:mtval-cheri-causes[xrefstyle=short] respectively.
 
 .Encoding of TYPE field
-[#mtval-cheri-type,width=60%,float="center",align="center",options=header,cols="30%,70%"]
+[#mtval-cheri-type,width=65%,float="center",align="center",options=header,cols="30%,70%"]
 |==============================================================================
 | CHERI Type Code | Description
 | 0               | CHERI instruction access fault
@@ -756,16 +756,24 @@ xref:mtval-cheri-causes[xrefstyle=short] respectively.
 |==============================================================================
 
 .Encoding of CAUSE field
-[#mtval-cheri-causes,width=40%,float="center",align="center",options=header]
+[#mtval-cheri-causes,width=55%,float="center",align="center",options=header]
 |==============================================================================
 | CHERI Cause Code | Description
 | 0                | Tag violation
 | 1                | Seal violation
 | 2                | Permission violation
-| 3                | Length violation
-| 4                | Invalid address violation
+| 3                | Invalid address violation
+| 4                | Length violation
 | 5-15             | Reserved
 |==============================================================================
+
+CHERI violations have the following order in priority:
+
+. Tag violation (_Highest_)
+. Seal violation
+. Permission violation
+. Invalid address violation
+. Length violation (_Lowest_)
 
 [#supervisor-level-csrs-section]
 === Supervisor-Level CSRs

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1091,22 +1091,24 @@ a CSR:
 
 . If A's address cannot be held, then convert it to another address that the
 register can hold.
-. If A's address is invalid and A's bounds do not equal the bounds of the
-<<infinite-cap>> capability, then A's tag is set to 0.
+. If A's address is invalid and A does not have infinite bounds (see
+xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0.
 . Write the final (potentially modified) version of capability A to the CSR e.g.
 <<mtvecc>>, <<mepcc>>, etc.
 
 The following procedure must be used instead when jumping or branching to a
 capability A. Note that A is the <<pcc>> when executing direct jumps and branches
-or the CHERI execution mode is Legacy (see xref:section_zcheri_legacy[xrefstyle=short]):
+or the CHERI execution mode is Legacy (see
+xref:section_cheri_legacy_ext[xrefstyle=short]):
 
 . Calculate the effective target address T of the jump or branch as required by
 the instruction's behavior.
-. If T is invalid and A's bounds do not equal the bounds of the <<infinite-cap>>
-capability, then A's tag is set to 0. The instruction gives rise to a CHERI
+. If T is invalid and A does not have infinite bounds (see
+xref:section_cap_encoding[xrefstyle=short]), then A's tag is set to 0. The
+instruction gives rise to a CHERI
 fault; _CHERI jump or branch fault_ is reported in the TYPE field and Tag
 Violation is reported in the CAUSE field of <<mtval>> or <<stval>>.
-. If T is invalid and A's bounds equal the bounds of the <<infinite-cap>> capability,
+. If T is invalid and A has infinite bounds (see xref:section_cap_encoding[xrefstyle=short]),
 then A's tag is unchanged and T is written into A's address field. The hart
 will raise an instruction access fault as is usual in RISC-V.
 

--- a/src/riscv-legacy-integration.adoc
+++ b/src/riscv-legacy-integration.adoc
@@ -1,3 +1,4 @@
+[#section_cheri_legacy_ext]
 == "Zcheri_legacy" Extension for CHERI Legacy Mode
 
 {cheri_legacy_ext_name} is an optional extension to {cheri_base_ext_name}.

--- a/src/trigger-integration.adoc
+++ b/src/trigger-integration.adoc
@@ -20,7 +20,7 @@ mcontrol/mcontrol6 after (on previous instruction)
 
 | .>|3 .<|Instruction address breakpoint |mcontrol/mcontrol6 execute address before
 | .>|*{cheri_excep_mcause}* .<|*Prior to instruction address translation:* +
-*CHERI fault due to PCC checks (tag, execute permission and bounds)* |
+*CHERI fault due to PCC checks (tag, execute permission, invalid address and bounds)* |
 | .>|12, 1 .<|During instruction address translation: +
 First encountered page fault or access fault |
 | .>|1 .<|With physical address for instruction: +
@@ -41,10 +41,10 @@ Environment break |
 
 | .>| *{cheri_excep_mcause}* .<| *CHERI faults due to:* +
 *PCC <<asr_perm>> clear* +
-*Branch/jump target address checks (tag, execute permissions and bounds)* |
+*Branch/jump target address checks (tag, execute permissions, invalid address and bounds)* |
 | .>|*{cheri_excep_mcause}* .<|*Prior to address translation for an explicit memory access:* +
 *Load/store/AMO capability address misaligned* +
-*CHERI fault due to capability checks (tag, permissions and bounds)* |
+*CHERI fault due to capability checks (tag, permissions, invalid address and bounds)* |
 
 | .>|4,6 .<|Optionally: +
 Load/store/AMO address misaligned |


### PR DESCRIPTION
* Unify the invalid address handling for both CSR and control transfer instructions
* The new invalid address handling clears the tag if the capability being written is not Infinity. Also, invalid address conversion is now performed before anything else

Fixes #139