### PR TITLE
amoswap_32bit_cap: fix the amoswap.c mnemonics

### DIFF
--- a/src/insns/amoswap_32bit_cap.adoc
+++ b/src/insns/amoswap_32bit_cap.adoc
@@ -11,10 +11,10 @@ Atomic Operation (AMOSWAP.C), 32-bit encoding
 include::xlen_variable_warning.adoc[]
 
 Capability Mode Mnemonics::
-`amoswap.c, offset(cs1)`
+`amoswap.c cd, cs2, offset(cs1)`
 
 Legacy Mode Mnemonics::
-`amoswap.c, offset(rs1)`
+`amoswap.c cd, cs2, offset(rs1)`
 
 Encoding::
 include::wavedrom/amoswap_cap.adoc[]


### PR DESCRIPTION
Fix the amoswap.c mnemonics, list all three parameters.