### PR TITLE
Fix typo in debug integration spec

### DIFF
--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -179,8 +179,8 @@ The reset value is the <<infinite-cap>> capability.
 
 If {cheri_default_ext_name} is implemented:
 
-* The <<m_bit>> is reset to be {cheri_default_ext_name} ({INT_MODE_VALUE}).
-* The debugger can set the <<m_bit>> to {cheri_base_mode_ext} ({CAP_MODE_VALUE}) by executing <<MODESW>> from the program buffer
+* The <<m_bit>> is reset to {cheri_int_mode_name} ({INT_MODE_VALUE}).
+* The debugger can set the <<m_bit>> to {cheri_cap_mode_name} ({CAP_MODE_VALUE}) by executing <<MODESW>> from the program buffer
 ** if <<MODESW>> is not supported in debug mode then the same can be done by reading the CSR, using <<SCMODE>> and then writing the CSR.
 ** This only needs doing once after resetting the core.
 * The <<m_bit>> is used on debug mode entry to determine which CHERI execution mode to enter.


### PR DESCRIPTION
* Fix reference to variable that was not previously define.
* Change use of extension name variable to CHERI mode variable. 