### PR TITLE
Clarify bit-slices in edge cases of the decoded bound figure

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -637,7 +637,7 @@ For the address to be valid for the current bounds encoding, the value
 in the _Upper Section_ of xref:comp_addr_bounds[xrefstyle=short] _must
 not change_ as this will change the meaning of the bounds.
 
-This gives a range of `s=2^E+MW^`, which as shown in
+This gives a range of `s=2^E+MW^`, as shown in
 xref:cap_bounds_map[xrefstyle=short].
 
 The gap between the object bounds and the bound of the representable range

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -613,13 +613,20 @@ bounds are formed of two or three sections:
 * Lower bits are set to zero
 ** This is only if there is an internal exponent (EF=0)
 
-.Composition of address bounds
-[#comp_addr_bounds,options=header,align="center"]
+.Composition of the decoded top address bound
+[#comp_addr_bounds,options=header,align="center",cols="2,4,2,2"]
 |==============================================================================
-| Configuration  | Upper section | Middle Section | Lower section
-| EF=0           | address[MXLEN-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
-| EF=1, i.e. E=0 | address[MXLEN-1:MW] + ct   2+| T[MW - 1:0]
+| Configuration  | Upper section (if E + MW &#8804; MXLEN) | Middle Section | Lower section
+| EF=0           | address[MXLEN:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
+| EF=1, i.e. E=0 | address[MXLEN:MW] + ct   2+| T[MW - 1:0]
 |==============================================================================
+
+The top described by xref:comp_addr_bounds[xrefstyle=short] is MXLEN+1 bits
+wide to allow capabilities to span the whole address space. The address is
+zero-extended by one bit. The malformed check (see
+xref:section_cap_malformed[xrefstyle=short]) ensures that the top never
+overflows into MXLEN+2 bits and that the base never overflows into MXLEN+1
+bits.
 
 The _representable range_ defines the range of addresses which do not corrupt
 the bounds encoding. The encoding was first introduced in


### PR DESCRIPTION
@tariqkurd-repo pointed out that the table was slightly wrong in big exponent cases (negative-width bit-slices). This fixes it while hopefully not making it too much more confusing!