### PR TITLE
Clarify behaviour of scss with malformed bounds

### DIFF
--- a/src/insns/scss_32bit.adoc
+++ b/src/insns/scss_32bit.adoc
@@ -22,8 +22,11 @@ Encoding::
 include::wavedrom/scss.adoc[]
 
 Description::
-`rd` is set to 1 if the tag of capabilities `cs1`  and `cs2`  are equal and the
-bounds and permissions of `cs2`  are a subset of those of `cs1`.
+`rd` is set to 1 if the tag of capabilities `cs1` and `cs2` are equal and the
+bounds and permissions of `cs2` are a subset of those of `cs1`.
+
+Capabilities with <<section_cap_malformed,malformed bounds>> are considered to
+have a base and top of 0.
 
 NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.


### PR DESCRIPTION
This clarifies that malformed capabilities have bounds of [0,0) for the purposes of SCSS. I think their bounds don't affect any other instructions except GCBASE and GCLEN which already specify 0. CBLD is unaffect because it checks for malformed capabilities explicitly.

This behaviour can almost be inferred from GCBASE and GCLEN, but I think it's better to be explicit rather than to depend on the assumption that SCSS behaves the same as those instructions.

Fixes #281 