### PR TITLE
Clarified the "malformed capabilities" definition

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -530,6 +530,10 @@ CHERI enforces the following invariants for all valid (i.e., tagged) capabilitie
 . The bounds are not malformed.
 . No reserved bit in the capability encoding is set.
 
+A tagged capability that violates those invariants (i.e., a tagged but malformed capability or a tagged
+capability with any reserved bit set) can only possibly be caused by
+a logic or memory fault (e.g., bit flipping).
+
 Capabilities with malformed bounds:
 
 . Return both base and top bounds as zero, which affects instructions like <<GCBASE>>.

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -509,8 +509,8 @@ equivalent to _b_=0 and _t_&#8805;2^MXLEN^.
 [#section_cap_malformed]
 ===== Malformed Capability Bounds
 
-A capability is _malformed_ if its encoding does not describe a valid
-capability because its bounds cannot be correctly decoded. The following check
+A capability is _malformed_ if its bounds cannot be correctly decoded.
+The following check
 indicates whether a capability is malformed. `enableL8` is true when MXLEN=32
 and false otherwise, indicating whether the `L8` bit is available for extra
 precision when `EF=1`.
@@ -525,9 +525,10 @@ malformed    =  !EF && (malformedMSB || malformedLSB)
 NOTE: The check is for malformed _bounds_, so it does not include reserved
 bits!
 
-It is impossible for a CHERI core to generate a tagged capability with malformed
-bounds, or with any reserved bits set. If such a capability exists then it must
-have been caused by a logic or memory fault.
+CHERI enforces the following invariants for all valid (i.e., tagged) capabilities:
+
+. The bounds are not malformed.
+. No reserved bit in the capability encoding is set.
 
 Capabilities with malformed bounds:
 

--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -34,3 +34,4 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Robert N. M. Watson <robert.watson@cl.cam.ac.uk>
 * Toby Wenman <toby.wenman@codasip.com>
 * Jonathan Woodruff <jonathan.woodruff@cl.cam.ac.uk>
+* Jason Zhijingcheng Yu <yu.zhi@comp.nus.edu.sg>


### PR DESCRIPTION
This attempts to address #310 by clarifying the definition of "malformed capabilities". The relationship between valid capabilities and malformed capabilities is now separately mentioned as what CHERI instructions check and enforce. 