### PR TITLE
C.JAL and C.J are not register-based

### DIFF
--- a/src/insns/j_16bit.adoc
+++ b/src/insns/j_16bit.adoc
@@ -4,7 +4,7 @@
 ==== C.J
 
 Synopsis::
-Register based jumps without link, 16-bit encodings
+Jump without link, 16-bit encodings
 
 Mnemonic::
 `c.j offset`

--- a/src/insns/jal_16bit.adoc
+++ b/src/insns/jal_16bit.adoc
@@ -4,7 +4,7 @@
 ==== C.JAL
 
 Synopsis::
-Register based jumps with link, 16-bit encodings
+Jump with link, 16-bit encodings
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Mnemonic (RV32)::
 `c.jal c1, offset`

--- a/src/insns/jalr_16bit.adoc
+++ b/src/insns/jalr_16bit.adoc
@@ -4,7 +4,7 @@
 ==== C.JALR
 
 Synopsis::
-Register based jumps with link, 16-bit encodings
+Jump register with link, 16-bit encodings
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Mnemonic::
 `c.jalr c1, cs1`

--- a/src/insns/jr_16bit.adoc
+++ b/src/insns/jr_16bit.adoc
@@ -4,7 +4,7 @@
 ==== C.JR
 
 Synopsis::
-Register based jumps without link, 16-bit encodings
+Jump register without link, 16-bit encodings
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Mnemonic::
 `c.jr cs1`


### PR DESCRIPTION
`C.JAL` and `C.J` add an offset to pcc, there is no base register.
Also tidied (IMO) the synopses for all the compressed jump insts.