### PR TITLE
Removed src1 != 0 constraint for cbld

### DIFF
--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -30,7 +30,7 @@ capabilities from integer values.
 
 NOTE: When `cs1` is `c0` this will set the tag to 0 and leave the metadata
 otherwise unchanged. However this may change in future extensions,
-and so software should not assume `cs1==0` to lead to a pseudo instruction
+and so software should not assume `cs1==0` to be a pseudo instruction
 for tag clearing.
 
 Prerequisites::

--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -28,9 +28,10 @@ xref:section_cap_malformed[xrefstyle=short]), and all reserved bits in `cs2` 's
 metadata are 0; otherwise, copy `cs2` to `cd` and clear `cd` 's tag. <<CBLD>> is typically used alongside <<SCHI>> to build
 capabilities from integer values.
 
-NOTE: Although currently this will set the tag to 0 and leave the metadata
-otherwise unchanged when `cs1` is `c0`, this may change in future extensions,
-and so software should not assume this.
+NOTE: When `cs1` is `c0` this will set the tag to 0 and leave the metadata
+otherwise unchanged. However this may change in future extensions,
+and so software should not assume `cs1==0` to lead to a pseudo instruction
+for tag clearing.
 
 Prerequisites::
 {cheri_base_ext_name}

--- a/src/insns/wavedrom/cbld.adoc
+++ b/src/insns/wavedrom/cbld.adoc
@@ -5,7 +5,7 @@
   {bits: 7,  name: 'opcode',  attr: ['7', 'OP=0110011'], type: 8},
   {bits: 5,  name: 'cd',      attr: ['5', 'dest'], type: 2},
   {bits: 3,  name: 'funct3',  attr: ['3', 'CBLD=101'], type: 8},
-  {bits: 5,  name: 'cs1',     attr: ['5', 'src1 != 0'], type: 4},
+  {bits: 5,  name: 'cs1',     attr: ['5', 'src1'], type: 4},
   {bits: 5,  name: 'cs2',     attr: ['5', 'src2'], type: 3},
   {bits: 7,  name: 'funct7',  attr: ['7', 'CBLD=0000110'], type: 3},
 ]}


### PR DESCRIPTION
This came up in a discussion. `src1 != 0` would lead to an exception, which is not desired in this case. This will close #222.