### PR TITLE
Correct the length violation condition for cbo.clean & cbo.flush

### DIFF
--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -19,7 +19,7 @@ endif::[]
 
 ifdef::cbo_clean_flush[]
 | Permission violation  | It does not grant <<w_perm>> and <<r_perm>>
-| Length violation      | At least one byte accessed is within the bounds
+| Length violation      | None of the bytes accessed are within the bounds
 endif::cbo_clean_flush[]
 
 ifdef::cbo_inval[]


### PR DESCRIPTION
The sense of this column elsewhere is "raise a length violation if <condition>", but here it was backwards.

Fixes #213