### PR TITLE
Revert "Fix malformed check to avoid 65-bit top overflow"

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -496,8 +496,8 @@ capability because its bounds cannot be correctly decoded. The following check
 indicates whether a capability is malformed.
 
 ```
-malformedMSB =  (E == CAP_MAX_E     && B         != 0)
-             || (E == CAP_MAX_E - 1 && B[MW - 1] != 0)
+malformedMSB =  (E == CAP_MAX_E     && B[MW - 1:MW - 2] != 0)
+             || (E == CAP_MAX_E - 1 && B[MW - 1]        != 0)
 malformedLSB =  (E  < 0)
 malformed    =  !EF && (malformedMSB || malformedLSB)
 ```


### PR DESCRIPTION
Landed with incorrect commit message.