### PR TITLE
ACPERM clears tag if reserved bits are set

### DIFF
--- a/src/insns/acperm_32bit.adoc
+++ b/src/insns/acperm_32bit.adoc
@@ -36,7 +36,7 @@ clear all AP permissions and the <<m_bit>>, and skip the next step
 . Clear AP permissions as required to meet the rules below.
 . Encode the AP permissions for MXLEN=32 according to <<cap_perms_encoding32>>.
 . Copy `cs1` to `cd`, and update the AP and SDP fields with the newly calculated versions.
-. Set `cd.tag=0` if `cs1` is sealed.
+. Set `cd.tag=0` if `cs1` is sealed or if any reserved fields of `cs1` are set.
 +
 Some combinations of permissions cannot be encoded for MXLEN=32, and are not useful when MXLEN=64.
 These cases are defined to return useful minimal sets of permissions, which may be no permissions.


### PR DESCRIPTION
fixes https://github.com/riscv/riscv-cheri/issues/323