### PR TITLE
Indicate GCMODE output for non-X caps

### DIFF
--- a/src/insns/gcmode_32bit.adoc
+++ b/src/insns/gcmode_32bit.adoc
@@ -15,9 +15,10 @@ include::wavedrom/gcmode.adoc[]
 Description::
 Decode the CHERI execution mode from the capability in `cs1` and write the
 result to `rd`. It is not required that `cs1` has its tag set to 1. The output
-in `rd` is 0 if the capability in `cs1` does not have <<x_perm>> set;
-otherwise, the output is {CAP_MODE_VALUE} if `cs1` 's CHERI execution mode is
-{cheri_cap_mode_name} or {INT_MODE_VALUE} if the mode is {cheri_int_mode_name}.
+in `rd` is 0 if the capability in `cs1` does not have <<x_perm>> set or the
+AP field cannot be produced by <<ACPERM>>; otherwise, the output is
+{CAP_MODE_VALUE} if `cs1` 's CHERI execution mode is {cheri_cap_mode_name} or
+{INT_MODE_VALUE} if the mode is {cheri_int_mode_name}.
 
 Exceptions::
 include::require_cre.adoc[]

--- a/src/insns/gcmode_32bit.adoc
+++ b/src/insns/gcmode_32bit.adoc
@@ -13,12 +13,11 @@ Encoding::
 include::wavedrom/gcmode.adoc[]
 
 Description::
-Decode the CHERI execution mode from the capability in `cs1` and write
-the result to `rd`. The output in `rd` is {CAP_MODE_VALUE} if the CHERI
-execution mode of the capability in `cs1` is
-{cheri_cap_mode_name} and {INT_MODE_VALUE} if the mode
-is {cheri_int_mode_name}. It is not required that `cs1`
-has its tag set to 1.
+Decode the CHERI execution mode from the capability in `cs1` and write the
+result to `rd`. It is not required that `cs1` has its tag set to 1. The output
+in `rd` is 0 if the capability in `cs1` does not have <<x_perm>> set;
+otherwise, the output is {CAP_MODE_VALUE} if `cs1` 's CHERI execution mode is
+{cheri_cap_mode_name} or {INT_MODE_VALUE} if the mode is {cheri_int_mode_name}.
 
 Exceptions::
 include::require_cre.adoc[]


### PR DESCRIPTION
Change the specification for GCMODE so that it returns 0 when the input capability goes not have the X permission set.

Fixes https://github.com/riscv/riscv-cheri/issues/376