### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/img/cap-encoding-xlen32.edn
+++ b/src/img/cap-encoding-xlen32.edn
@@ -1,12 +1,12 @@
 [bytefield]
 ----
-(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 30}])
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 25}])
 (def row-height 80)
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 50 :font-size 26 :labels (reverse ["0" "1" "2" "" "" "" "" "" "" "9" "10" "11" "12" "" "" "" "" "17" "18" "19" "20" "21" "" "" "24" "25" "" "" "" "29" "30" "31"])})
+(draw-column-headers {:height 50 :font-size 22 :labels (reverse ["0" "1" "2" "" "" "" "" "" "" "9" "10" "11" "12" "" "" "" "" "17" "18" "19" "20" "21" "" "" "24" "25" "" "" "" "29" "30" "31"])})
 
 (draw-box "SDP"         {:span 2})
 (draw-box "AP, M"       {:span 5})

--- a/src/img/cap-encoding-xlen64.edn
+++ b/src/img/cap-encoding-xlen64.edn
@@ -1,12 +1,12 @@
 [bytefield]
 ----
-(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 30}])
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 25}])
 (def row-height 80)
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 50 :font-size 26 :labels (reverse ["0" "2" "3" "" "" "" "13" "14" "16" "17" "" "" "25" "26" "27" "28" "" "" "" "" "45" "46" "" "" "51" "52" "53" "56" "57" "" "" "63"])})
+(draw-column-headers {:height 50 :font-size 22 :labels (reverse ["0" "2" "3" "" "" "" "13" "14" "16" "17" "" "" "25" "26" "27" "28" "" "" "" "" "45" "46" "" "" "51" "52" "53" "56" "57" "" "" "63"])})
 
 (draw-box "Reserved"    {:span 4})
 (draw-box "SDP"         {:span 2})

--- a/src/img/sv57pte.edn
+++ b/src/img/sv57pte.edn
@@ -1,6 +1,6 @@
 [bytefield]
 ----
-(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 20}])
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 18}])
 (def row-height 40 )
 (def row-header-fn nil)
 (def left-margin 30)

--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -136,16 +136,6 @@ encodings
     ** Any changes will affect assembly code, but assembler aliases can provide
 backwards compatibility
 
-==== Pending Extensions
-
-The base RISC-V ISAs, along with most extensions, have been reviewed for
-compatibility with CHERI. However, the following extensions are yet to be
-reviewed:
-
-* Core-Local Interrupt Controller (CLIC)
-
-CAUTION: The list above is not complete!
-
 ==== Partially Incompatible Extensions
 
 There are RISC-V extensions in development that may duplicate some aspects of

--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -145,5 +145,3 @@ These include:
 
 * RISC-V CFI specification
 * "J" Pointer Masking
-
-CAUTION: The list above is not complete!

--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -42,7 +42,7 @@ is manipulated, and control its use. This metadata includes:
 between data and capabilities
 * _bounds_ limiting the range of addresses that may be dereferenced
 * _permissions_ controlling the specific operations that may be performed
-* _sealing_ which is used to support higher-level software encapsulation
+* _type_ which is used to support higher-level software encapsulation
 
 The CHERI model is motivated by the _principle of least privilege_, which
 argues that greater security can be obtained by minimizing the privileges


### PR DESCRIPTION
* Change introduction sentence to mention capability types instead of sealing
* Reduce font in some figures to ensure bit field names do not overflow diagram
* Remove "pending extension" section with only CLIC since that is still in development and is generally orthogonal to CHERI

Partially fixes https://github.com/riscv/riscv-cheri/issues/363