### PR TITLE
Clarify the behaviour of CBLD with cs1=c0

### DIFF
--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -35,10 +35,9 @@ Otherwise, copy `cs2` to `cd` and clear `cd` 's tag.
 <<CBLD>> is typically used alongside <<SCHI>> to build
 capabilities from integer values.
 
-NOTE: When `cs1` is `c0` this will set the tag to 0 and leave the metadata
-otherwise unchanged. However this may change in future extensions,
-and so software should not assume `cs1==0` to be a pseudo instruction
-for tag clearing.
+NOTE: When `cs1` is `c0` this will copy `cs2` to `cd` and clear `cd.tag`.
+However this may change in future extensions, and so software should not
+assume `cs1==0` to be a pseudo instruction for tag clearing.
 
 Exceptions::
 include::require_cre.adoc[]


### PR DESCRIPTION
The old wording was slightly confusing and ambiguous - why does it mention leaving the other metadata unchanged, when this instruction only ever changes the tag?

This is hopefully a bit clearer.