### PR TITLE
Fix dscratch{0,1}c reset values

### DIFF
--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -142,11 +142,12 @@ need it. <<dscratch0>> is extended into <<dscratch0c>>.
 include::img/dscratch0reg.edn[]
 
 [#dscratch0c,reftext="dscratch0c"]
-==== Debug Scratch Register 0 (dscratch0c)
+==== Debug Scratch Register 0 Capability (dscratch0c)
 
 The <<dscratch0c>> register is a CLEN-bit plus tag bit renamed extension to
-<<dscratch0>> that is able to hold a capability. Its reset value is the
-<<null-cap>> capability.
+<<dscratch0>> that is able to hold a capability.
+
+{TAG_RESET_CSR}
 
 .Debug scratch 0 capability register
 include::img/dscratch0creg.edn[]
@@ -160,15 +161,16 @@ need it. <<dscratch1>> is extended into <<dscratch1c>>.
 
 {TAG_RESET_CSR}
 
-.Debug scratch 0 register
+.Debug scratch 1 register
 include::img/dscratch1reg.edn[]
 
 [#dscratch1c,reftext="dscratch1c"]
-==== Debug Scratch Register 1 (dscratch1c)
+==== Debug Scratch Register 1 Capability (dscratch1c)
 
 The <<dscratch1c>> register is a CLEN-bit plus tag bit renamed extension to
-<<dscratch1>> that is able to hold a capability. Its reset value is the
-<<null-cap>> capability.
+<<dscratch1>> that is able to hold a capability.
+
+{TAG_RESET_CSR}
 
 .Debug scratch 1 capability register
 include::img/dscratch1creg.edn[]


### PR DESCRIPTION
Minor fix in the text  for reset values of dscratch{0,1}c registers