### PR TITLE
Add GCMODE instruction

### DIFF
--- a/src/csv/CHERI_ISA.csv
+++ b/src/csv/CHERI_ISA.csv
@@ -51,6 +51,7 @@
 "GCLEN","✔","✔","","","","✔","✔","Both","","","","","","","","","","","","","","","","","OP","1-src 1-dst","","","Get capability length","","","","","","","",""
 "GCTYPE","✔","✔","","","","✔","✔","Both","","","","","","","","","","","","","","","","","OP","1-src 1-dst","","","Get capability type","","","","","","","",""
 "SCMODE","✔","✔","","","","✔","","Both","","","","","","","","","","","","","","","","","OP","1-src 1-dst","","","Set the mode bit of a capability, no permissions required","","","","","","","",""
+"GCMODE","✔","✔","","","","✔","","Both","","","","","","","","","","","","","","","","","OP","1-src 1-dst","","","Get the mode bit of a capability, no permissions required","","","","","","","",""
 "MODESW","✔","✔","","","","✔","","Both","","","","","","","","","","","","","","","","","OP","no operands","","","Directly switch mode ({cheri_int_mode_name}/ {cheri_cap_mode_name})","mode==D (optional)","","","","","","",""
 "C.MODESW","✔","✔","","","","✔","","Both","","","","","","","","","","","","","","","","","C1","no operands","","","Directly switch mode ({cheri_int_mode_name}/ {cheri_cap_mode_name})","mode==D (optional)","","","","","","",""
 "C.ADDI16SP","✔","✔","","","","✔","✔","Both","","","","✔","","","","","","","","","","","","","C0","","","","ADD immediate to stack pointer, CADD in Capability Mode","","","","","","","",""

--- a/src/insns/gcmode_32bit.adoc
+++ b/src/insns/gcmode_32bit.adoc
@@ -1,0 +1,30 @@
+<<<
+
+[#GCMODE,reftext="GCMODE"]
+==== GCMODE
+
+Synopsis::
+Capability get CHERI execution mode
+
+Mnemonic::
+`gcmode rd, cs1`
+
+Encoding::
+include::wavedrom/gcmode.adoc[]
+
+Description::
+Decode the architectural capability CHERI execution mode from `cs1` and write
+the result to `rd`. It is not required that the input capability `cs1`  has its
+tag set to 1.
+
+Exceptions::
+include::require_cre.adoc[]
+
+Prerequisites::
+{cheri_default_ext_name}
+
+Operation::
+[source,SAIL,subs="verbatim,quotes"]
+--
+TODO
+--

--- a/src/insns/gcmode_32bit.adoc
+++ b/src/insns/gcmode_32bit.adoc
@@ -13,9 +13,12 @@ Encoding::
 include::wavedrom/gcmode.adoc[]
 
 Description::
-Decode the architectural capability CHERI execution mode from `cs1` and write
-the result to `rd`. It is not required that the input capability `cs1`  has its
-tag set to 1.
+Decode the CHERI execution mode from the capability in `cs1` and write
+the result to `rd`. The output in `rd` is {CAP_MODE_VALUE} if the CHERI
+execution mode of the capability in `cs1` is
+pass:attributes,quotes[{cheri_cap_mode_name}] and {INT_MODE_VALUE} if the mode
+is pass:attributes,quotes[{cheri_int_mode_name}]. It is not required that `cs1`
+has its tag set to 1.
 
 Exceptions::
 include::require_cre.adoc[]

--- a/src/insns/wavedrom/gcmode.adoc
+++ b/src/insns/wavedrom/gcmode.adoc
@@ -1,0 +1,12 @@
+
+[wavedrom, ,svg]
+....
+{reg: [
+  {bits: 7,  name: 'opcode',  attr: ['7', 'OP=0110011'], type: 8},
+  {bits: 5,  name: 'rd',      attr: ['5', 'dest'], type: 2},
+  {bits: 3,  name: 'funct3',  attr: ['3', 'GCMODE=000'], type: 8},
+  {bits: 5,  name: 'cs1',     attr: ['5', 'src'], type: 4},
+  {bits: 5,  name: 'funct5',  attr: ['5', 'GCMODE=00011'], type: 3},
+  {bits: 7,  name: 'funct7',  attr: ['7', 'GCMODE=0001000'], type: 3},
+]}
+....

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -54,6 +54,8 @@ include::insns/gcbase_32bit.adoc[]
 
 include::insns/gclen_32bit.adoc[]
 
+include::insns/gcmode_32bit.adoc[]
+
 include::insns/gctype_32bit.adoc[]
 
 include::insns/scbnds_32bit.adoc[]

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -115,7 +115,9 @@ gctag x1, c1
 [#section_hybrid_ext_instructions]
 === Zcherihybrid Instructions
 
-{cheri_default_ext_name} introduces a small number of new mode-switching instructions to the base RISC-V integer ISA, as shown in <<Zcheri_hybrid_instruction_extension>>.
+{cheri_default_ext_name} introduces a small number of new mode-switching and
+capability manipulation instructions to the base RISC-V integer ISA, as shown
+in <<Zcheri_hybrid_instruction_extension>>.
 Additionally, the behavior of some existing instructions changes depending on the current CHERI execution mode.
 
 ==== Capability Load and Store Instructions
@@ -142,6 +144,10 @@ the sign-extended offset.
 A new <<SCMODE>> instruction allows setting a capability's CHERI execution
 mode to the indicated value. The output is written to an unprivileged *c*
 register, not <<pcc>>.
+
+A new <<GCMODE>> instruction allows decoding the CHERI execution mode from an
+arbitrary capability held in an *x* register. The output is written to an
+unprivileged *x* register.
 
 ==== Mode Change Instructions
 


### PR DESCRIPTION
Add GCMODE instruction that decodes the mode from an arbitrary capability in an *x* register and writes the value to another *x* register.

GCMODE allows inspecting a capability's CHERI execution mode without the need for software to "manually" decode the capability's metadata using `gchi`.

Fixes #302.