### PR TITLE
Remove reset notice for debug CSRs without tag/metadata

### DIFF
--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -136,8 +136,6 @@ The <<dscratch0>> register is as defined in cite:[riscv-debug-spec]. It is an
 optional DXLEN-bit scratch register that can be used by implementations which
 need it. <<dscratch0>> is extended into <<dscratch0c>>.
 
-{TAG_RESET_CSR}
-
 .Debug scratch 0 register
 include::img/dscratch0reg.edn[]
 
@@ -158,8 +156,6 @@ include::img/dscratch0creg.edn[]
 The <<dscratch1>> register is as defined in cite:[riscv-debug-spec]. It is an
 optional DXLEN-bit scratch register that can be used by implementations which
 need it. <<dscratch1>> is extended into <<dscratch1c>>.
-
-{TAG_RESET_CSR}
 
 .Debug scratch 1 register
 include::img/dscratch1reg.edn[]


### PR DESCRIPTION
Remove reset notice from CSRs that do not have tags or metadata because they are the DXLEN version rather than the CLEN version.