### PR TITLE
amo_32bit.adoc: fix the amo<op>.[w|d] mnemonics

### DIFF
--- a/src/insns/amo_32bit.adoc
+++ b/src/insns/amo_32bit.adoc
@@ -14,16 +14,16 @@ Synopsis::
 Atomic Operations (AMO<OP>.W, AMO<OP>.D), 32-bit encodings
 
 Capability Mode Mnemonics (RV64)::
-`amo<op>.[w|d], offset(cs1)`
+`amo<op>.[w|d] rd, rs2, offset(cs1)`
 
 Capability Mode Mnemonics (RV32)::
-`amo<op>.w, offset(cs1)`
+`amo<op>.w rd, rs2, offset(cs1)`
 
 Legacy Mode Mnemonics (RV64)::
-`amo<op>.[w|d], offset(rs1)`
+`amo<op>.[w|d] rd, rs2, offset(rs1)`
 
 Legacy Mode Mnemonics (RV32)::
-`amo<op>.w, offset(rs1)`
+`amo<op>.w rd, rs2, offset(rs1)`
 
 Encoding::
 include::wavedrom/amo.adoc[]


### PR DESCRIPTION
Fix the amo<op>.[w|d] mnemonics, list all three parameters.