### PR TITLE
Miscellaneous wording and typo fixes

### DIFF
--- a/src/insns/sh123add_32bit.adoc
+++ b/src/insns/sh123add_32bit.adoc
@@ -28,7 +28,7 @@ Encoding::
 {reg:[
     { bits:  7, name: 0x33, attr: ['OP'] },
     { bits:  5, name: 'cd/rd' },
-    { bits:  3, name: 0x2, attr: ['SH1ADD=010', 'SH2ADD=100', 'SH3ADD=110'] },
+    { bits:  3, name: 'func3', attr: ['SH1ADD=010', 'SH2ADD=100', 'SH3ADD=110'] },
     { bits:  5, name: 'rs1' },
     { bits:  5, name: 'cs2/rs2' },
     { bits:  7, name: 0x10, attr: ['SH[1|2|3]ADD'] },

--- a/src/insns/sh123adduw_32bit.adoc
+++ b/src/insns/sh123adduw_32bit.adoc
@@ -28,7 +28,7 @@ Encoding::
 {reg:[
     { bits:  7, name: 0x3b, attr: ['OP'] },
     { bits:  5, name: 'cd/rd' },
-    { bits:  3, name: 0x2, attr: ['rv64: SH1ADD.UW=010', 'rv64: SH2ADD.UW=100', 'rv64: SH3ADD.UW=110'] },
+    { bits:  3, name: 'func3', attr: ['rv64: SH1ADD.UW=010', 'rv64: SH2ADD.UW=100', 'rv64: SH3ADD.UW=110'] },
     { bits:  5, name: 'rs1' },
     { bits:  5, name: 'cs2/rs2' },
     { bits:  7, name: 0x10, attr: ['rv64: SH[1|2|3]ADD.UW'] },

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -362,7 +362,7 @@ xref:default-csrnames-added[xrefstyle=short].
 include::generated/csr_added_hybrid_table_body.adoc[]
 |===
 
-[#mstatus_legacy]
+[#mstatus_hybrid]
 ==== Machine Status Registers (mstatus and mstatush)
 
 {cheri_default_ext_name} eliminates some restrictions for SXL and UXL imposed in

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -199,9 +199,9 @@ Load and store instructions change behavior depending on the CHERI execution
 mode although the instruction's encoding remains unchanged.
 
 Loads and stores behave as described in
-xref:section_existing_riscv_insns[xrefstyle=short] when in pass:attributes,quotes[{cheri_cap_mode_name}]
+xref:section_existing_riscv_insns[xrefstyle=short] when in pass:attributes,quotes[{cheri_cap_mode_name}].
 In pass:attributes,quotes[{cheri_int_mode_name}], the instructions behave as described in
-the RISC-V base ISA (i.e. without the 'C' prefix) and rely on *x* operands
+the RISC-V base ISA and rely on *x* operands
 only. The capability authorising the memory access is <<ddc>> and the memory
 address is given by sign-extending the 12-bit immediate offset and adding it to
 the base address in the *x* register operand.

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -400,7 +400,7 @@ xref:section_cheri_disable[xrefstyle=short], while in that privilege mode.
 [#mtdc,reftext="mtdc"]
 ==== Machine Trap Default Capability Register (mtdc)
 
-The <<mtdc>> register is pass:attributes,quotes[{cheri_cap_mode_name}] width read/write register dedicated
+The <<mtdc>> register is a capability width read/write register dedicated
 for use by machine mode. Typically, it is used to hold a data capability to a
 machine-mode hart-local context space, to load into <<ddc>>.
 
@@ -450,7 +450,7 @@ The reset value is 0.
 [#stdc,reftext="stdc"]
 ==== Supervisor Trap Default Capability Register (stdc)
 
-The <<stdc>> register is pass:attributes,quotes[{cheri_cap_mode_name}] width read/write register dedicated
+The <<stdc>> register is a capability width read/write register dedicated
 for use by supervisor mode. Typically, it is used to hold a data capability to
 a supervisor-mode hart-local context space, to load into <<ddc>>.
 

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -362,6 +362,7 @@ xref:default-csrnames-added[xrefstyle=short].
 include::generated/csr_added_hybrid_table_body.adoc[]
 |===
 
+[#mstatus_legacy]
 ==== Machine Status Registers (mstatus and mstatush)
 
 {cheri_default_ext_name} eliminates some restrictions for SXL and UXL imposed in

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -424,7 +424,7 @@ Only 1 and 2 are supported values for SXL and UXL and the fields must be
 read-only in implementations supporting {cheri_base_ext_name}. The effective
 XLEN in S-mode and U-mode are termed SXLEN and UXLEN, respectively.
 
-The MBE, SBE, and UBE fields determines the endianness of memory accesses other
+The MBE, SBE, and UBE fields determine the endianness of memory accesses other
 than instruction fetches performed from M-mode, S-mode, or U-mode,
 respectively. xBE=0 indicates little endian and xBE=1 is big endian. MBE must
 be read-only. SBE and UBE must be read only and equal to MBE, if S-mode or

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -424,11 +424,11 @@ Only 1 and 2 are supported values for SXL and UXL and the fields must be
 read-only in implementations supporting {cheri_base_ext_name}. The effective
 XLEN in S-mode and U-mode are termed SXLEN and UXLEN, respectively.
 
-The MBE, SBE, and UBE fields determine whether explicit loads and stores
-performed from M-mode, S-mode, or U-mode, respectively, are little endian
-(xBE = 0) or big endian (xBE = 1).  MBE must be read only.  SBE and UBE must be
-read only and equal to MBE, if S-mode or U-mode, respectively, is implemented,
-or read only zero otherwise.
+The MBE, SBE, and UBE fields determines the endianness of memory accesses other
+than instruction fetches performed from M-mode, S-mode, or U-mode,
+respectively. xBE=0 indicates little endian and xBE=1 is big endian. MBE must
+be read-only. SBE and UBE must be read only and equal to MBE, if S-mode or
+U-mode, respectively, is implemented, or read-only zero otherwise.
 
 NOTE: A further CHERI extension, {cheri_default_ext_name}, optionally makes SXL,
 UXL, MBE, SBE, and UBE writeable, so implementations that support multiple base


### PR DESCRIPTION
No spec changes. Only miscellaneous fixes for wording, cross references and removal of outdated text across the spec. These changes were originally at https://github.com/riscv/riscv-cheri/pull/236, but I split them out to keep the history organized.