### PR TITLE
Use "bounds" violation instead of "length"

### DIFF
--- a/src/attributes.adoc
+++ b/src/attributes.adoc
@@ -93,4 +93,4 @@ endif::[]
 :cheri_excep_cause_seal:     1
 :cheri_excep_cause_perm:     2
 :cheri_excep_cause_inv_addr: 3
-:cheri_excep_cause_length:   4
+:cheri_excep_cause_bounds:   4

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -31,7 +31,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>> or <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
+| Bounds violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 |==============================================================================
 
 :!cap_atomic:

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -32,7 +32,7 @@ ifdef::cbo_inval[]
 | Permission violation  | Authority capability does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the AP field could not have been produced by <<ACPERM>>
 endif::[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | None of the bytes accessed are within the bounds, or the capability has <<section_cap_malformed,malformed>> bounds
+| Bounds violation      | None of the bytes accessed are within the bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 
 |==============================================================================
 

--- a/src/insns/condbr_common.adoc
+++ b/src/insns/condbr_common.adoc
@@ -1,5 +1,5 @@
 Exceptions::
 When the target address is not within the <<pcc>>'s bounds, and the branch is taken,
 a _CHERI jump or
-branch fault_ is reported in the TYPE field and Length Violation is reported in
+branch fault_ is reported in the TYPE field and Bounds violation is reported in
 the CAUSE field of <<mtval>> or <<stval>>:

--- a/src/insns/hypv-virt-loadx.adoc
+++ b/src/insns/hypv-virt-loadx.adoc
@@ -52,7 +52,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation             | Authority capability is sealed
 | Permission violation       | Authority capability does not grant <<r_perm>> or <<x_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation           | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
+| Bounds violation           | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 |==============================================================================
 
 Prerequisites for {cheri_cap_mode_name}::

--- a/src/insns/jal_32bit.adoc
+++ b/src/insns/jal_32bit.adoc
@@ -37,7 +37,7 @@ Exceptions::
 |==============================================================================
 | CAUSE                      | {cheri_int_mode_name} | {cheri_cap_mode_name} | Reason
 | Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation           | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds.
+| Bounds violation           | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds.
 |==============================================================================
 
 include::pcrel_debug_warning.adoc[]

--- a/src/insns/jalr_32bit.adoc
+++ b/src/insns/jalr_32bit.adoc
@@ -53,7 +53,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        |      | ✔     | `cs1` is sealed and the immediate is not 0
 | Permission violation  |      | ✔     | `cs1` does not grant <<x_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | ✔    | ✔     | The target address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds, which will fail
+| Bounds violation      | ✔    | ✔     | Minimum length instruction is not within the target capability's bounds, which will fail
 if `cs1` has <<section_cap_malformed,malformed>> bounds in {cheri_cap_mode_name}.
 |==============================================================================
 

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<r_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
+| Bounds violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 
 |==============================================================================
 +

--- a/src/insns/mret_sret.adoc
+++ b/src/insns/mret_sret.adoc
@@ -27,7 +27,7 @@ Exceptions::
 CHERI fault exceptions occur when <<pcc>> does not grant <<asr_perm>> because
 <<MRET>> and <<SRET>> require access to privileged CSRs. When that exception
 occurs, _CHERI instruction access fault_ is reported in the TYPE field and the
-Permission Violation codes is reported in the CAUSE field of <<mtval>> or
+Permission violation code is reported in the CAUSE field of <<mtval>> or
 <<stval>>.
 
 Operation::

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -19,7 +19,7 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
 | Seal violation        | Authority capability is sealed
 | Permission violation  | Authority capability does not grant <<w_perm>>, or the AP field could not have been produced by <<ACPERM>>
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
-| Length violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
+| Bounds violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 |==============================================================================
 +
 :!store_cond:

--- a/src/insns/zcmt_cmjalt.adoc
+++ b/src/insns/zcmt_cmjalt.adoc
@@ -50,7 +50,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        |  ✔
 | Permission violation  |  ✔
 | Invalid address violation  |  ✔
-| Length violation      |  ✔
+| Bounds violation      |  ✔
 |==============================================================================
 
 include::pcrel_debug_warning.adoc[]

--- a/src/insns/zcmt_cmjt.adoc
+++ b/src/insns/zcmt_cmjt.adoc
@@ -50,7 +50,7 @@ reported in the CAUSE field of <<mtval>> or <<stval>>:
 | Seal violation        |  ✔
 | Permission violation  |  ✔
 | Invalid address violation  |  ✔
-| Length violation      |  ✔
+| Bounds violation      |  ✔
 |==============================================================================
 
 include::pcrel_debug_warning.adoc[]

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -778,7 +778,7 @@ xref:mtval-cheri-causes[xrefstyle=short] respectively.
 | {cheri_excep_cause_seal}      | Seal violation
 | {cheri_excep_cause_perm}      | Permission violation
 | {cheri_excep_cause_inv_addr}  | Invalid address violation
-| {cheri_excep_cause_length}    | Length violation
+| {cheri_excep_cause_bounds}    | Bounds violation
 | 5-15                          | Reserved
 |==============================================================================
 
@@ -788,7 +788,7 @@ CHERI violations have the following order in priority:
 . Seal violation
 . Permission violation
 . Invalid address violation
-. Length violation (_Lowest_)
+. Bounds violation (_Lowest_)
 
 [#supervisor-level-csrs-section]
 === Supervisor-Level CSRs
@@ -1016,23 +1016,23 @@ NOTE: `auth_cap` is <<ddc>> for {cheri_int_mode_name} and `cs1` for {cheri_cap_m
 | All | {cheri_excep_mcause} | {cheri_excep_type_pcc} | {cheri_excep_cause_seal}     | <<pcc>> seal            | isCapSealed(<<pcc>>)^1^
 | All | {cheri_excep_mcause} | {cheri_excep_type_pcc} | {cheri_excep_cause_perm}     | <<pcc>> permission      | not(<<pcc>>.<<x_perm>>)
 | All | {cheri_excep_mcause} | {cheri_excep_type_pcc} | {cheri_excep_cause_inv_addr} | <<pcc>> invalid address | <<pcc>> holds an invalid address
-| All | {cheri_excep_mcause} | {cheri_excep_type_pcc} | {cheri_excep_cause_length}   | <<pcc>> length          | Any byte of current instruction out of <<pcc>> bounds
+| All | {cheri_excep_mcause} | {cheri_excep_type_pcc} | {cheri_excep_cause_bounds}   | <<pcc>> bounds          | Any byte of current instruction out of <<pcc>> bounds
 6+| *CSR/Xret additional exception check*
 | CSR*, <<MRET>>, <<SRET>> | {cheri_excep_mcause} | {cheri_excep_type_pcc} | {cheri_excep_cause_perm}          | <<pcc>> permission | not(<<pcc>>.<<asr_perm>>) when required for CSR access or execution of <<MRET>>/<<SRET>>
 6+| *direct jumps additional exception check*
-| <<JAL>>, <<insns-conbr-32bit>> | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_length} | <<pcc>> length     | any byte of minimum length instruction at target out of <<pcc>> bounds
+| <<JAL>>, <<insns-conbr-32bit>> | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_bounds} | <<pcc>> bounds     | any byte of minimum length instruction at target out of <<pcc>> bounds
 6+| *indirect jumps additional exception checks*
 | indirect jumps | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_tag}      |`cs1` tag             | not(`cs1.tag`)
 | indirect jumps | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_seal}     |`cs1` seal            | isCapSealed(`cs1`) and imm12 != 0
 | indirect jumps | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_perm}     |`cs1` permission      | not(`cs1`.<<x_perm>>)
 | indirect jumps | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_inv_addr} |`cs1` invalid address | target address is an invalid address
-| indirect jumps | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_length}   |`cs1` length          | any byte of minimum length instruction at target out of `cs1` bounds
+| indirect jumps | {cheri_excep_mcause} | {cheri_excep_type_jump} | {cheri_excep_cause_bounds}   |`cs1` bounds          | any byte of minimum length instruction at target out of `cs1` bounds
 6+| *Load additional exception checks*
 | all loads        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_tag}      | `auth_cap` tag             | not(`auth_cap.tag`)
 | all loads        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_seal}     | `auth_cap` seal            | isCapSealed(`auth_cap`)
 | all loads        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_perm}     | `auth_cap` permission      | not(`auth_cap`.<<r_perm>>)
 | all loads        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_inv_addr} | `auth_cap` invalid address | Address is invalid (see <<section_invalid_addr_conv>>)
-| all loads        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_length}   | `auth_cap` length          | Any byte of load access out of `auth_cap` bounds
+| all loads        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_bounds}   | `auth_cap` bounds          | Any byte of load access out of `auth_cap` bounds
 | capability loads | 4                    | N/A                     | N/A                          | load address misaligned    | Misaligned capability load
 6+| *Store/atomic/cache-block-operation additional exception checks*
 | all stores, all atomics, all cbos              | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_tag}    |`auth_cap` tag        | not(`auth_cap.tag`)
@@ -1041,9 +1041,9 @@ NOTE: `auth_cap` is <<ddc>> for {cheri_int_mode_name} and `cs1` for {cheri_cap_m
 | all stores, all atomics, CBO.INVAL*, CBO.ZERO* | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_perm}   |`auth_cap` permission | not(`auth_cap`.<<w_perm>>)
 | CBO.CLEAN*, CBO.FLUSH*                         | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_perm}   |`auth_cap` permission | not(`auth_cap`.<<r_perm>>) and not(`auth_cap`.<<w_perm>>)
 | all stores, all atomics, all cbos              | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_inv_addr} |`auth_cap` invalid address | Address is invalid (see <<section_invalid_addr_conv>>)
-| all stores, all atomics                        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_length}   |`auth_cap` length          | any byte of access out of `auth_cap` bounds
-| CBO.ZERO*, CBO.INVAL*                          | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_length}   |`auth_cap` length          | any byte of cache block out of `auth_cap` bounds
-| CBO.CLEAN*, CBO.FLUSH*                         | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_length}   |`auth_cap` length          | all bytes of cache block out of `auth_cap` bounds
+| all stores, all atomics                        | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_bounds}   |`auth_cap` bounds          | any byte of access out of `auth_cap` bounds
+| CBO.ZERO*, CBO.INVAL*                          | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_bounds}   |`auth_cap` bounds          | any byte of cache block out of `auth_cap` bounds
+| CBO.CLEAN*, CBO.FLUSH*                         | {cheri_excep_mcause} | {cheri_excep_type_data} | {cheri_excep_cause_bounds}   |`auth_cap` bounds          | all bytes of cache block out of `auth_cap` bounds
 | CBO.INVAL*                                     | {cheri_excep_mcause} | {cheri_excep_type_pcc}  | {cheri_excep_cause_perm}     |<<pcc>> permission         | not(<<pcc>>.<<asr_perm>>)
 | capability stores                              | 6                    | N/A                     | N/A                          |capability alignment       | Misaligned capability store
 |=========================================================================================


### PR DESCRIPTION
This error also applies to access before the start of the capability, so length is not an accurate term, and most existing software already refers to it as a bounds violation.

Fixes: https://github.com/riscv/riscv-cheri/issues/366