### PR TITLE
Chapter 3 note about the relationship between privileged and unprivileged components

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -15,6 +15,14 @@ NOTE: The changes described in this specification also ensure that
 
 NOTE: RV128 is not currently supported by any CHERI extension.
 
+NOTE: In line with the base RISC-V ISA, the unprivileged component
+with its corresponding {cheri_base_ext_name} changes
+as described in this chapter can be used with
+an entirely different privileged-level design. The changes for the privileged
+component described in this chapter are designed to support existing
+popular operating systems, and assume the standard
+privileged architecture specified in the RISC-V ISA.
+
 === Memory
 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address


### PR DESCRIPTION
Related to discussions in #317 

This adds a note at the beginning of chapter 3 to clarify the split privileged/unprivileged design that mirrors the base RISC-V ISA. 