### PR TITLE
Allow alternative capability encodings

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -27,7 +27,7 @@ initially ported to CHERIv9 while providing spatial safety, temporal safety and
 compartmentalization support alongside a good measure of compatibility with
 RISC-V software that is not aware of CHERI. Alternative capability encoding
 specifications must provide key primitives, such as permissions and bounds,
-from in this specification while using a different encoding that, for example,
+from this specification while using a different encoding that, for example,
 changes the granularity of bounds or adds new features. For simplicity of
 expression, the text is written as if this was the only possible capability
 encoding possible for CHERI RISC-V.

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -19,6 +19,19 @@ current draft and expected to be part of privileged architecture 1.13.
 MXLEN without including the tag bit. The value of CLEN is always calculated
 based on MXLEN regardless of the effective XLEN value.
 
+NOTE: We briefly note that the capability encoding described in this section
+could be replaced with an entirely different design without changing how CHERI
+integrates with the RISC-V ISA, and possibly without even changing the ABI. In
+particular, this capability encoding specification was designed to run software
+initially ported to CHERIv9 while providing spatial safety, temporal safety and
+compartmentalization support alongside a good measure of compatibility with
+RISC-V software that is not aware of CHERI. Alternative capability encoding
+specifications must provide key primitives, such as permissions and bounds,
+from in this specification while using a different encoding that, for example,
+changes the granularity of bounds or adds new features. For simplicity of
+expression, the text is written as if this was the only possible capability
+encoding possible for CHERI RISC-V.
+
 [#section_cap_encoding]
 === Capability Encoding
 

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -21,7 +21,7 @@ based on MXLEN regardless of the effective XLEN value.
 
 NOTE: We briefly note that the capability encoding described in this section
 could be replaced with an entirely different design without changing how CHERI
-integrates with the RISC-V ISA, and possibly without even changing the ABI. In
+integrates with the RISC-V ISA. In
 particular, this capability encoding specification was designed to run software
 initially ported to CHERIv9 while providing spatial safety, temporal safety and
 compartmentalization support alongside a good measure of compatibility with

--- a/src/insns/sentry_32bit.adoc
+++ b/src/insns/sentry_32bit.adoc
@@ -22,6 +22,11 @@ Description::
 Capability `cd` is written with the capability in `cs1` with its type bit set to 1.
 Attempting to seal an already sealed capability will lead to the tag of `cd` being set to 0.
 
+NOTE: The SENTRY instruction may give rise to an illegal instruction fault when
+the implementation supports a capability encoding that requires permissions to
+seal a capability. This is not the case when the implementation supports the
+capability encoding described in xref:section_cap_description[xrefstyle=short].
+
 Exceptions::
 include::require_cre.adoc[]
 

--- a/src/insns/sentry_32bit.adoc
+++ b/src/insns/sentry_32bit.adoc
@@ -22,10 +22,11 @@ Description::
 Capability `cd` is written with the capability in `cs1` with its type bit set to 1.
 Attempting to seal an already sealed capability will lead to the tag of `cd` being set to 0.
 
-NOTE: The SENTRY instruction may give rise to an illegal instruction fault when
-the implementation supports a capability encoding that requires permissions to
-seal a capability. This is not the case when the implementation supports the
-capability encoding described in xref:section_cap_description[xrefstyle=short].
+NOTE: The <<SENTRY>> instruction may give rise to an illegal instruction fault
+when the implementation does not support capability type 1 (unrestricted
+sentry; see xref:section_cap_sealed[xrefstyle=short]). This is not the case
+when the implementation supports the capability encoding described in
+xref:section_cap_description[xrefstyle=short].
 
 Exceptions::
 include::require_cre.adoc[]


### PR DESCRIPTION
Allow implementations supporting CHERI RISC-V to use alternative capability encodings that provide most key features, such as bounds and permissions, but may change, for example, the granularity of bounds or offer additional features. Also, allow the `sentry` instruction to become an illegal when using alternative capability encodings that do not provide ambient sealing permission.

The paragraph allowing alternative encodings is largely inspired from the paragraph in the RISC-V Privileged Specification that allows alternative privileged ISA designs.

Fix #324