### PR TITLE
clarify malformed cap handling

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -45,7 +45,7 @@ include::img/cap-encoding-xlen64.edn[]
 
 Reserved bits are available for future extensions to {cheri_base_ext_name}.
 
-NOTE: Reserved bits must be 0 in valid capabilities.
+NOTE: Reserved bits must be 0 in tagged capabilities.
 
 === Components of a Capability
 
@@ -521,8 +521,9 @@ malformed    =  !EF && (malformedMSB || malformedLSB)
 NOTE: The check is for malformed _bounds_, so it does not include reserved
 bits!
 
-Capabilities with malformed bounds are always invalid anywhere in the system
-i.e. their tags are always 0.
+It is impossible for a CHERI core to generate a tagged capability with malformed
+bounds, or with any reserved bits set. If such a capability exists then it must
+have been caused by a logic or memory fault.
 
 [#section_special_caps]
 === Special Capabilities

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -525,9 +525,12 @@ It is impossible for a CHERI core to generate a tagged capability with malformed
 bounds, or with any reserved bits set. If such a capability exists then it must
 have been caused by a logic or memory fault.
 
-Capabilities with malformed bounds return both base and top bounds as zero. This
-causes all capability manipulation instructions such as <<CADDI>> to clear the tag
-on the result.
+Capabilities with malformed bounds:
+
+. Return both base and top bounds as zero, which affects instructions like <<GCBASE>>.
+. Cause certain manipulation instructions like <<CADDI>> to always clear the tag of the result.
+
+See specific instruction pages for full details of the effect of malformed capabilities.
 
 [#section_special_caps]
 === Special Capabilities

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -525,6 +525,10 @@ It is impossible for a CHERI core to generate a tagged capability with malformed
 bounds, or with any reserved bits set. If such a capability exists then it must
 have been caused by a logic or memory fault.
 
+Capabilities with malformed bounds return both base and top bounds as zero. This
+causes all capability manipulation instructions such as <<CADDI>> to clear the tag
+on the result.
+
 [#section_special_caps]
 === Special Capabilities
 

--- a/src/insns/amoswap_32bit_cap.adoc
+++ b/src/insns/amoswap_32bit_cap.adoc
@@ -27,6 +27,8 @@ Atomic swap of capability type, authorised by the capability in <<ddc>>.
 
 :cap_atomic:
 
+include::malformed_no_check.adoc[]
+
 include::atomic_exceptions.adoc[]
 
 Exceptions::

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -28,7 +28,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds
+| Length violation      | At least one byte accessed is outside the authority capability bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
 |==============================================================================
 
 :!cap_atomic:

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -28,7 +28,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability is <<section_cap_malformed,malformed>>
+| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 |==============================================================================
 
 :!cap_atomic:

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -21,10 +21,12 @@ When these instructions cause CHERI exceptions, _CHERI data fault_
 is reported in the TYPE field and the following codes may be
 reported in the CAUSE field of <<mtval>> or <<stval>>:
 
-[width="50%",options=header,cols="2,^1",align=center]
+<<<
+
+[%autowidth,options=header,align=center]
 |==============================================================================
 | CAUSE                 | Reason
-| Tag violation         | Authority capability tag set to 0
+| Tag violation         | Authority capability tag set to 0, or has any reserved bits set
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -28,7 +28,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
+| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability is <<section_cap_malformed,malformed>>
 |==============================================================================
 
 :!cap_atomic:

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -26,7 +26,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | CAUSE                 | Reason
 | Tag violation         | Authority capability tag set to 0
 | Seal violation        | Authority capability is sealed
-| Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>
+| Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | At least one byte accessed is outside the authority capability bounds
 |==============================================================================

--- a/src/insns/cadd_32bit.adoc
+++ b/src/insns/cadd_32bit.adoc
@@ -34,7 +34,7 @@ Encoding::
 include::wavedrom/cadd.adoc[]
 
 NOTE: <<CADD>> with `rs2=x0` is decoded as <<CMV>> instead, the key
-difference being that tagged and sealed capabilities do not have their tag
+difference being that tagged capabilities cannot their tag
 cleared by <<CMV>>.
 
 Description::

--- a/src/insns/cadd_32bit.adoc
+++ b/src/insns/cadd_32bit.adoc
@@ -48,6 +48,8 @@ For <<CADD>>, the address is incremented by the value in
 For <<CADDI>>, the address is incremented by the immediate value
 `imm`.
 
+include::malformed_clear_tag.adoc[]
+
 Exceptions::
 include::require_cre.adoc[]
 

--- a/src/insns/cadd_32bit.adoc
+++ b/src/insns/cadd_32bit.adoc
@@ -34,7 +34,7 @@ Encoding::
 include::wavedrom/cadd.adoc[]
 
 NOTE: <<CADD>> with `rs2=x0` is decoded as <<CMV>> instead, the key
-difference being that tagged capabilities cannot their tag
+difference being that tagged capabilities cannot have their tag
 cleared by <<CMV>>.
 
 Description::

--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -24,10 +24,10 @@ Description::
 Copy `cs2` to `cd` and set `cd.tag` to 1 if
 
 . `cs1.tag` is set, and
-. `cs1` 's bounds are not <<section_cap_malformed,malformed>>, and
+. `cs1` 's bounds are not <<section_cap_malformed,malformed>>, and all reserved fields are zero, and
 . `cs1` is not sealed, and
 . `cs2` 's permissions and bounds are equal to or a subset of `cs1` 's, and
-. `cs2` 's bounds are not <<section_cap_malformed,malformed>>, and
+. `cs2` 's bounds are not <<section_cap_malformed,malformed>>, and all reserved fields are zero, and
 . `cs2` 's permissions could have been legally produced by <<ACPERM>>, and
 . All reserved bits in `cs2` 's metadata are 0;
 

--- a/src/insns/cbld_32bit.adoc
+++ b/src/insns/cbld_32bit.adoc
@@ -24,9 +24,10 @@ Description::
 Copy `cs2` to `cd` and set `cd.tag` to 1 if
 
 . `cs1.tag` is set, and
+. `cs1` 's bounds are not <<section_cap_malformed,malformed>>, and
 . `cs1` is not sealed, and
 . `cs2` 's permissions and bounds are equal to or a subset of `cs1` 's, and
-. `cs2` 's bounds are not malformed (see xref:section_cap_malformed[xrefstyle=short]), and
+. `cs2` 's bounds are not <<section_cap_malformed,malformed>>, and
 . `cs2` 's permissions could have been legally produced by <<ACPERM>>, and
 . All reserved bits in `cs2` 's metadata are 0;
 

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -25,11 +25,11 @@ endif::[]
 | Seal violation        | It is sealed
 
 ifdef::cbo_clean_flush[]
-| Permission violation  | It does not grant <<w_perm>> and <<r_perm>>
+| Permission violation  | It does not grant <<w_perm>> and <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::cbo_clean_flush[]
 
 ifdef::cbo_inval[]
-| Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>
+| Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | None of the bytes accessed are within the bounds

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -32,7 +32,8 @@ ifdef::cbo_inval[]
 | Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | None of the bytes accessed are within the bounds
+| Length violation      | None of the bytes accessed are within the bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
+
 |==============================================================================
 
 

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -21,15 +21,15 @@ endif::[]
 [%autowidth,options=header,align=center]
 |==============================================================================
 | CAUSE                 | Reason
-| Tag violation         | The tag set to 0
-| Seal violation        | It is sealed
+| Tag violation         | Authority capability tag set to 0, or has any reserved bits set
+| Seal violation        | Authority capability is sealed
 
 ifdef::cbo_clean_flush[]
-| Permission violation  | It does not grant <<w_perm>> and <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
+| Permission violation  | Authority capability does not grant <<w_perm>> and <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::cbo_clean_flush[]
 
 ifdef::cbo_inval[]
-| Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
+| Permission violation  | Authority capability does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | None of the bytes accessed are within the bounds, or the capability has <<section_cap_malformed,malformed>> bounds

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -32,7 +32,7 @@ ifdef::cbo_inval[]
 | Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | None of the bytes accessed are within the bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
+| Length violation      | None of the bytes accessed are within the bounds, or the capability is <<section_cap_malformed,malformed>>
 
 |==============================================================================
 

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -32,7 +32,7 @@ ifdef::cbo_inval[]
 | Permission violation  | It does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | None of the bytes accessed are within the bounds, or the capability is <<section_cap_malformed,malformed>>
+| Length violation      | None of the bytes accessed are within the bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 
 |==============================================================================
 

--- a/src/insns/cmv_16bit.adoc
+++ b/src/insns/cmv_16bit.adoc
@@ -33,6 +33,8 @@ Capability register `cd` is replaced with the contents of `cs2`.
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 Standard RISC-V <<C_MV>> instruction.
 
+include::malformed_no_check.adoc[]
+
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 {c_cheri_base_ext_names}
 

--- a/src/insns/cmv_32bit.adoc
+++ b/src/insns/cmv_32bit.adoc
@@ -29,6 +29,8 @@ Description::
 The contents of capability register `cs1`  are written to capability register
 `cd`. <<CMV>> unconditionally moves the whole capability to `cd` .
 
+include::malformed_no_check.adoc[]
+
 Exceptions::
 include::require_cre.adoc[]
 

--- a/src/insns/csrrw_32bit.adoc
+++ b/src/insns/csrrw_32bit.adoc
@@ -40,6 +40,8 @@ The assembler pseudo-instruction to write a capability CSR in pass:attributes,qu
 +
 Access to XLEN-wide CSRs from other extensions is as specified by RISC-V.
 
+NOTE: When writing `cs1`, if the bounds are <<section_cap_malformed,malformed>>, any reserved bits are set
+or the permission could not have been produced by <<ACPERM>> then clear the tag before writing to the CSR.
 
 Permissions::
 Accessing privileged CSRs require <<asr_perm>>, including existing RISC-V CSRs,

--- a/src/insns/gcbase_32bit.adoc
+++ b/src/insns/gcbase_32bit.adoc
@@ -21,8 +21,8 @@ include::wavedrom/gcbase.adoc[]
 Description::
 Decode the base integer address from `cs1` 's bounds and write the result to
 `rd`. It is not required that the input capability `cs1`  has its tag set to 1.
-<<GCBASE>> outputs 0 if `cs1` 's bounds are malformed (see
-xref:section_cap_malformed[xrefstyle=short]).
+
+include::malformed_return_0.adoc[]
 
 Exceptions::
 include::require_cre.adoc[]
@@ -30,7 +30,7 @@ include::require_cre.adoc[]
 Prerequisites::
 {cheri_base_ext_name}
 
-Operation:: TODO #need to check that it returns 0 if malformed#
+Operation::
 +
 --
 TODO

--- a/src/insns/gclen_32bit.adoc
+++ b/src/insns/gclen_32bit.adoc
@@ -26,6 +26,8 @@ tag set to 1. <<GCLEN>> outputs 0 if `cs1` 's bounds are malformed (see
 xref:section_cap_malformed[xrefstyle=short]), and 2^MXLEN^-1 if the length of
 `cs1` is 2^MXLEN^.
 
+include::malformed_return_0.adoc[]
+
 Exceptions::
 include::require_cre.adoc[]
 

--- a/src/insns/jalr_32bit.adoc
+++ b/src/insns/jalr_32bit.adoc
@@ -49,7 +49,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 [%autowidth,options=header,align=center]
 |==============================================================================
 | CAUSE                 | pass:attributes,quotes[{cheri_int_mode_name}] | pass:attributes,quotes[{cheri_cap_mode_name}] | Reason
-| Tag violation         |      | ✔     | `cs1` has tag set to 0
+| Tag violation         |      | ✔     | `cs1` has tag set to 0, or has any reserved bits set
 | Seal violation        |      | ✔     | `cs1` is sealed and the immediate is not 0
 | Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]

--- a/src/insns/jalr_32bit.adoc
+++ b/src/insns/jalr_32bit.adoc
@@ -53,7 +53,8 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        |      | ✔     | `cs1` is sealed and the immediate is not 0
 | Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds.
+| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds, which will fail
+if `cs1` has <<section_cap_malformed,malformed>> bounds in pass:attributes,quotes[{cheri_cap_mode_name}].
 |==============================================================================
 
 include::pcrel_debug_warning.adoc[]

--- a/src/insns/jalr_32bit.adoc
+++ b/src/insns/jalr_32bit.adoc
@@ -51,7 +51,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | CAUSE                 | pass:attributes,quotes[{cheri_int_mode_name}] | pass:attributes,quotes[{cheri_cap_mode_name}] | Reason
 | Tag violation         |      | ✔     | `cs1` has tag set to 0
 | Seal violation        |      | ✔     | `cs1` is sealed and the immediate is not 0
-| Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>
+| Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds.
 |==============================================================================

--- a/src/insns/load_32bit_cap.adoc
+++ b/src/insns/load_32bit_cap.adoc
@@ -31,6 +31,8 @@ access is obtained by adding `rs1` to the sign-extended 12-bit offset.
 The tag value written to `cd` is 0 if the tag of the memory location loaded is
 0 or <<ddc>> does not grant <<c_perm>>.
 
+include::malformed_no_check.adoc[]
+
 :has_cap_data:
 include::load_exceptions.adoc[]
 +

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -19,7 +19,8 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds
+| Length violation      | At least one byte accessed is outside the authority capability bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
+
 |==============================================================================
 +
 :!load_res:

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability is <<section_cap_malformed,malformed>>
+| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 
 |==============================================================================
 +

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -15,7 +15,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 [%autowidth,options=header,align=center]
 |==============================================================================
 | CAUSE                 | Reason
-| Tag violation         | Authority capability tag set to 0
+| Tag violation         | Authority capability tag set to 0, or has any reserved bits set
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -17,7 +17,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | CAUSE                 | Reason
 | Tag violation         | Authority capability tag set to 0
 | Seal violation        | Authority capability is sealed
-| Permission violation  | Authority capability does not grant <<r_perm>>
+| Permission violation  | Authority capability does not grant <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | At least one byte accessed is outside the authority capability bounds
 |==============================================================================

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
+| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability is <<section_cap_malformed,malformed>>
 
 |==============================================================================
 +

--- a/src/insns/load_res_cap_32bit.adoc
+++ b/src/insns/load_res_cap_32bit.adoc
@@ -29,6 +29,8 @@ Load reserved instructions, authorised by the capability in <<ddc>>.
 
 :cap_load:
 
+include::malformed_no_check.adoc[]
+
 include::load_exceptions.adoc[]
 +
 include::require_cre.adoc[]

--- a/src/insns/malformed_clear_tag.adoc
+++ b/src/insns/malformed_clear_tag.adoc
@@ -1,2 +1,1 @@
-NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>, as malformed bounds
-cause both the base and top bounds to be zero which is not legal in a tagged capability.
+NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>.

--- a/src/insns/malformed_clear_tag.adoc
+++ b/src/insns/malformed_clear_tag.adoc
@@ -1,1 +1,2 @@
-NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>.
+NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>, as malformed bounds
+cause both the base and top bounds to be zero which is not legal in a tagged capability.

--- a/src/insns/malformed_clear_tag.adoc
+++ b/src/insns/malformed_clear_tag.adoc
@@ -1,0 +1,1 @@
+NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>.

--- a/src/insns/malformed_clear_tag.adoc
+++ b/src/insns/malformed_clear_tag.adoc
@@ -1,1 +1,2 @@
-NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>.
+NOTE: This instruction sets `cd.tag=0` if `cs1` 's bounds are <<section_cap_malformed,malformed>>,
+or if any of the reserved fields are set.

--- a/src/insns/malformed_no_check.adoc
+++ b/src/insns/malformed_no_check.adoc
@@ -1,3 +1,3 @@
 NOTE: This instruction does not perform a <<section_cap_malformed,malformed>>
-bounds check, and so can propagate a <<section_cap_malformed,malformed>> 
+bounds check, and so can propagate a <<section_cap_malformed,malformed>>
 tagged capability.

--- a/src/insns/malformed_no_check.adoc
+++ b/src/insns/malformed_no_check.adoc
@@ -1,3 +1,2 @@
 NOTE: This instruction can propagate tagged capabilities which are <<section_cap_malformed,malformed>>,
 have reserved bits set or have a permission field which cannot be produced by <<ACPERM>>.
-

--- a/src/insns/malformed_no_check.adoc
+++ b/src/insns/malformed_no_check.adoc
@@ -1,0 +1,3 @@
+NOTE: This instruction does not perform a <<section_cap_malformed,malformed>>
+bounds check, and so can propagate a <<section_cap_malformed,malformed>> 
+tagged capability.

--- a/src/insns/malformed_no_check.adoc
+++ b/src/insns/malformed_no_check.adoc
@@ -1,3 +1,3 @@
-NOTE: This instruction does not perform a <<section_cap_malformed,malformed>>
-bounds check, and so can propagate a <<section_cap_malformed,malformed>>
-tagged capability.
+NOTE: This instruction can propagate tagged capabilities which are <<section_cap_malformed,malformed>>,
+have reserved bits set or have a permission field which cannot be produced by <<ACPERM>>.
+

--- a/src/insns/malformed_no_check.adoc
+++ b/src/insns/malformed_no_check.adoc
@@ -1,2 +1,2 @@
-NOTE: This instruction can propagate tagged capabilities which are <<section_cap_malformed,malformed>>,
+NOTE: This instruction can propagate tagged capabilities which have <<section_cap_malformed,malformed>> bounds,
 have reserved bits set or have a permission field which cannot be produced by <<ACPERM>>.

--- a/src/insns/malformed_return_0.adoc
+++ b/src/insns/malformed_return_0.adoc
@@ -1,1 +1,1 @@
-NOTE: This instruction returns 0 if `cs1` 's bounds are <<section_cap_malformed,malformed>>.
+NOTE: If `cs1` 's bounds are <<section_cap_malformed,malformed>> then the bounds decode as zero, which causes this instruction to return zero.

--- a/src/insns/malformed_return_0.adoc
+++ b/src/insns/malformed_return_0.adoc
@@ -1,0 +1,1 @@
+NOTE: This instruction returns 0 if `cs1` 's bounds are <<section_cap_malformed,malformed>>.

--- a/src/insns/scaddr_32bit.adoc
+++ b/src/insns/scaddr_32bit.adoc
@@ -24,6 +24,8 @@ capability to `cd`. The tag bit of the output capability is 0 if `cs1` did not
 have its tag set to 1, `rs2` is outside the <<section_cap_representable_check>> of `cs1`
 or if `cs1` is sealed.
 
+include::malformed_clear_tag.adoc[]
+
 Exceptions::
 include::require_cre.adoc[]
 

--- a/src/insns/scbnds_32bit.adoc
+++ b/src/insns/scbnds_32bit.adoc
@@ -42,6 +42,8 @@ tag is 0  or `cs1` is sealed.
 +
 `immediate = ZeroExtend(s ? uimm<<4 : uimm)`
 
+include::malformed_return_0.adoc[]
+
 Exceptions::
 include::require_cre.adoc[]
 

--- a/src/insns/scbnds_32bit.adoc
+++ b/src/insns/scbnds_32bit.adoc
@@ -42,7 +42,7 @@ tag is 0  or `cs1` is sealed.
 +
 `immediate = ZeroExtend(s ? uimm<<4 : uimm)`
 
-include::malformed_return_0.adoc[]
+include::malformed_clear_tag.adoc[]
 
 Exceptions::
 include::require_cre.adoc[]

--- a/src/insns/scbndsr_32bit.adoc
+++ b/src/insns/scbndsr_32bit.adoc
@@ -29,6 +29,8 @@ if its bounds exceed `cs1` 's bounds, `cs1` 's tag is 0 or `cs1`  is sealed.
 Exceptions::
 include::require_cre.adoc[]
 
+include::malformed_return_0.adoc[]
+
 Prerequisites::
 {cheri_base_ext_name}
 

--- a/src/insns/scbndsr_32bit.adoc
+++ b/src/insns/scbndsr_32bit.adoc
@@ -29,7 +29,7 @@ if its bounds exceed `cs1` 's bounds, `cs1` 's tag is 0 or `cs1`  is sealed.
 Exceptions::
 include::require_cre.adoc[]
 
-include::malformed_return_0.adoc[]
+include::malformed_clear_tag.adoc[]
 
 Prerequisites::
 {cheri_base_ext_name}

--- a/src/insns/scss_32bit.adoc
+++ b/src/insns/scss_32bit.adoc
@@ -26,7 +26,7 @@ Description::
 bounds and permissions of `cs2` are a subset of those of `cs1`.
 
 NOTE: If either `cs1` 's or `cs2` 's bounds are <<section_cap_malformed,malformed>>
-then the instruction returns zero.
+or if either have any bits set in reserved fields, then the instruction returns zero.
 
 NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.

--- a/src/insns/scss_32bit.adoc
+++ b/src/insns/scss_32bit.adoc
@@ -25,8 +25,8 @@ Description::
 `rd` is set to 1 if the tag of capabilities `cs1` and `cs2` are equal and the
 bounds and permissions of `cs2` are a subset of those of `cs1`.
 
-Capabilities with <<section_cap_malformed,malformed bounds>> are considered to
-have a base and top of 0.
+NOTE: If either `cs1` 's or `cs2` 's bounds are <<section_cap_malformed,malformed>>
+then the base and top bounds decode as zero, which causes this instruction to return zero.
 
 NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.

--- a/src/insns/scss_32bit.adoc
+++ b/src/insns/scss_32bit.adoc
@@ -26,7 +26,7 @@ Description::
 bounds and permissions of `cs2` are a subset of those of `cs1`.
 
 NOTE: If either `cs1` 's or `cs2` 's bounds are <<section_cap_malformed,malformed>>
-then instruction returns zero.
+then the instruction returns zero.
 
 NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.

--- a/src/insns/scss_32bit.adoc
+++ b/src/insns/scss_32bit.adoc
@@ -26,7 +26,7 @@ Description::
 bounds and permissions of `cs2` are a subset of those of `cs1`.
 
 NOTE: If either `cs1` 's or `cs2` 's bounds are <<section_cap_malformed,malformed>>
-then the base and top bounds decode as zero, which causes this instruction to return zero.
+then instruction returns zero.
 
 NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.

--- a/src/insns/store_32bit_cap.adoc
+++ b/src/insns/store_32bit_cap.adoc
@@ -33,6 +33,8 @@ access is obtained by adding `rs1` to the sign-extended 12-bit offset. The
 capability written to memory has the tag set to 0 if `cs2` 's tag is 0 or
 <<ddc>> does not grant <<c_perm>>.
 
+include::malformed_no_check.adoc[]
+
 :has_cap_data:
 include::store_exceptions.adoc[]
 +

--- a/src/insns/store_cond_cap_32bit.adoc
+++ b/src/insns/store_cond_cap_32bit.adoc
@@ -29,6 +29,8 @@ Store conditional instructions, authorised by the capability in <<ddc>>.
 
 :store_cond:
 
+include::malformed_no_check.adoc[]
+
 include::store_exceptions.adoc[]
 +
 include::require_cre.adoc[]

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
+| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability is <<section_cap_malformed,malformed>>
 |==============================================================================
 +
 :!store_cond:

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds
+| Length violation      | At least one byte accessed is outside the authority capability bounds, which includes the case where the capability is <<section_cap_malformed,malformed>> as the bounds decode as zero
 |==============================================================================
 +
 :!store_cond:

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -15,7 +15,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 [%autowidth,options=header,align=center]
 |==============================================================================
 | CAUSE                 | Reason
-| Tag violation         | Authority capability tag set to 0
+| Tag violation         | Authority capability tag set to 0, or has any reserved bits set
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability is <<section_cap_malformed,malformed>>
+| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 |==============================================================================
 +
 :!store_cond:

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -17,7 +17,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | CAUSE                 | Reason
 | Tag violation         | Authority capability tag set to 0
 | Seal violation        | Authority capability is sealed
-| Permission violation  | Authority capability does not grant <<w_perm>>
+| Permission violation  | Authority capability does not grant <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Length violation      | At least one byte accessed is outside the authority capability bounds
 |==============================================================================

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -152,9 +152,6 @@ the bounds exactly
 capability with the fields from another capability
 * <<CMV>>: move a capability from a *c* register to another *c* register
 
-NOTE: <<CBLD>> outputs a capability with tag set to 0 if the input
-capability's bounds are malformed.
-
 ifdef::cheri_v9_annotations[]
 NOTE: *CHERI v9 Note:* <<SCBNDS>> and <<SCBNDSI>> perform the role
 of the old CSETBOUNDSEXACT while the <<SCBNDSR>> is the old


### PR DESCRIPTION
More clarification on malformed capability handling, following the discussion in https://github.com/riscv/riscv-cheri/pull/279

cmv, lc, sc, amoswap.c propagate malformed caps
caddi, cadd, scaddr, scbnds* de-tag
gchi, gcperm ignore
gcbase, gclen return 0

also if the permission can't be created by ACPERM then clear _all_ permissions, which affect load/store/cbo/amo dereferencing and also the target capability for JALR
