### PR TITLE
acperm: clarify ASR rule for MXLEN=32

### DIFF
--- a/src/insns/acperm_32bit.adoc
+++ b/src/insns/acperm_32bit.adoc
@@ -56,7 +56,7 @@ NOTE: The combination of <<x_perm>> clear and <<m_bit>> set is reserved for futu
 
 The MXLEN=32 additional rules are:
 
-. Clear <<asr_perm>> if _all_ other permissions are not set
+. Clear <<asr_perm>> unless _all_ other permissions are set
 . Clear <<c_perm>> and <<x_perm>> if <<r_perm>> is not set
 . Clear <<x_perm>> if <<x_perm>> and <<r_perm>> _are_ set, but <<c_perm>> and <<w_perm>> _are not_ set.
 


### PR DESCRIPTION
Fix a contradiction between acperm rule 1 for MXLEN=32 and table 3.

Table 3 shows that for MXLEN=32, the ASR bit can be set only if all of R, W, C and X are set. Rephrase rule 1 to be in line with this.