### PR TITLE
Remove out of place text in legacy ext

### DIFF
--- a/src/riscv-legacy-integration.adoc
+++ b/src/riscv-legacy-integration.adoc
@@ -403,8 +403,6 @@ machine-mode hart-local context space, to load into <<ddc>>.
 
 {TAG_RESET_CSR}
 
-value is the <<null-cap>> capability.
-
 .Machine-mode trap data capability register
 include::img/mtdcreg.edn[]
 


### PR DESCRIPTION
Looks like a chunk of a sentence remained from a previous change.