### PR TITLE
clarify when prefetches don't prefetch

### DIFF
--- a/src/insns/malformed_shadd_clear_tag.adoc
+++ b/src/insns/malformed_shadd_clear_tag.adoc
@@ -1,0 +1,2 @@
+NOTE: This instruction sets `cd.tag=0` if `cs2` 's bounds are
+<<section_cap_malformed,malformed>>, or if any of the reserved fields are set.

--- a/src/insns/prefetch.i.adoc
+++ b/src/insns/prefetch.i.adoc
@@ -44,13 +44,16 @@ likely to be accessed by an instruction fetch in the near future. The encoding
 is only valid if imm[4:0]=0. The authorising capability for this operation is
 <<ddc>>.
 
-In either mode, instruction does not perform a memory access
+In either mode, PREFETCH.I does not perform a memory access
 if one or more of the following conditions of the authorising capability are met:
+
 * The tag is not set
 * The sealed bit is set
 * No bytes of the cache line requested is in bounds
 * The <<x_perm>> is not set
-* Any reserved bits are set, the permissions could not have been produced by <<ACPERM>> or the bounds are <<section_cap_malformed,malformed>>.
+* Any reserved bits are set
+* The permissions could not have been produced by <<ACPERM>>
+* The bounds are <<section_cap_malformed,malformed>>.
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.i.adoc
+++ b/src/insns/prefetch.i.adoc
@@ -44,16 +44,9 @@ likely to be accessed by an instruction fetch in the near future. The encoding
 is only valid if imm[4:0]=0. The authorising capability for this operation is
 <<ddc>>.
 
-In either mode, PREFETCH.I does not perform a memory access
-if one or more of the following conditions of the authorising capability are met:
-
-* The tag is not set
-* The sealed bit is set
-* No bytes of the cache line requested is in bounds
-* The <<x_perm>> is not set
-* Any reserved bits are set
-* The permissions could not have been produced by <<ACPERM>>
-* The bounds are <<section_cap_malformed,malformed>>
+:prefetch_insn: PREFETCH.I
+:prefetch_perm: <<x_perm>>
+include::prefetch_cap_checks.adoc[]
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.i.adoc
+++ b/src/insns/prefetch.i.adoc
@@ -34,12 +34,7 @@ likely to be accessed by an instruction fetch in the near future. The encoding
 is only valid if imm[4:0]=0. The authorising capability for this operation is
 `cs1`. This instruction does not throw any exceptions. However, following
 <<CHERI_SPEC>>, this instruction does not perform a prefetch if it is
-not authorized by `cs1`. This instruction does not perform a memory access
-if one or more of the following conditions of `cs1` are met:
-* The tag is not set
-* The sealed bit is set
-* No bytes of the cache line requested is in bounds
-* The <<x_perm>> is not set
+not authorized by `cs1`.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 A PREFETCH.I instruction indicates to hardware that the cache block whose
@@ -49,6 +44,13 @@ likely to be accessed by an instruction fetch in the near future. The encoding
 is only valid if imm[4:0]=0. The authorising capability for this operation is
 <<ddc>>.
 
+In either mode, instruction does not perform a memory access
+if one or more of the following conditions of the authorising capability are met:
+* The tag is not set
+* The sealed bit is set
+* No bytes of the cache line requested is in bounds
+* The <<x_perm>> is not set
+* Any reserved bits are set, the permissions could not have been produced by <<ACPERM>> or the bounds are <<section_cap_malformed,malformed>>.
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.i.adoc
+++ b/src/insns/prefetch.i.adoc
@@ -33,8 +33,8 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by an instruction fetch in the near future. The encoding
 is only valid if imm[4:0]=0. The authorising capability for this operation is
 `cs1`. This instruction does not throw any exceptions. However, following
-<<CHERI_SPEC>>, this instruction does not perform a prefetch if it is
-not authorized by `cs1`.
+xref:CHERI_SPEC[xrefstyle=short], this instruction does not perform a prefetch
+if it is not authorized by `cs1`.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 A PREFETCH.I instruction indicates to hardware that the cache block whose
@@ -53,7 +53,7 @@ if one or more of the following conditions of the authorising capability are met
 * The <<x_perm>> is not set
 * Any reserved bits are set
 * The permissions could not have been produced by <<ACPERM>>
-* The bounds are <<section_cap_malformed,malformed>>.
+* The bounds are <<section_cap_malformed,malformed>>
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.r.adoc
+++ b/src/insns/prefetch.r.adoc
@@ -44,13 +44,16 @@ likely to be accessed by a data read (i.e. load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is <<ddc>>.
 
-In either mode, instruction does not perform a memory access
+In either mode, PREFETCH.R does not perform a memory access
 if one or more of the following conditions of the authorising capability are met:
+
 * The tag is not set
 * The sealed bit is set
 * No bytes of the cache line requested is in bounds
 * The <<r_perm>> is not set
-* Any reserved bits are set, the permissions could not have been produced by <<ACPERM>> or the bounds are <<section_cap_malformed,malformed>>.
+* Any reserved bits are set
+* The permissions could not have been produced by <<ACPERM>>
+* The bounds are <<section_cap_malformed,malformed>>.
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.r.adoc
+++ b/src/insns/prefetch.r.adoc
@@ -44,16 +44,9 @@ likely to be accessed by a data read (i.e. load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is <<ddc>>.
 
-In either mode, PREFETCH.R does not perform a memory access
-if one or more of the following conditions of the authorising capability are met:
-
-* The tag is not set
-* The sealed bit is set
-* No bytes of the cache line requested is in bounds
-* The <<r_perm>> is not set
-* Any reserved bits are set
-* The permissions could not have been produced by <<ACPERM>>
-* The bounds are <<section_cap_malformed,malformed>>
+:prefetch_insn: PREFETCH.R
+:prefetch_perm: <<r_perm>>
+include::prefetch_cap_checks.adoc[]
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.r.adoc
+++ b/src/insns/prefetch.r.adoc
@@ -33,8 +33,8 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by a data read (i.e. load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is `cs1`. This instruction does not throw any exceptions. However,
-in following <<CHERI_SPEC>>, this instruction does not perform a prefetch
-if it is not authorized by `cs1`.
+in following xref:CHERI_SPEC[xrefstyle=short], this instruction does not
+perform a prefetch if it is not authorized by `cs1`.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 A PREFETCH.R instruction indicates to hardware that the cache block whose
@@ -53,7 +53,7 @@ if one or more of the following conditions of the authorising capability are met
 * The <<r_perm>> is not set
 * Any reserved bits are set
 * The permissions could not have been produced by <<ACPERM>>
-* The bounds are <<section_cap_malformed,malformed>>.
+* The bounds are <<section_cap_malformed,malformed>>
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.r.adoc
+++ b/src/insns/prefetch.r.adoc
@@ -34,12 +34,7 @@ likely to be accessed by a data read (i.e. load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is `cs1`. This instruction does not throw any exceptions. However,
 in following <<CHERI_SPEC>>, this instruction does not perform a prefetch
-if it is not authorized by `cs1`.  This instruction does not perform a memory
-access if one or more of the following conditions of `cs1` are met:
-* The tag is not set
-* The sealed bit is set
-* No bytes of the cache line requested is in bounds
-* The <<r_perm>> is not set
+if it is not authorized by `cs1`.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 A PREFETCH.R instruction indicates to hardware that the cache block whose
@@ -49,6 +44,13 @@ likely to be accessed by a data read (i.e. load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is <<ddc>>.
 
+In either mode, instruction does not perform a memory access
+if one or more of the following conditions of the authorising capability are met:
+* The tag is not set
+* The sealed bit is set
+* No bytes of the cache line requested is in bounds
+* The <<r_perm>> is not set
+* Any reserved bits are set, the permissions could not have been produced by <<ACPERM>> or the bounds are <<section_cap_malformed,malformed>>.
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.w.adoc
+++ b/src/insns/prefetch.w.adoc
@@ -33,8 +33,8 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by a data write (i.e. store) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is `cs1`. This instruction does not throw any exceptions. However,
-following <<CHERI_SPEC>>, this instruction does not perform a prefetch if it
-is not authorized by `cs1`.
+following xref:CHERI_SPEC[xrefstyle=short], this instruction does not perform a
+prefetch if it is not authorized by `cs1`.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 A PREFETCH.W instruction indicates to hardware that the cache block whose
@@ -53,7 +53,7 @@ if one or more of the following conditions of the authorising capability are met
 * The <<w_perm>> is not set
 * Any reserved bits are set
 * The permissions could not have been produced by <<ACPERM>>
-* The bounds are <<section_cap_malformed,malformed>>.
+* The bounds are <<section_cap_malformed,malformed>>
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.w.adoc
+++ b/src/insns/prefetch.w.adoc
@@ -34,12 +34,7 @@ likely to be accessed by a data write (i.e. store) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is `cs1`. This instruction does not throw any exceptions. However,
 following <<CHERI_SPEC>>, this instruction does not perform a prefetch if it
-is not authorized by `cs1`. This instruction does not perform a memory access
-if one or more of the following conditions of `cs1` are met:
-* The tag is not set
-* The sealed bit is set
-* No bytes of the cache line requested is in bounds
-* The <<w_perm>> is not set
+is not authorized by `cs1`.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 A PREFETCH.W instruction indicates to hardware that the cache block whose
@@ -48,6 +43,14 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by a data write (i.e. store) in the near future.  The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is <<ddc>>.
+
+In either mode, instruction does not perform a memory access
+if one or more of the following conditions of the authorising capability are met:
+* The tag is not set
+* The sealed bit is set
+* No bytes of the cache line requested is in bounds
+* The <<w_perm>> is not set
+* Any reserved bits are set, the permissions could not have been produced by <<ACPERM>> or the bounds are <<section_cap_malformed,malformed>>.
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.w.adoc
+++ b/src/insns/prefetch.w.adoc
@@ -44,13 +44,16 @@ likely to be accessed by a data write (i.e. store) in the near future.  The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is <<ddc>>.
 
-In either mode, instruction does not perform a memory access
+In either mode, PREFETCH.W does not perform a memory access
 if one or more of the following conditions of the authorising capability are met:
+
 * The tag is not set
 * The sealed bit is set
 * No bytes of the cache line requested is in bounds
 * The <<w_perm>> is not set
-* Any reserved bits are set, the permissions could not have been produced by <<ACPERM>> or the bounds are <<section_cap_malformed,malformed>>.
+* Any reserved bits are set
+* The permissions could not have been produced by <<ACPERM>>
+* The bounds are <<section_cap_malformed,malformed>>.
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch.w.adoc
+++ b/src/insns/prefetch.w.adoc
@@ -44,16 +44,9 @@ likely to be accessed by a data write (i.e. store) in the near future.  The
 encoding is only valid if imm[4:0]=0. The authorising capability for this
 operation is <<ddc>>.
 
-In either mode, PREFETCH.W does not perform a memory access
-if one or more of the following conditions of the authorising capability are met:
-
-* The tag is not set
-* The sealed bit is set
-* No bytes of the cache line requested is in bounds
-* The <<w_perm>> is not set
-* Any reserved bits are set
-* The permissions could not have been produced by <<ACPERM>>
-* The bounds are <<section_cap_malformed,malformed>>
+:prefetch_insn: PREFETCH.W
+:prefetch_perm: <<w_perm>>
+include::prefetch_cap_checks.adoc[]
 
 Prerequisites for pass:attributes,quotes[{cheri_cap_mode_name}]::
 Zicbop, {cheri_base_ext_name}

--- a/src/insns/prefetch_cap_checks.adoc
+++ b/src/insns/prefetch_cap_checks.adoc
@@ -1,0 +1,13 @@
+In either mode, {prefetch_insn} does not perform a memory access
+if one or more of the following conditions of the authorising capability are met:
+
+* The tag is not set
+* The sealed bit is set
+* No bytes of the cache line requested is in bounds
+* The {prefetch_perm} is not set
+* Any reserved bits are set
+* The permissions could not have been produced by <<ACPERM>>
+* The bounds are <<section_cap_malformed,malformed>>
+
+:prefetch_insn!:
+:prefetch_perm!:

--- a/src/insns/sh123add_32bit.adoc
+++ b/src/insns/sh123add_32bit.adoc
@@ -36,12 +36,16 @@ Encoding::
 ....
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Increment the address field of `cs2` by `rs1` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
-+
-Follow the rules from <<CADD>> for checking the validity of the source capability.
+Increment the address field of `cs2` by `rs1` shifted left by _n_ bit positions
+and write the result to `cd`. The tag bit of the output capability is 0 if
+`cs2` did not have its tag set to 1, the incremented address is outside `cs2`
+'s <<section_cap_representable_check>> or `cs2` is sealed.
+
+include::malformed_shadd_clear_tag.adoc[]
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Increment `rs2` by `rs1` shifted left by _n_ bit positions.
+Increment `rs2` by `rs1` shifted left by _n_ bit positions and write the result
+to `rd`.
 
 Exceptions::
 None

--- a/src/insns/sh123add_32bit.adoc
+++ b/src/insns/sh123add_32bit.adoc
@@ -37,6 +37,8 @@ Encoding::
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
 Increment the address field of `cs2` by `rs1` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
++
+Follow the rules from <<CADD>> for checking the validity of the source capability.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 Increment `rs2` by `rs1` shifted left by _n_ bit positions.

--- a/src/insns/sh123adduw_32bit.adoc
+++ b/src/insns/sh123adduw_32bit.adoc
@@ -36,12 +36,16 @@ Encoding::
 ....
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Increment the address field of `cs2` by the unsigned word in `rs1` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
-+
-Follow the rules from <<CADD>> for checking the validity of the source capability.
+Increment the address field of `cs2` by the unsigned word in `rs1` shifted left
+by _n_ bit positions and write the result to `cd`. The tag bit of the output
+capability is 0 if `cs2` did not have its tag set to 1, the incremented address
+is outside `cs2` 's <<section_cap_representable_check>> or `cs2` is sealed.
+
+include::malformed_shadd_clear_tag.adoc[]
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Increment `rs2` by the unsigned word in `rs1` shifted left by _n_ bit positions.
+Increment `rs2` by the unsigned word in `rs1` shifted left by _n_ bit positions
+and write the result to `rd`.
 
 Exceptions::
 None

--- a/src/insns/sh123adduw_32bit.adoc
+++ b/src/insns/sh123adduw_32bit.adoc
@@ -37,6 +37,8 @@ Encoding::
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
 Increment the address field of `cs2` by the unsigned word in `rs1` shifted left by _n_ bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
++
+Follow the rules from <<CADD>> for checking the validity of the source capability.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 Increment `rs2` by the unsigned word in `rs1` shifted left by _n_ bit positions.

--- a/src/insns/sh4add_32bit.adoc
+++ b/src/insns/sh4add_32bit.adoc
@@ -30,12 +30,16 @@ Encoding::
 ....
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Increment the address field of `cs2` by `rs1` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
-+
-Follow the rules from <<CADD>> for checking the validity of the source capability.
+Increment the address field of `cs2` by `rs1` shifted left by 4 bit positions
+and write the result to `cd`. The tag bit of the output capability is 0 if
+`cs2` did not have its tag set to 1, the incremented address is outside `cs2`
+'s <<section_cap_representable_check>> or `cs2` is sealed.
+
+include::malformed_shadd_clear_tag.adoc[]
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Increment `rs2` by `rs1` shifted left by 4 bit positions.
+Increment `rs2` by `rs1` shifted left by 4 bit positions and write the result
+to `rd`.
 
 Exceptions::
 None

--- a/src/insns/sh4add_32bit.adoc
+++ b/src/insns/sh4add_32bit.adoc
@@ -31,6 +31,8 @@ Encoding::
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
 Increment the address field of `cs2` by `rs1` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
++
+Follow the rules from <<CADD>> for checking the validity of the source capability.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 Increment `rs2` by `rs1` shifted left by 4 bit positions.

--- a/src/insns/sh4adduw_32bit.adoc
+++ b/src/insns/sh4adduw_32bit.adoc
@@ -27,6 +27,8 @@ Encoding::
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
 Increment the address field of `cs2` by the unsigned word in `rs1` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
++
+Follow the rules from <<CADD>> for checking the validity of the source capability.
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
 Increment `rs2` by the unsigned word in `rs1` shifted left by 4 bit positions.

--- a/src/insns/sh4adduw_32bit.adoc
+++ b/src/insns/sh4adduw_32bit.adoc
@@ -26,12 +26,16 @@ Encoding::
 ....
 
 pass:attributes,quotes[{cheri_cap_mode_name}] Description::
-Increment the address field of `cs2` by the unsigned word in `rs1` shifted left by 4 bit positions. Clear the tag if the resulting capability is unrepresentable or `cs2` is sealed.
-+
-Follow the rules from <<CADD>> for checking the validity of the source capability.
+Increment the address field of `cs2` by the unsigned word in `rs1` shifted left
+by 4 bit positions and write the result to `cd`. The tag bit of the output
+capability is 0 if `cs2` did not have its tag set to 1, the incremented address
+is outside `cs2` 's <<section_cap_representable_check>> or `cs2` is sealed.
+
+include::malformed_shadd_clear_tag.adoc[]
 
 pass:attributes,quotes[{cheri_int_mode_name}] Description::
-Increment `rs2` by the unsigned word in `rs1` shifted left by 4 bit positions.
+Increment `rs2` by the unsigned word in `rs1` shifted left by 4 bit positions
+and write the result to `rd`.
 
 Exceptions::
 None


### PR DESCRIPTION
the malformed cases were missing, and also the cases should be symmetrical between it mode / cap mode which wasn't clear before
fixes https://github.com/riscv/riscv-cheri/issues/312