### PR TITLE
hybrid: fix a sentence that uses the old definition of M

### DIFF
--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -48,7 +48,7 @@ The CHERI execution mode is key in providing backwards compatibility with the
 base RISC-V ISA. RISC-V software is able to execute unchanged in
 implementations supporting both {cheri_base_ext_name} and
 {cheri_default_ext_name} provided that the <<infinite-cap>> capability is installed in <<ddc>> and <<pcc>>
-(with <<m_bit,M=0>>, i.e. in pass:attributes,quotes[{cheri_int_mode_name}]).
+(with <<m_bit,M={INT_MODE_VALUE}>>, i.e. in pass:attributes,quotes[{cheri_int_mode_name}]).
 Setting both registers to <<infinite-cap>> ensures that:
 
 * All permissions are granted


### PR DESCRIPTION
Integer pointer mode is now M = 1. Fix a sentence that hasn't been converted to the new definition of the M bit.