### PR TITLE
Minor rephrasing for L8 bit description

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -563,7 +563,7 @@ expanded base is 0 and top is 2^MXLEN^.
 | AP       | zeros | Grants no permissions
 | S        | zero  | Unsealed
 | EF       | zero  | Internal exponent format
-| L~8~     | zero  | Top address bit (MXLEN=32 only)
+| L~8~     | zero  | Top address reconstruction bit (MXLEN=32 only)
 | T        | zeros | Top address bits
 | T~E~     | zeros | Exponent bits
 | B        | zeros | Base address bits
@@ -599,7 +599,7 @@ or 'root' capability.
                         | Grants all permissions
 | S             | zero  | Unsealed
 | EF            | zero  | Internal exponent format
-| L~8~          | zero  | Top address bit (MXLEN=32 only)
+| L~8~          | zero  | Top address reconstruction bit (MXLEN=32 only)
 | T             | zeros | Top address bits
 | T~E~          | zeros | Exponent bits
 | B             | zeros | Base address bits


### PR DESCRIPTION
L8 is not directly a top address bit, so this avoids confusion