### PR TITLE
Delete incorrect note in atomic store operation

### DIFF
--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -8,7 +8,6 @@ If <<c_perm>> is not granted then store the memory tag as zero, and load `cd.tag
 +
 If the authorizing capability does not grant <<lm_perm>>, and the tag of `cd` is 1 and `cd` is not sealed, then an implicit <<ACPERM>> clearing <<w_perm>> and <<lm_perm>> is performed to obtain the final permissions on `cd` (see <<LC>>).
 +
-(_This tag clearing behaviour may become a data dependent exception in future._)
 endif::[]
 ifndef::cap_atomic[]
 Requires <<r_perm>> and <<w_perm>> in the authorising capability.


### PR DESCRIPTION
This dates back to the initial commit and there are currently no plans to change this behaviour.