### PR TITLE
Clarify that cbld cd.tag=0 if checks fail

### DIFF
--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -25,7 +25,7 @@ Copy `cs2` to `cd` and set the tag to 1 if `cs1.tag` is set, `cs1` is not
 sealed, `cs2` 's permissions and bounds are equal to or a subset of `cs1` 's,
 `cs2` 's bounds are not malformed (see
 xref:section_cap_malformed[xrefstyle=short]), and all reserved bits in `cs2` 's
-metadata are 0. <<CBLD>> is typically used alongside <<SCHI>> to build
+metadata are 0; otherwise, copy `cs2` to `cd` and clear `cd` 's tag. <<CBLD>> is typically used alongside <<SCHI>> to build
 capabilities from integer values.
 
 NOTE: Although currently this will set the tag to 0 and leave the metadata


### PR DESCRIPTION
Fixes #186 