### PR TITLE
Fix minor typos wording

### DIFF
--- a/src/img/mtveccreg.edn
+++ b/src/img/mtveccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})

--- a/src/img/mtvecreg.edn
+++ b/src/img/mtvecreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
 
 (draw-box "BASE [MXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)"             {:span 8})

--- a/src/img/stveccreg.edn
+++ b/src/img/stveccreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
 (draw-box "Tag" {:span 1})
 (draw-box ""    {:span 1 :borders {}})

--- a/src/img/stvecreg.edn
+++ b/src/img/stvecreg.edn
@@ -6,7 +6,7 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
 
 (draw-box "BASE (Address)[SXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)"                     {:span 8})

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -430,7 +430,7 @@ UXL, MBE, SBE, and UBE writeable, so implementations that support multiple base
 ISAs must support both {cheri_base_ext_name} and {cheri_legacy_ext_name}.
 
 [#mtvec, reftext="mtvec"]
-==== Machine Trap-Vector Base-Address Registers (mtvec)
+==== Machine Trap Vector Base Address Register (mtvec)
 
 The <<mtvec>> register is as defined in cite:[riscv-priv-spec]. It is an
 MXLEN-bit register used as the executable vector jumped to when taking traps
@@ -441,7 +441,7 @@ into machine mode. It is extended into <<mtvecc>>.
 include::img/mtvecreg.edn[]
 
 [#mtvecc,reftext="mtvecc"]
-==== Machine Trap-Vector Base-Address Capability Registers (mtvecc)
+==== Machine Trap Vector Base Address Capability Register (mtvecc)
 
 The <<mtvecc>> register is a renamed extension of <<mtvec>> that holds a
 capability.  Its reset value is the <<infinite-cap>> capability. The capability
@@ -491,7 +491,7 @@ is extended into <<mscratchc>>.
 include::img/mscratchreg.edn[]
 
 [#mscratchc, reftext="mscratchc"]
-==== Machine Scratch Register Capability (mscratchc)
+==== Machine Scratch Capability Register (mscratchc)
 
 The <<mscratchc>> register is a renamed extension of <<mscratch>> that is able to
 hold a capability.
@@ -783,7 +783,7 @@ hold capabilities or with other new functions. <<pcc>> must grant <<asr_perm>>
 to access S-mode CSRs regardless of the RISC-V privilege mode.
 
 [#stvec,reftext="stvec"]
-==== Supervisor Trap Vector Base Address Registers (stvec)
+==== Supervisor Trap Vector Base Address Register (stvec)
 
 The <<stvec>> register is as defined in cite:[riscv-priv-spec]. It is an
 SXLEN-bit register used as the executable vector jumped to when taking traps
@@ -793,7 +793,7 @@ into supervisor mode. It is extended into <<stvecc>>.
 include::img/stvecreg.edn[]
 
 [#stvecc,reftext="stvecc"]
-==== Supervisor Trap Vector Base Address Registers (stvecc)
+==== Supervisor Trap Vector Base Address Capability Register (stvecc)
 
 The <<stvec>> register is an SXLEN-bit WARL read/write register that holds the
 trap vector configuration, consisting of a vector base address (BASE) and a
@@ -820,7 +820,7 @@ is extended into <<sscratchc>>.
 include::img/sscratchreg.edn[]
 
 [#sscratchc, reftext="sscratchc"]
-==== Supervisor Scratch Registers (sscratchc)
+==== Supervisor Scratch Capability Register (sscratchc)
 
 The <<sscratchc>> register is a renamed extension of <<sscratch>> that is able to
 hold a capability.

--- a/src/riscv-legacy-integration.adoc
+++ b/src/riscv-legacy-integration.adoc
@@ -427,7 +427,7 @@ The reset value is 0.
 [#menvcfg,reftext="menvcfg"]
 ==== Machine Environment Configuration Register (menvcfg)
 
-{cheri_legacy_ext_name} adds two new enable bits to <<menvcfg>> as shown in
+{cheri_legacy_ext_name} adds a new enable bit to <<menvcfg>> as shown in
 xref:menvcfgmodereg[xrefstyle=short].
 
 .Machine environment configuration register (*menvcfg*)
@@ -462,7 +462,7 @@ include::img/stdcreg.edn[]
 ==== Supervisor Environment Configuration Register (senvcfg)
 
 The *senvcfg* register operates as described in the RISC-V Privileged
-Specification. {cheri_legacy_ext_name} adds two new enable bits as shown in
+Specification. {cheri_legacy_ext_name} adds a new enable bit as shown in
 xref:senvcfgreg[xrefstyle=short].
 
 .Supervisor environment configuration register (*senvcfg*)
@@ -471,7 +471,7 @@ include::img/senvcfgreg.edn[]
 
 The CHERI Register Enable (<<CRE>>) bit controls whether U-mode can perform
 explicit accesses to CHERI registers.  When <<CRE>>=1, CHERI registers can be read
-and written by U-mode.  When <<CRE>>=0, CHERI registers are in U-mode disabled as
+and written by U-mode.  When <<CRE>>=0, CHERI registers are disabled in U-mode as
 described.
 
 * senvcfg.<<CRE>> is read-only-zero if:


### PR DESCRIPTION
Fixed minor typos and wording that I spotted as I read through the spec.