### PR TITLE
clarify 16-bit instruction mapping

### DIFF
--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -115,6 +115,90 @@ include::insns/store_32bit_fp.adoc[]
 <<<
 === "C" Standard Extension for Compressed Instructions
 
+One group of 16-bit encodings are remapped to different instructions dependant
+upon the CHERI execution mode, MXLEN and which extensions are supported.
+
+NOTE: Zcf and Zilsd are incompatible
+NOTE: Zcd and <<Zcmp>>/<<Zcmt>> incompatible
+
+
+==== RV32
+
+.16-bit instruction remapping in pass:attributes,quotes[{cheri_int_mode_name}]
+[#16bit_insn_remapping_rv32_a]
+[width="100%",options=header]
+|==============================================================================
+2+|Encoding    5+| Supported Extensions
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
+|111    |00      | N/A    | C.FSW   | N/A | N/A        | C.SD
+|011    |00      | N/A    | C.FLW   | N/A | N/A        | C.LD
+|111    |10      | N/A    | C.FSWSP | N/A | N/A        | C.SDSP
+|011    |10      | N/A    | C.FLWSP | N/A | N/A        | C.LDSP
+
+|101    |00      | N/A    | N/A     | C.FSD    | reserved^1^       | N/A
+|001    |00      | N/A    | N/A     | C.FLD    | reserved^1^       | N/A
+|101    |10      | N/A    | N/A     | C.FSDSP  | <<Zcmp>>/<<Zcmt>> | N/A
+|001    |10      | N/A    | N/A     | C.FLDSP  | reserved^1^       | N/A
+|==============================================================================
+
+^1^ reserved for future standard Zcm extensions
+
+.16-bit instruction remapping in pass:attributes,quotes[{cheri_cap_mode_name}]
+[#16bit_insn_remapping_rv32_b]
+[width="100%",options=header]
+|==============================================================================
+2+|Encoding    5+| Supported Extensions
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
+|111    |00    5+| C.SC
+|011    |00    5+| C.LC
+|111    |10    5+| C.SCSP
+|011    |10    5+| C.LCSP
+
+|101    |00      | N/A    | N/A     | C.FSD    | reserved^1^       | N/A
+|001    |00      | N/A    | N/A     | C.FLD    | reserved^1^       | N/A
+|101    |10      | N/A    | N/A     | C.FSDSP  | <<Zcmp>>/<<Zcmt>> | N/A
+|001    |10      | N/A    | N/A     | C.FLDSP  | reserved^1^       | N/A
+|==============================================================================
+
+^1^ reserved for future standard Zcm extensions
+
+<<<
+==== RV64
+
+.16-bit instruction remapping in pass:attributes,quotes[{cheri_int_mode_name}]
+[#16bit_insn_remapping_rv64_a]
+[width="100%",options=header]
+|==============================================================================
+2+|Encoding    5+| Supported Extensions
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
+|111    |00      | C.SD   | N/A     | N/A | N/A        | N/A
+|011    |00      | C.LD   | N/A     | N/A | N/A        | N/A
+|111    |10      | C.SDSP | N/A     | N/A | N/A        | N/A
+|011    |10      | C.LDSP | N/A     | N/A | N/A        | N/A
+
+|101    |00      | N/A    | N/A     | C.FSD   | N/A         | N/A
+|001    |00      | N/A    | N/A     | C.FLD   | N/A         | N/A
+|101    |10      | N/A    | N/A     | C.FSDSP | N/A         | N/A
+|001    |10      | N/A    | N/A     | C.FLDSP | N/A         | N/A
+|==============================================================================
+
+.16-bit instruction remapping in pass:attributes,quotes[{cheri_cap_mode_name}]
+[#16bit_insn_remapping_rv64_b]
+[width="100%",options=header]
+|==============================================================================
+2+|Encoding    5+| Supported Extensions
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
+|111    |00      | C.SD   | N/A     | N/A | N/A        | N/A
+|011    |00      | C.LD   | N/A     | N/A | N/A        | N/A
+|111    |10      | C.SDSP | N/A     | N/A | N/A        | N/A
+|011    |10      | C.LDSP | N/A     | N/A | N/A        | N/A
+
+|101    |00    5+| C.SC
+|001    |00    5+| C.LC
+|101    |10    5+| C.SCSP
+|001    |10    5+| C.LCSP
+|==============================================================================
+
 include::insns/condbr_16bit.adoc[]
 
 include::insns/cmv_16bit.adoc[]
@@ -184,6 +268,7 @@ include::insns/sh4add_32bit.adoc[]
 include::insns/sh4adduw_32bit.adoc[]
 
 <<<
+[#Zcb,reftext="Zcb"]
 === "Zcb" Standard Extension For Code-Size Reduction
 
 include::insns/load_16bit_Zcb.adoc[]


### PR DESCRIPTION
clarify the mapping of 16-bit encodings like C.FLW and C.FLD in int mode and cap mode for RV32 and RV64
it's confusing, so these tables help me understand what's going on