### PR TITLE
Reword the ASR description to clarify Zstid register behaviour.

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -121,8 +121,8 @@ Execute Permission (X):: Allow instruction execution.
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all
 privileged (M-mode and S-mode) CSRs.
-If {tid_ext_name} is supported the <<utid>>, <<utidc>>, <<stid>>, <<stidc>>, <<mtid>>, 
-<<mtidc>> registers are all considered privileged for the purposes of writing 
+If {tid_ext_name} is supported the <<utid>>, <<utidc>>, <<stid>>, <<stidc>>, <<mtid>>,
+<<mtidc>> registers are all considered privileged for the purposes of writing
 and unprivileged for reading, and thus require ASR-permission for writes but not reads.
 In all cases a suitable privilege mode is required for access.
 

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -120,10 +120,13 @@ Execute Permission (X):: Allow instruction execution.
 
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all
-privileged (M-mode and S-mode) CSRs with the following exceptions:
-. <<utid>>, <<utidc>>, <<stid>>, <<stidc>>, <<mtid>>, <<mtidc>> all require ASR
-access for writing and not for reading, as well as having a suitable privileged
-execution mode.
+privileged (M-mode and S-mode).
+
+If {tid_ext_name} is supported the <<utid>>, <<utidc>>, <<stid>>, <<stidc>>, <<mtid>>, 
+<<mtidc>> registers are all considered privileged for the purposes of writing 
+and unprivileged for reading, and thus require ASR-permission for writes but not reads.
+
+In all cases a suitable privilege mode is required for access.
 
 [#cap_permissions_encoding]
 ===== Permission Encoding

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -120,12 +120,10 @@ Execute Permission (X):: Allow instruction execution.
 
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all
-privileged (M-mode and S-mode).
-
+privileged (M-mode and S-mode) CSRs.
 If {tid_ext_name} is supported the <<utid>>, <<utidc>>, <<stid>>, <<stidc>>, <<mtid>>, 
 <<mtidc>> registers are all considered privileged for the purposes of writing 
 and unprivileged for reading, and thus require ASR-permission for writes but not reads.
-
 In all cases a suitable privilege mode is required for access.
 
 [#cap_permissions_encoding]


### PR DESCRIPTION
The thread id registers introduced in Zstid differ in behaviour with other registers in that they have different behaviour for reads than writes, and the utidc register is treated as privileged for the purposes of ASR checking. Try and clarify this more.