### PR TITLE
Clarify read behaviour of misc CSR ops

### DIFF
--- a/src/insns/csrr_32bit.adoc
+++ b/src/insns/csrr_32bit.adoc
@@ -51,6 +51,9 @@ Description::
 These are standard RISC-V CSR instructions with extended functionality for
 accessing capability CSRs, such as <<mtvec>>/<<mtvecc>>.
 +
+For capability CSRs, the full capability is read into `cd` in pass:attributes,quotes[{cheri_cap_mode_name}].
+In pass:attributes,quotes[{cheri_int_mode_name}], the address field is instead read into `rd`.
++
 Unlike <<CSRRW>>, these instructions only update the address field and the tag
 as defined in xref:extended_CSR_writing[xrefstyle=short] when writing
 capability CSRs regardless of the execution mode. The final address to

--- a/src/insns/wavedrom/csr-instr.adoc
+++ b/src/insns/wavedrom/csr-instr.adoc
@@ -5,7 +5,7 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode',   attr: ['7', 'SYSTEM=1110011'], type: 8},
-  {bits: 5,  name: 'rd',       attr: ['5', 'dest'], type: 2},
+  {bits: 5,  name: 'rd/cd',    attr: ['5', 'dest'], type: 2},
   {bits: 3,  name: 'funct3',   attr: ['3', 'CSRRS=010', 'CSRRC=011', 'CSRRWI=101', 'CSRRSI=110', 'CSRRCI=111'], type: 8},
   {bits: 5,  name: 'rs1/uimm', attr: ['5', 'source', 'source', 'uimm[4:0]', 'uimm[4:0]', 'uimm[4:0]'], type: 4},
   {bits: 12, name: 'csr',      attr: ['12', 'source/dest CSR'], type: 4},

--- a/src/insns/wavedrom/csrr.adoc
+++ b/src/insns/wavedrom/csrr.adoc
@@ -3,7 +3,7 @@
 ....
 {reg: [
   {bits: 7,  name: 'opcode', attr: ['7', 'SYSTEM=1110011 '], type: 8},
-  {bits: 5,  name: 'rd',     attr: ['5', 'dest',], type: 2},
+  {bits: 5,  name: 'rd/cd',  attr: ['5', 'dest',], type: 2},
   {bits: 3,  name: 'funct3', attr: ['3', 'CSRRW', 'CSRRS', 'CSRRC', 'CSRRWI', 'CSRRSI', 'CSRRCI'], type: 8},
   {bits: 5,  name: 'rs1',    attr: ['5', 'source', 'source', 'source', 'uimm[4:0]', 'uimm[4:0]', 'uimm[4:0]'], type: 4},
   {bits: 12, name: 'csr',    attr: ['12', 'source/dest'], type: 4},


### PR DESCRIPTION
I think this was the intended behaviour but wanted to make it more explicit.