### PR TITLE
Remove unused prefetch exception text

### DIFF
--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -26,26 +26,8 @@ ifdef::cbo_inval[]
 | Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>
 | Length violation      | At least one byte accessed is outside the bounds
 endif::[]
-
-ifdef::prefetch_i[]
-| Permission violation  | It does not grant <<x_perm>>
-| Length violation      | At least one byte accessed is within the bounds
-endif::[]
-
-ifdef::prefetch_r[]
-| Permission violation  | It does not grant <<r_perm>>
-| Length violation      | At least one byte accessed is within the bounds
-endif::[]
-
-ifdef::prefetch_w[]
-| Permission violation  | It does not grant <<w_perm>>
-| Length violation      | At least one byte accessed is within the bounds
-endif::[]
 |==============================================================================
 
 
 :!cbo_clean_flush:
 :!cbo_inval:
-:!prefetch_r:
-:!prefetch_w:
-:!prefetch_i:


### PR DESCRIPTION
These exceptions do not happen any more and this file is no longer included from the prefetch instructions.