### PR TITLE
Make CRE not a WARL field

### DIFF
--- a/src/attributes.adoc
+++ b/src/attributes.adoc
@@ -65,7 +65,7 @@ endif::[]
 :non-csrrw-and:  <<CSRRWI>>, <<CSRRS>>, <<CSRRSI>>, <<CSRRC>> and <<CSRRCI>>
 
 :TAG_RESET_CSR: The tag of the CSR must be reset to zero. The reset values of the metadata and address fields are UNSPECIFIED.
-:REQUIRE_CRE_CSR: Access to this CSR is illegal if the <<section_cheri_disable,effective CRE>> for the current privilege is zero.
+:REQUIRE_CRE_CSR: Access to this CSR is illegal if <<section_cheri_disable,CHERI register access is disabled>> for the current privilege.
 
 :CAP_MODE_VALUE: 0
 :INT_MODE_VALUE: 1

--- a/src/attributes.adoc
+++ b/src/attributes.adoc
@@ -65,7 +65,7 @@ endif::[]
 :non-csrrw-and:  <<CSRRWI>>, <<CSRRS>>, <<CSRRSI>>, <<CSRRC>> and <<CSRRCI>>
 
 :TAG_RESET_CSR: The tag of the CSR must be reset to zero. The reset values of the metadata and address fields are UNSPECIFIED.
-:REQUIRE_CRE_CSR: Access to this CSR is illegal if CRE for the current mode is zero (see <<section_cheri_disable>>).
+:REQUIRE_CRE_CSR: Access to this CSR is illegal if the effective CRE for the current privilege is zero (see <<section_cheri_disable>>).
 
 :CAP_MODE_VALUE: 0
 :INT_MODE_VALUE: 1

--- a/src/attributes.adoc
+++ b/src/attributes.adoc
@@ -65,7 +65,7 @@ endif::[]
 :non-csrrw-and:  <<CSRRWI>>, <<CSRRS>>, <<CSRRSI>>, <<CSRRC>> and <<CSRRCI>>
 
 :TAG_RESET_CSR: The tag of the CSR must be reset to zero. The reset values of the metadata and address fields are UNSPECIFIED.
-:REQUIRE_CRE_CSR: Access to this CSR is illegal if the effective CRE for the current privilege is zero (see <<section_cheri_disable>>).
+:REQUIRE_CRE_CSR: Access to this CSR is illegal if the <<section_cheri_disable,effective CRE>> for the current privilege is zero.
 
 :CAP_MODE_VALUE: 0
 :INT_MODE_VALUE: 1

--- a/src/insns/require_cre.adoc
+++ b/src/insns/require_cre.adoc
@@ -1,1 +1,1 @@
-This instruction is illegal if the <<section_cheri_disable,CHERI register access is disabled>> for the current privilege is.
+This instruction is illegal if the <<section_cheri_disable,CHERI register access is disabled>> for the current privilege.

--- a/src/insns/require_cre.adoc
+++ b/src/insns/require_cre.adoc
@@ -1,1 +1,1 @@
-This instruction is illegal if the effective CRE for the current privilege is zero (see <<section_cheri_disable>>).
+This instruction is illegal if the <<section_cheri_disable,effective CRE>> for the current privilege is zero.

--- a/src/insns/require_cre.adoc
+++ b/src/insns/require_cre.adoc
@@ -1,1 +1,1 @@
-This instruction is illegal if CRE for the current privilege mode is zero (see <<section_cheri_disable>>).
+This instruction is illegal if the effective CRE for the current privilege is zero (see <<section_cheri_disable>>).

--- a/src/insns/require_cre.adoc
+++ b/src/insns/require_cre.adoc
@@ -1,1 +1,1 @@
-This instruction is illegal if the <<section_cheri_disable,effective CRE>> for the current privilege is zero.
+This instruction is illegal if the <<section_cheri_disable,CHERI register access is disabled>> for the current privilege is.

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -84,7 +84,7 @@ The current CHERI execution mode is given by the <<m_bit>> of the <<pcc>> and th
 * The Mode is pass:attributes,quotes[{cheri_cap_mode_name}] when the <<m_bit>> of the <<pcc>> is {CAP_MODE_VALUE}, *and* <<section_cheri_disable,CHERI register access is enabled>> for the current privilege.
 * Otherwise the Mode is pass:attributes,quotes[{cheri_int_mode_name}].
 
-When the <<m_bit>> can be set follows the rules defined by <<ACPERM>>.
+When the <<m_bit>> can be set, the rules defined by <<ACPERM>> must be followed.
 
 [#m_bit_observe,reftext="Observing the CHERI Execution Mode"]
 ==== Observing the CHERI Execution Mode

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -79,12 +79,10 @@ In both encodings:
 * Mode (M)={CAP_MODE_VALUE} indicates pass:attributes,quotes[{cheri_cap_mode_name}].
 * Mode (M)={INT_MODE_VALUE} indicates pass:attributes,quotes[{cheri_int_mode_name}].
 
-The current CHERI execution mode is given by the <<m_bit>> of the <<pcc>> and the
-CRE bits in <<mseccfg>>, <<menvcfg>>, and <<senvcfg>> as follows:
+The current CHERI execution mode is given by the <<m_bit>> of the <<pcc>> and the <<section_cheri_disable,CHERI register access settings>> as follows:
 
-* The Mode is pass:attributes,quotes[{cheri_cap_mode_name}] when the <<m_bit>> of the <<pcc>> is {CAP_MODE_VALUE}, *and* the effective
-CRE=1 for the current privilege level
-* The Mode is pass:attributes,quotes[{cheri_int_mode_name}] when the <<section_cheri_disable,effective CRE>> for the current privilege is 0 *or* the <<m_bit>> of the <<pcc>> is {INT_MODE_VALUE}
+* The Mode is pass:attributes,quotes[{cheri_cap_mode_name}] when the <<m_bit>> of the <<pcc>> is {CAP_MODE_VALUE}, *and* <<section_cheri_disable,CHERI register access is enabled>> for the current privilege.
+* Otherwise the Mode is pass:attributes,quotes[{cheri_int_mode_name}].
 
 When the <<m_bit>> can be set follows the rules defined by <<ACPERM>>.
 
@@ -329,9 +327,11 @@ instruction exception
 * All allowed instructions execute as if the CHERI execution mode is pass:attributes,quotes[{cheri_int_mode_name}].
 The mode bit in <<pcc>> is treated as if it was zero while CHERI register access is disabled.
 
-CHERI register access is disabled if XLEN in the current mode is less than
-MXLEN, if the endianness in the current mode is not the reset value of
-<<mstatus>>.MBE, or if the effective CRE for the current privilege is 0.
+CHERI register access is disabled if
+
+* XLEN in the current mode is less than MXLEN, or
+* the endianness in the current mode is not the reset value of <<mstatus>>.MBE, or
+* the effective CRE for the current privilege is 0.
 
 The effective CRE for the current privilege is:
 
@@ -339,7 +339,7 @@ The effective CRE for the current privilege is:
 * Supervisor: `mseccfg.CRE & menvcfg.CRE`
 * User: `mseccfg.CRE & menvcfg.CRE & senvcfg.CRE`
 
-NOTE: CRE is always enabled in debug mode.
+NOTE: The effective CRE is always 1 in debug mode.
 
 Disabling CHERI register access has no effect on implicit accesses or security
 checks.  The last capability installed in <<pcc>> and <<ddc>> before disabling
@@ -420,9 +420,11 @@ xref:mseccfgmodereg[xrefstyle=short].
 [#mseccfgmodereg]
 include::img/mseccfgreg.edn[]
 
-The CHERI Register Enable (CRE) bit controls whether M-mode has access to capability registers and instructions.
-When CRE=1, all CHERI instructions and registers can be accessed.
-When CRE=0, CHERI register and instruction access is prohibited for M-mode and lower privilege levels as described in xref:section_cheri_disable[xrefstyle=short].
+The CHERI Register Enable (CRE) bit controls whether M-mode and lower privilege
+levels have access to capability registers and instructions.
+When <<mseccfg>>.CRE=1, all CHERI instructions and registers can be accessed.
+When <<mseccfg>>.CRE=0, CHERI register and instruction access is prohibited for
+M-mode and lower privilege levels as described in xref:section_cheri_disable[xrefstyle=short].
 
 The reset value is 0.
 
@@ -437,11 +439,10 @@ xref:menvcfgmodereg[xrefstyle=short].
 include::img/menvcfgmodereg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether less privileged levels can
-perform explicit accesses to CHERI registers. When the CRE bit is set to 1 and <<mseccfg>>.CRE=1,
-CHERI registers can be read and written by less privileged levels. When set to 0,
+perform explicit accesses to CHERI registers. When <<menvcfg>>.CRE=1 and <<mseccfg>>.CRE=1,
+CHERI registers can be read and written by less privileged levels. When <<menvcfg>>.CRE=0,
 CHERI registers are disabled in less privileged levels as described in
 xref:section_cheri_disable[xrefstyle=short].
-CRE is read-only zero if <<mseccfg>>.CRE=0.
 
 The reset value is 0.
 
@@ -471,9 +472,10 @@ xref:senvcfgreg[xrefstyle=short].
 include::img/senvcfgreg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether U-mode can perform
-explicit accesses to CHERI registers.  When CRE=1 and <<menvcfg>>.CRE=1 and
-<<mseccfg>>.CRE=1 CHERI registers can be read and written by U-mode. When CRE=0,
-CHERI registers are disabled in U-mode as described.
+explicit accesses to CHERI registers. When <<senvcfg>>.CRE=1 and <<menvcfg>>.CRE=1 and
+<<mseccfg>>.CRE=1 CHERI registers can be read and written by U-mode. When <<senvcfg>>.CRE=0,
+CHERI registers are disabled in U-mode as described in
+xref:section_cheri_disable[xrefstyle=short].
 
 The reset value is 0.
 

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -437,7 +437,7 @@ xref:menvcfgmodereg[xrefstyle=short].
 include::img/menvcfgmodereg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether less privileged levels can
-perform explicit accesses to CHERI registers. perform explicit accesses to CHERI registers. When the CRE bit is set to 1 and <<mseccfg>>.CRE=1,
+perform explicit accesses to CHERI registers. When the CRE bit is set to 1 and <<mseccfg>>.CRE=1,
 CHERI registers can be read and written by less privileged levels. When set to 0,
 CHERI registers are disabled in less privileged levels as described in
 xref:section_cheri_disable[xrefstyle=short].

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -84,7 +84,7 @@ CRE bits in <<mseccfg>>, <<menvcfg>>, and <<senvcfg>> as follows:
 
 * The Mode is pass:attributes,quotes[{cheri_cap_mode_name}] when the <<m_bit>> of the <<pcc>> is {CAP_MODE_VALUE}, *and* the effective
 CRE=1 for the current privilege level
-* The Mode is pass:attributes,quotes[{cheri_int_mode_name}] when the effective CRE=0 for the current privilege level *or* the <<m_bit>> of the <<pcc>> is {INT_MODE_VALUE}
+* The Mode is pass:attributes,quotes[{cheri_int_mode_name}] when the <<section_cheri_disable,effective CRE>> for the current privilege is 0 *or* the <<m_bit>> of the <<pcc>> is {INT_MODE_VALUE}
 
 When the <<m_bit>> can be set follows the rules defined by <<ACPERM>>.
 
@@ -331,30 +331,15 @@ The mode bit in <<pcc>> is treated as if it was zero while CHERI register access
 
 CHERI register access is disabled if XLEN in the current mode is less than
 MXLEN, if the endianness in the current mode is not the reset value of
-<<mstatus>>.MBE, or if CRE active at the current mode (<<mseccfg>>.CRE for M-mode, <<menvcfg>>.CRE for
-S-mode or <<senvcfg>>.CRE for U-mode) is 0.
+<<mstatus>>.MBE, or if the effective CRE for the current privilege is 0.
+
+The effective CRE for the current privilege is:
+
+* Machine: `mseccfg.CRE`
+* Supervisor: `mseccfg.CRE & menvcfg.CRE`
+* User: `mseccfg.CRE & menvcfg.CRE & senvcfg.CRE`
 
 NOTE: CRE is always enabled in debug mode.
-
-<<mseccfg>>.CRE, <<menvcfg>>.CRE, and <<senvcfg>>.CRE form a single WARL field.
-This allows higher privilege software to restrict lower
-privilege software access to CHERI register state, and the ability to enter
-pass:attributes,quotes[{cheri_cap_mode_name}]. The valid configurations are shown in
-xref:xenvcfg-warl-field[xrefstyle=short].
-
-[[xenvcfg-warl-field]]
-.Xenvcfg joint WARL field
-[%autowidth,float="center",align="center",cols="<,<,<,<",options="header"]
-|===
-|<<mseccfg>>.CRE |<<menvcfg>>.CRE|<<senvcfg>>.CRE|Comment
-|0               |read-only 0    | read-only 0   |<<mseccfg>>.CRE=0 completely disables CHERI access
-|1               |0              | read-only 0   |<<menvcfg>>.CRE=0 disables access for privilege less than M-mode
-|1               |1              | 0/1           |<<senvcfg>>.CRE can be programmed to enable/disable access for U-mode
-|===
-
-The WARL programming nature is extended to include UXLEN and SXLEN, as they can
-only be programmed to be smaller than MXLEN if the CRE bit active for the current
-mode is disabled.
 
 Disabling CHERI register access has no effect on implicit accesses or security
 checks.  The last capability installed in <<pcc>> and <<ddc>> before disabling
@@ -452,9 +437,9 @@ xref:menvcfgmodereg[xrefstyle=short].
 include::img/menvcfgmodereg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether less privileged levels can
-perform explicit accesses to CHERI registers.  When CRE=1, CHERI registers can
-be read and written by less privileged levels.  When CRE=0, CHERI registers are
-disabled in less privileged levels as described in
+perform explicit accesses to CHERI registers. When CRE=1 and <<mseccfg>>.CRE=1,
+CHERI registers can be read and written by less privileged levels. When CRE=0,
+CHERI registers are disabled in less privileged levels as described in
 xref:section_cheri_disable[xrefstyle=short].
 CRE is read-only zero if <<mseccfg>>.CRE=0.
 
@@ -486,15 +471,9 @@ xref:senvcfgreg[xrefstyle=short].
 include::img/senvcfgreg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether U-mode can perform
-explicit accesses to CHERI registers.  When CRE=1, CHERI registers can be read
-and written by U-mode.  When CRE=0, CHERI registers are disabled in U-mode as
-described.
-
-* <<senvcfg>>.CRE is read-only-zero if:
-** <<mstatus>>.MBE is not the reset value OR
-* UXLEN<MXLEN OR
-* <<mseccfg>>.CRE==0 OR
-* <<menvcfg>>.CRE==0
+explicit accesses to CHERI registers.  When CRE=1 and <<menvcfg>>.CRE=1 and
+<<mseccfg>>.CRE=1 CHERI registers can be read and written by U-mode. When CRE=0,
+CHERI registers are disabled in U-mode as described.
 
 The reset value is 0.
 

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -437,8 +437,8 @@ xref:menvcfgmodereg[xrefstyle=short].
 include::img/menvcfgmodereg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether less privileged levels can
-perform explicit accesses to CHERI registers. When CRE=1 and <<mseccfg>>.CRE=1,
-CHERI registers can be read and written by less privileged levels. When CRE=0,
+perform explicit accesses to CHERI registers. perform explicit accesses to CHERI registers. When the CRE bit is set to 1 and <<mseccfg>>.CRE=1,
+CHERI registers can be read and written by less privileged levels. When set to 0,
 CHERI registers are disabled in less privileged levels as described in
 xref:section_cheri_disable[xrefstyle=short].
 CRE is read-only zero if <<mseccfg>>.CRE=0.


### PR DESCRIPTION
Change the CRE bits so they are always writable, but the effective CRE depends on multiple values. This is significantly simpler to specify, avoids an entire cross-CSR WARL field (WARL fields are a pain), and removes some undefined behaviour (do the bits retain their values when they are read-only zero).

Fixes #331

Note, I deleted the text about SXLEN/UXLEN. Those didn't seem fully specified tbh, but I'll need to add them back somehow.