### PR TITLE
Fix typo.

### DIFF
--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -99,7 +99,7 @@ include::generated/csr_alias_action_table_body.adoc[]
 |==============================================================================
 
 ^*^ The vector range check is to ensure that vectored entry to the handler
- in within bounds of the capability written to `Xtvecc`. The check on writing
+ is within bounds of the capability written to `Xtvecc`. The check on writing
  must include the lowest (0 offset) and highest possible offset (e.g. 64 * MXLEN bits where HICAUSE=16).
 
 NOTE: _XLEN writing_ is only available if {cheri_default_ext_name} is implemented.


### PR DESCRIPTION
Fix small typo in the vector range check description for the csr action table.