### PR TITLE
fix jump descriptions, and add in the invalid address exception

### DIFF
--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -27,6 +27,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         | Authority capability tag set to 0
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>
+| Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | At least one byte accessed is outside the authority capability bounds
 |==============================================================================
 

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -31,6 +31,7 @@ endif::cbo_clean_flush[]
 ifdef::cbo_inval[]
 | Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>
 endif::[]
+| Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | None of the bytes accessed are within the bounds
 |==============================================================================
 

--- a/src/insns/j_16bit.adoc
+++ b/src/insns/j_16bit.adoc
@@ -20,7 +20,6 @@ include::wavedrom/c-j-format-ls.adoc[]
 
 Description::
 Set the next PC following the standard `jal` definition.
- Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.
  *There is no difference in pass:attributes,quotes[{cheri_cap_mode_name}] or pass:attributes,quotes[{cheri_int_mode_name}] execution for this instruction.*
 
 Exceptions::

--- a/src/insns/j_16bit.adoc
+++ b/src/insns/j_16bit.adoc
@@ -19,8 +19,9 @@ Encoding::
 include::wavedrom/c-j-format-ls.adoc[]
 
 Description::
-Set the next PC following the standard `jal` definition.
- *There is no difference in pass:attributes,quotes[{cheri_cap_mode_name}] or pass:attributes,quotes[{cheri_int_mode_name}] execution for this instruction.*
+Set the next PC following the standard <<JAL>> definition.
++
+*There is no difference in pass:attributes,quotes[{cheri_cap_mode_name}] or pass:attributes,quotes[{cheri_int_mode_name}] execution for this instruction.*
 
 Exceptions::
 See <<JAL>>

--- a/src/insns/jal_16bit.adoc
+++ b/src/insns/jal_16bit.adoc
@@ -21,7 +21,11 @@ pass:attributes,quotes[{cheri_int_mode_name}] Expansion (RV32)::
 Encoding (RV32)::
 include::wavedrom/c-jal-format-ls.adoc[]
 
-include::jal_common.adoc[]
+pass:attributes,quotes[{cheri_cap_mode_name}] Description::
+Link the next linear <<pcc>> to `cd` and seal. Jump to <<pcc>>.address+offset.
+
+pass:attributes,quotes[{cheri_int_mode_name}] Description::
+Set the next PC and link to `rd` according to the standard <<JAL>> definition.
 
 Exceptions::
 See <<JAL>>

--- a/src/insns/jal_32bit.adoc
+++ b/src/insns/jal_32bit.adoc
@@ -33,10 +33,12 @@ address which is written to the <<pcc>>'s address field. The address of the
 instruction following the jump (<<pcc>> + 4) is written to `rd`.
 
 Exceptions::
-CHERI fault exceptions occur when a minimum length instruction at the target
-address is not within the bounds of the <<pcc>>. In this case, _CHERI jump or
-branch fault_ is reported in the TYPE field and Length Violation is reported in
-the CAUSE field of <<mtval>> or <<stval>>.
+[%autowidth,options=header,align=center]
+|==============================================================================
+| CAUSE                      | pass:attributes,quotes[{cheri_int_mode_name}] | pass:attributes,quotes[{cheri_cap_mode_name}] | Reason
+| Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
+| Length violation           | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds.
+|==============================================================================
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/insns/jal_common.adoc
+++ b/src/insns/jal_common.adoc
@@ -1,7 +1,0 @@
-pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Link the next linear <<pcc>> to `cd` and seal. Jump to <<pcc>>.address+offset.
- Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.
-
-pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Set the next PC and link to `rd` according to the standard <<JAL>> definition.
- Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.

--- a/src/insns/jalr_16bit.adoc
+++ b/src/insns/jalr_16bit.adoc
@@ -21,7 +21,13 @@ pass:attributes,quotes[{cheri_int_mode_name}] Expansion::
 Encoding::
 include::wavedrom/c-jalr-format-ls.adoc[]
 
-include::jalr_common.adoc[]
+pass:attributes,quotes[{cheri_cap_mode_name}] Description::
+See <<JALR>> for execution of the expanded instruction as shown above.
+Note that the `offset` is zero in the expansion.
+
+pass:attributes,quotes[{cheri_int_mode_name}] Description::
+See <<JALR>> for execution of the expanded instruction as shown above.
+Note that the `offset` is zero in the expansion.
 
 Exceptions::
 See <<JALR>>

--- a/src/insns/jalr_32bit.adoc
+++ b/src/insns/jalr_32bit.adoc
@@ -22,10 +22,11 @@ include::wavedrom/ct-unconditional-2.adoc[]
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
 JALR allows unconditional, indirect jumps to a target capability. The
-target capability is obtained by unsealing `cs1` if the immediate is zero and
-incrementing its address by the sign-extended 12-bit immediate otherwise,
-and then setting the least-significant bit of the
-result to zero. The target capability may have
+target capability is unsealed if the `offset` is zero.
+The target address is obtained by adding the sign-extended 12-bit
+`offset` to `cs1.address`, then setting the
+least-significant bit of the result to zero.
+The target capability may have
 xref:section_invalid_addr_conv[xrefstyle=short]
 performed and is then installed in <<pcc>>. The <<pcc>>
 of the next instruction following the jump (<<pcc>> + 4) is sealed and written
@@ -51,7 +52,8 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         |      | ✔     | `cs1` has tag set to 0
 | Seal violation        |      | ✔     | `cs1` is sealed and the immediate is not 0
 | Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>
-| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds. This check uses the address after it has undergone xref:section_invalid_addr_conv[xrefstyle=short] but with the original bounds.
+| Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
+| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds.
 |==============================================================================
 
 include::pcrel_debug_warning.adoc[]

--- a/src/insns/jalr_common.adoc
+++ b/src/insns/jalr_common.adoc
@@ -1,7 +1,0 @@
-
-pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Link the next linear <<pcc>> to `cd` and seal. Jump to `cs1.address+offset`. <<pcc>> metadata is copied from `cs1`, and is unsealed if necessary. Note that execution has several exception checks.
-
-pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Set the next PC and link to `rd` according to the standard <<JALR>> definition.
- Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.

--- a/src/insns/jr_16bit.adoc
+++ b/src/insns/jr_16bit.adoc
@@ -22,11 +22,12 @@ Encoding::
 include::wavedrom/c-cr-format-ls.adoc[]
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Jump to `cs1.address+offset`. <<pcc>> metadata is copied from `cs1`, and is unsealed if necessary. Note that execution has several exception checks.
+See <<JALR>> for execution of the expanded instruction as shown above.
+Note that the `offset` is zero in the expansion.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Set the next PC according to the standard `jalr` definition.
- Check a minimum length instruction is in <<pcc>> bounds at the target PC, take a CHERI Length Violation exception on error.
+See <<JALR>> for execution of the expanded instruction as shown above.
+Note that the `offset` is zero in the expansion.
 
 Exceptions::
 See <<JALR>>

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -18,6 +18,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Tag violation         | Authority capability tag set to 0
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>>
+| Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | At least one byte accessed is outside the authority capability bounds
 |==============================================================================
 +

--- a/src/insns/require_cre.adoc
+++ b/src/insns/require_cre.adoc
@@ -1,1 +1,1 @@
-This instruction is illegal if CRE for the current mode is zero (see <<section_cheri_disable>>).
+This instruction is illegal if CRE for the current privilege mode is zero (see <<section_cheri_disable>>).

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -18,6 +18,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Tag violation         | Authority capability tag set to 0
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<w_perm>>
+| Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | At least one byte accessed is outside the authority capability bounds
 |==============================================================================
 +

--- a/src/insns/wavedrom/c-cr-format-ls.adoc
+++ b/src/insns/wavedrom/c-cr-format-ls.adoc
@@ -4,7 +4,7 @@
 ....
 {reg: [
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
-  {bits: 5, name: 'cs2/rs2', type: 4, attr: ['5','0']},
+  {bits: 5, name: 'funct5',  type: 4, attr: ['5','C.JR=00000']},
   {bits: 5, name: 'cs1/rs1', type: 4, attr: ['5','src!=0']},
   {bits: 4, name: 'funct4',  type: 8, attr: ['4','C.JR=1000']},
 ], config: {bits: 16}}

--- a/src/insns/wavedrom/c-jalr-format-ls.adoc
+++ b/src/insns/wavedrom/c-jalr-format-ls.adoc
@@ -4,7 +4,7 @@
 ....
 {reg: [
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
-  {bits: 5, name: 'cs2/rs2', type: 4, attr: ['5','0']},
+  {bits: 5, name: 'funct5',  type: 4, attr: ['5','C.JALR=00000']},
   {bits: 5, name: 'cs1/rs1', type: 4, attr: ['5','src!=0']},
   {bits: 4, name: 'funct4',  type: 8, attr: ['4', 'C.JALR=1001']},
 ], config: {bits: 16}}

--- a/src/insns/zcmp_cmpopret.adoc
+++ b/src/insns/zcmp_cmpopret.adoc
@@ -52,6 +52,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         |  ✔
 | Seal violation        |  ✔
 | Permission violation  |  ✔
+| Invalid address violation  |  ✔
 | Length violation      |  ✔
 |==============================================================================
 

--- a/src/insns/zcmp_cmpopretz.adoc
+++ b/src/insns/zcmp_cmpopretz.adoc
@@ -52,6 +52,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         |  ✔
 | Seal violation        |  ✔
 | Permission violation  |  ✔
+| Invalid address violation  |  ✔
 | Length violation      |  ✔
 |==============================================================================
 

--- a/src/insns/zcmt_cmjalt.adoc
+++ b/src/insns/zcmt_cmjalt.adoc
@@ -47,6 +47,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         |  ✔
 | Seal violation        |  ✔
 | Permission violation  |  ✔
+| Invalid address violation  |  ✔
 | Length violation      |  ✔
 |==============================================================================
 

--- a/src/insns/zcmt_cmjt.adoc
+++ b/src/insns/zcmt_cmjt.adoc
@@ -47,6 +47,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Tag violation         |  ✔
 | Seal violation        |  ✔
 | Permission violation  |  ✔
+| Invalid address violation  |  ✔
 | Length violation      |  ✔
 |==============================================================================
 


### PR DESCRIPTION
This PR is fixing various omissions that we've noticed in the existing v0.8.2 release
I'll keep it open for a little while until more errors have been fixed