### PR TITLE
Reword the scss instruction.

### DIFF
--- a/src/insns/scss_32bit.adoc
+++ b/src/insns/scss_32bit.adoc
@@ -4,9 +4,10 @@
 ==== SCSS
 
 ifdef::cheri_v9_annotations[]
-NOTE: *CHERI v9 Note:* ctestsubset does not use ddc if cs1==0
-
 NOTE: *CHERI v9 Note:* this instruction was called CTESTSUBSET.
+
+NOTE: *CHERI v9 Note:* this instruction does not use ddc if cs1==0
+
 
 endif::[]
 


### PR DESCRIPTION
The scss description includes a note for comparison to the v9 spec. The note incorrectly referred to the v9 instruction as not having the default capability behaviour when in fact it is the renamed scss instruction which doesn't. Corrected the name and reordered the note to clarify this.