### PR TITLE
Swap roles of xtval and xtval2

### DIFF
--- a/src/hypervisor-integration.adoc
+++ b/src/hypervisor-integration.adoc
@@ -211,9 +211,9 @@ The behavior of <<vstval2>> is the same as for <<stval2>>.
 NOTE: <<vstval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>>
 is.
 
-#.Virtual supervisor trap value register 2
-#[#vstval2-format]
-#include::img/vstval2reg.edn[]
+.Virtual supervisor trap value register 2
+[#vstval2-format]
+include::img/vstval2reg.edn[]
 
 === Existing Hypervisor Load and Store Instructions
 

--- a/src/hypervisor-integration.adoc
+++ b/src/hypervisor-integration.adoc
@@ -169,26 +169,23 @@ include::img/vstdcreg.edn[]
 
 The <<vstval>> register is an SXLEN-bit read-write register.
 
-When a fault is taken into VS-mode <<vstval>> is updated as for <<stval>> for all CHERI exceptions.
+When a fault is taken into VS-mode <<vstval>> is updated as for <<stval>>.
 
 .Virtual supervisor trap value register
 [#vstval-format]
 include::img/vstvalreg.edn[]
 
-
 [#vstval2,reftext="vstval2"]
 === Virtual Supervisor Trap Value Register 2 (vstval2)
 
-The <<vstval2>> register is a VSXLEN-bit read-write register.
+The <<vstval2>> register is a VSXLEN-bit read-write register, which is added as
+part of {cheri_base_ext_name} when the hypervisor extension is supported. Its
+CSR address is 0x24b.
 
-The CSR address is 0x24b.
+When a CHERI fault is taken into VS-mode, <<vstval2>> is updated as for
+<<stval2>>.
 
-When a fault is taken into VS-mode <<vstval2>> is updated as for <<mtval2>> for all CHERI exceptions.
-It is set to zero in all other cases.
-
-NOTE: This is not a standard RISC-V CSR, but <<mtval2>> is. 0x24b is the regular location for the CSR.
-
-<<vstval2>> holds the same set of values that <<stval2>> can hold.
+NOTE: <<vstval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>> is.
 
 .Virtual supervisor trap value register 2
 [#vstval2-format]

--- a/src/hypervisor-integration.adoc
+++ b/src/hypervisor-integration.adoc
@@ -187,9 +187,10 @@ include::img/vstdcreg.edn[]
 [#vstval,reftext="vstval"]
 === Virtual Supervisor Trap Value Register (vstval)
 
-The <<vstval>> register is an SXLEN-bit read-write register.
+The <<vstval>> register is a VSXLEN-bit read-write register.
 
-When a fault is taken into VS-mode <<vstval>> is updated as for <<stval>>.
+<<vstval>> is updated following the same rules as <<mtval>> for CHERI exceptions
+which are taken in VS-mode.
 
 .Virtual supervisor trap value register
 [#vstval-format]
@@ -207,8 +208,7 @@ which are taken in VS-mode.
 
 The fields are identical to <<mtval2>> for CHERI exceptions.
 
-NOTE: <<vstval2>> is not a standard RISC-V CSR, but <<mtval2>>
-is.
+NOTE: <<vstval2>> is not a standard RISC-V CSR, but <<mtval2>> is.
 
 .Virtual supervisor trap value register 2
 [#vstval2-format]

--- a/src/hypervisor-integration.adoc
+++ b/src/hypervisor-integration.adoc
@@ -54,10 +54,9 @@ The reset value is 0.
 === Hypervisor Trap Value Register (htval)
 
 The <<htval>> register operates as described in cite:[riscv-priv-spec].
-Additionally, when a data memory access gives rise to a CHERI fault taken into
-HS-mode, <<htval>> is either zero or written with the HSXLEN-bit
-effective address which caused the fault according to the existing rules for
-reporting load/store addresses from cite:[riscv-priv-spec].
+
+<<htval>> is updated following the same rules as <<mtval>> for CHERI exceptions
+which are taken in HS-mode.
 
 .Hypervisor trap value register
 include::img/htvalreg.edn[]
@@ -69,12 +68,12 @@ The <<htval2>> register is an HSXLEN-bit read-write register, which is added as
 part of {cheri_base_ext_name} when the hypervisor extension is supported. Its
 CSR address is 0x64b.
 
-When a CHERI fault is taken into HS-mode, <<htval2>> is either zero or written
-with additional CHERI-specific exception information with the format shown in
-xref:hstval2-format[xrefstyle=short] to assist software in handling the trap.
-The behavior of <<htval2>> is the same as for <<stval2>>.
+<<htval2>> is updated following the same rules as <<mtval2>> for CHERI exceptions
+which are taken in HS-mode.
 
-NOTE: <<htval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>>
+The fields are identical to <<mtval2>> for CHERI exceptions.
+
+NOTE: <<htval2>> is not a standard RISC-V CSR, but <<mtval2>>
 is.
 
 .Hypervisor trap value register 2
@@ -203,12 +202,12 @@ The <<vstval2>> register is a VSXLEN-bit read-write register, which is added as
 part of {cheri_base_ext_name} when the hypervisor extension is supported. Its
 CSR address is 0x24b.
 
-When a CHERI fault is taken into VS-mode, <<vstval2>> is either zero or written
-with additional CHERI-specific exception information with the format shown in
-xref:vstval2-format[xrefstyle=short] to assist software in handling the trap.
-The behavior of <<vstval2>> is the same as for <<stval2>>.
+<<vstval2>> is updated following the same rules as <<mtval2>> for CHERI exceptions
+which are taken in VS-mode.
 
-NOTE: <<vstval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>>
+The fields are identical to <<mtval2>> for CHERI exceptions.
+
+NOTE: <<vstval2>> is not a standard RISC-V CSR, but <<mtval2>>
 is.
 
 .Virtual supervisor trap value register 2

--- a/src/hypervisor-integration.adoc
+++ b/src/hypervisor-integration.adoc
@@ -54,11 +54,32 @@ The reset value is 0.
 === Hypervisor Trap Value Register (htval)
 
 The <<htval>> register operates as described in cite:[riscv-priv-spec].
-Additionally, <<htval>> may be written with the exception codes described in
-xref:mtval[xrefstyle=short] when a CHERI exception occurs.
+Additionally, when a data memory access gives rise to a CHERI fault taken into
+HS-mode, <<htval>> is either zero or written with the HSXLEN-bit
+effective address which caused the fault according to the existing rules for
+reporting load/store addresses from cite:[riscv-priv-spec].
 
 .Hypervisor trap value register
 include::img/htvalreg.edn[]
+
+[#htval2,reftext="htval2"]
+=== Hypervisor Trap Value Register 2 (htval2)
+
+The <<htval2>> register is an HSXLEN-bit read-write register, which is added as
+part of {cheri_base_ext_name} when the hypervisor extension is supported. Its
+CSR address is 0x64b.
+
+When a CHERI fault is taken into HS-mode, <<htval2>> is either zero or written
+with additional CHERI-specific exception information with the format shown in
+xref:hstval2-format[xrefstyle=short] to assist software in handling the trap.
+The behavior of <<htval2>> is the same as for <<stval2>>.
+
+NOTE: <<htval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>>
+is.
+
+.Hypervisor trap value register 2
+[#hstval2-format]
+include::img/htval2reg.edn[]
 
 [#vsstatus,reftext="vsstatus"]
 === Virtual Supervisor Status Register (vsstatus)
@@ -182,14 +203,17 @@ The <<vstval2>> register is a VSXLEN-bit read-write register, which is added as
 part of {cheri_base_ext_name} when the hypervisor extension is supported. Its
 CSR address is 0x24b.
 
-When a CHERI fault is taken into VS-mode, <<vstval2>> is updated as for
-<<stval2>>.
+When a CHERI fault is taken into VS-mode, <<vstval2>> is either zero or written
+with additional CHERI-specific exception information with the format shown in
+xref:vstval2-format[xrefstyle=short] to assist software in handling the trap.
+The behavior of <<vstval2>> is the same as for <<stval2>>.
 
-NOTE: <<vstval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>> is.
+NOTE: <<vstval2>> and <<stval2>> are not standard RISC-V CSRs, but <<mtval2>>
+is.
 
-.Virtual supervisor trap value register 2
-[#vstval2-format]
-include::img/vstval2reg.edn[]
+#.Virtual supervisor trap value register 2
+#[#vstval2-format]
+#include::img/vstval2reg.edn[]
 
 === Existing Hypervisor Load and Store Instructions
 

--- a/src/img/htval2reg.edn
+++ b/src/img/htval2reg.edn
@@ -1,0 +1,20 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
+(def row-height 40)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "HSXLEN-1"])})
+
+(draw-box "Reserved"   {:span 12})
+(draw-box "TYPE"       {:span 4})
+(draw-box "Reserved"   {:span 12})
+(draw-box "CAUSE"      {:span 4})
+
+(draw-box "HSXLEN-20" {:span 12 :borders {}})
+(draw-box "4"        {:span 4 :borders {}})
+(draw-box "12"       {:span 12 :borders {}})
+(draw-box "4"        {:span 4 :borders {}})
+----

--- a/src/img/htvalreg.edn
+++ b/src/img/htvalreg.edn
@@ -1,16 +1,14 @@
 [bytefield]
 ----
-(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 21}])
-(def row-height 40 )
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 24}])
+(def row-height 40)
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "HSXLEN-1"])})
 
-(draw-box "HSXLEN-1" {:span 31 :text-anchor "start" :borders {}})
-(draw-box "0" {:borders {}})
-
-(draw-box "htval" {:font-size 20 :span 32})
+(draw-box "htval"   {:span 32})
 
 (draw-box "HSXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/mtval2reg.edn
+++ b/src/img/mtval2reg.edn
@@ -6,9 +6,15 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
 
-(draw-box "Addr"   {:span 32})
+(draw-box "Reserved"   {:span 12})
+(draw-box "TYPE"       {:span 4})
+(draw-box "Reserved"   {:span 12})
+(draw-box "CAUSE"      {:span 4})
 
-(draw-box "MXLEN" {:span 32 :borders {}})
+(draw-box "MXLEN-20" {:span 12 :borders {}})
+(draw-box "4"        {:span 4 :borders {}})
+(draw-box "12"       {:span 12 :borders {}})
+(draw-box "4"        {:span 4 :borders {}})
 ----

--- a/src/img/mtvalreg.edn
+++ b/src/img/mtvalreg.edn
@@ -6,15 +6,9 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
-(draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
-(draw-box "CAUSE"      {:span 4})
+(draw-box "mtval"   {:span 32})
 
-(draw-box "MXLEN-20" {:span 12 :borders {}})
-(draw-box "4"        {:span 4 :borders {}})
-(draw-box "12"       {:span 12 :borders {}})
-(draw-box "4"        {:span 4 :borders {}})
+(draw-box "MXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/stval2reg.edn
+++ b/src/img/stval2reg.edn
@@ -6,9 +6,15 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
 
-(draw-box "Addr"   {:span 32})
+(draw-box "Reserved"   {:span 12})
+(draw-box "TYPE"       {:span 4})
+(draw-box "Reserved"   {:span 12})
+(draw-box "CAUSE"      {:span 4})
 
-(draw-box "SXLEN" {:span 32 :borders {}})
+(draw-box "SXLEN-20" {:span 12 :borders {}})
+(draw-box "4"        {:span 4 :borders {}})
+(draw-box "12"       {:span 12 :borders {}})
+(draw-box "4"        {:span 4 :borders {}})
 ----

--- a/src/img/stvalreg.edn
+++ b/src/img/stvalreg.edn
@@ -6,15 +6,9 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
-(draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
-(draw-box "CAUSE"      {:span 4})
+(draw-box "stval"   {:span 32})
 
-(draw-box "SXLEN-20" {:span 12 :borders {}})
-(draw-box "4"        {:span 4 :borders {}})
-(draw-box "12"       {:span 12 :borders {}})
-(draw-box "4"        {:span 4 :borders {}})
+(draw-box "SXLEN" {:span 32 :borders {}})
 ----

--- a/src/img/vstval2reg.edn
+++ b/src/img/vstval2reg.edn
@@ -6,9 +6,15 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1"])})
 
-(draw-box "Addr"   {:span 32})
+(draw-box "Reserved"   {:span 12})
+(draw-box "TYPE"       {:span 4})
+(draw-box "Reserved"   {:span 12})
+(draw-box "CAUSE"      {:span 4})
 
-(draw-box "VSXLEN" {:span 32 :borders {}})
+(draw-box "VSXLEN-20" {:span 12 :borders {}})
+(draw-box "4"         {:span 4 :borders {}})
+(draw-box "12"        {:span 12 :borders {}})
+(draw-box "4"         {:span 4 :borders {}})
 ----

--- a/src/img/vstvalreg.edn
+++ b/src/img/vstvalreg.edn
@@ -6,15 +6,9 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 32)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1"])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
-(draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
-(draw-box "CAUSE"      {:span 4})
+(draw-box "vstval"   {:span 32})
 
-(draw-box "VSXLEN-20" {:span 12 :borders {}})
-(draw-box "4"         {:span 4 :borders {}})
-(draw-box "12"        {:span 12 :borders {}})
-(draw-box "4"         {:span 4 :borders {}})
+(draw-box "VSXLEN" {:span 32 :borders {}})
 ----

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -20,7 +20,7 @@ All misaligned atomics cause a store/AMO address misaligned exception to allow s
 +
 When these instructions cause CHERI exceptions, _CHERI data fault_
 is reported in the TYPE field and the following codes may be
-reported in the CAUSE field of <<mtval>> or <<stval>>:
+reported in the CAUSE field of <<mtval2>> or <<stval2>>:
 
 <<<
 

--- a/src/insns/cbo_exceptions.adoc
+++ b/src/insns/cbo_exceptions.adoc
@@ -1,7 +1,7 @@
 Exceptions::
 CHERI fault exceptions when the authorising capability fails one of the checks
-listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
-<<stval>> TYPE field and the corresponding code is written to CAUSE.
+listed below; in this case, _CHERI data fault_ is reported in the <<mtval2>> or
+<<stval2>> TYPE field and the corresponding code is written to CAUSE.
 +
 ifdef::cbo_inval[]
 The CBIE bit in <<menvcfg>> and <<senvcfg>> indicates whether

--- a/src/insns/condbr_common.adoc
+++ b/src/insns/condbr_common.adoc
@@ -2,4 +2,4 @@ Exceptions::
 When the target address is not within the <<pcc>>'s bounds, and the branch is taken,
 a _CHERI jump or
 branch fault_ is reported in the TYPE field and Bounds violation is reported in
-the CAUSE field of <<mtval>> or <<stval>>:
+the CAUSE field of <<mtval2>> or <<stval2>>:

--- a/src/insns/hypv-virt-loadx.adoc
+++ b/src/insns/hypv-virt-loadx.adoc
@@ -42,8 +42,8 @@ to `rd`.
 
 Exceptions::
 CHERI fault exception when the authorising capability fails one of the checks
-listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
-<<stval>> TYPE field and the corresponding code is written to CAUSE.
+listed below; in this case, _CHERI data fault_ is reported in the <<mtval2>> or
+<<stval2>> TYPE field and the corresponding code is written to CAUSE.
 +
 [%autowidth,options=header,align=center]
 |==============================================================================

--- a/src/insns/jalr_32bit.adoc
+++ b/src/insns/jalr_32bit.adoc
@@ -44,7 +44,7 @@ instruction following the jump is written to `rd`.
 Exceptions::
 When these instructions cause CHERI exceptions, _CHERI jump or branch fault_
 is reported in the TYPE field and the following codes may be
-reported in the CAUSE field of <<mtval>> or <<stval>>:
+reported in the CAUSE field of <<mtval2>> or <<stval2>>:
 
 [%autowidth,options=header,align=center]
 |==============================================================================

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -9,8 +9,8 @@ to CLEN/8.
 +
 endif::[]
 CHERI fault exception when the authorising capability fails one of the checks
-listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
-<<stval>> TYPE field and the corresponding code is written to CAUSE.
+listed below; in this case, _CHERI data fault_ is reported in the <<mtval2>> or
+<<stval2>> TYPE field and the corresponding code is written to CAUSE.
 +
 [%autowidth,options=header,align=center]
 |==============================================================================

--- a/src/insns/mret_sret.adoc
+++ b/src/insns/mret_sret.adoc
@@ -27,8 +27,8 @@ Exceptions::
 CHERI fault exceptions occur when <<pcc>> does not grant <<asr_perm>> because
 <<MRET>> and <<SRET>> require access to privileged CSRs. When that exception
 occurs, _CHERI instruction access fault_ is reported in the TYPE field and the
-Permission violation code is reported in the CAUSE field of <<mtval>> or
-<<stval>>.
+Permission violation code is reported in the CAUSE field of <<mtval2>> or
+<<stval2>>.
 
 Operation::
 [source,SAIL,subs="verbatim,quotes"]

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -9,8 +9,8 @@ to CLEN/8.
 +
 endif::[]
 CHERI fault exception when the authorising capability fails one of the checks
-listed below; in this case, _CHERI data fault_ is reported in the <<mtval>> or
-<<stval>> TYPE field and the corresponding code is written to CAUSE.
+listed below; in this case, _CHERI data fault_ is reported in the <<mtval2>> or
+<<stval2>> TYPE field and the corresponding code is written to CAUSE.
 +
 [%autowidth,options=header,align=center]
 |==============================================================================

--- a/src/insns/zcmt_cmjalt.adoc
+++ b/src/insns/zcmt_cmjalt.adoc
@@ -41,7 +41,7 @@ Requires <<jvtc>> to be tagged, not sealed, have <<x_perm>> and for the full XLE
 {cheri_cap_mode_name} Exceptions::
 When these instructions cause CHERI exceptions, _CHERI instruction access fault_
 is reported in the TYPE field and the following codes may be
-reported in the CAUSE field of <<mtval>> or <<stval>>:
+reported in the CAUSE field of <<mtval2>> or <<stval2>>:
 
 [width="50%",options=header,cols="2,^1",align=center]
 |==============================================================================

--- a/src/insns/zcmt_cmjt.adoc
+++ b/src/insns/zcmt_cmjt.adoc
@@ -41,7 +41,7 @@ Requires <<jvtc>> to be tagged, not sealed, have <<x_perm>> and for the full XLE
 {cheri_cap_mode_name} Exceptions::
 When these instructions cause CHERI exceptions, _CHERI instruction access fault_
 is reported in the TYPE field and the following codes may be
-reported in the CAUSE field of <<mtval>> or <<stval>>:
+reported in the CAUSE field of <<mtval2>> or <<stval2>>:
 
 [width="50%",options=header,cols="2,^1",align=center]
 |==============================================================================

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -744,25 +744,46 @@ WARNING: *CHERI v9 Note:* Encoding and values changed, and generally were
 simplified.
 endif::[]
 
-The <<mtval>> register is an MXLEN-bit read-write register. When a CHERI fault
-is taken into M-mode, <<mtval>> is written with additional CHERI-specific
-exception information with the format shown in
-xref:mtval-format[xrefstyle=short] to assist software in handling the trap.
+The <<mtval>> register is an MXLEN-bit read-write register formatted as shown
+in xref:mtval-format[xrefstyle=short]. When a data memory access gives rise to
+a CHERI fault taken into M-mode, <<mtval>> is either zero or written with the
+MXLEN-bit effective address which caused the fault according to the existing
+rules for reporting load/store addresses from cite:[riscv-priv-spec].
 
-If the hardware platform specifies that no exceptions set <<mtval>> to a
-nonzero value, then <<mtval>> is read-only zero.
+The behavior of <<mtval>> is otherwise as described in cite:[riscv-priv-spec].
 
 .Machine trap value register
 [#mtval-format]
 include::img/mtvalreg.edn[]
 
+[#mtval2,reftext="mtval2"]
+==== Machine Trap Value Register 2 (mtval2)
+
+ifdef::cheri_v9_annotations[]
+WARNING: *CHERI v9 Note:* This CSR was not part of CHERIv9.
+endif::[]
+
+The <<mtval2>> register is an MXLEN-bit read-write register, which is added as part of the
+Hypervisor extension cite:[riscv-priv-spec]. {cheri_base_ext_name} also requires the implementation of this CSR.
+
+When a CHERI fault is taken into M-mode, <<mtval2>> is either zero or written
+with additional CHERI-specific exception information with the format shown in
+xref:mtval2-format[xrefstyle=short] to assist software in handling the trap.
+
+If the hardware platform specifies that no exceptions set <<mtval2>> to a
+nonzero value, then <<mtval2>> is read-only zero.
+
+.Machine trap value register 2
+[#mtval2-format]
+include::img/mtval2reg.edn[]
+
 TYPE is a CHERI-specific fault type that caused the exception while CAUSE
 is the cause of the fault. The possible CHERI types and causes are encoded as
-shown in xref:mtval-cheri-type[xrefstyle=short] and
-xref:mtval-cheri-causes[xrefstyle=short] respectively.
+shown in xref:mtval2-cheri-type[xrefstyle=short] and
+xref:mtval2-cheri-causes[xrefstyle=short] respectively.
 
 .Encoding of TYPE field
-[#mtval-cheri-type,width=65%,float="center",align="center",options=header,cols="30%,70%"]
+[#mtval2-cheri-type,width=65%,float="center",align="center",options=header,cols="30%,70%"]
 |==============================================================================
 | CHERI Type Code           | Description
 | {cheri_excep_type_pcc}    | CHERI instruction access fault
@@ -772,7 +793,7 @@ xref:mtval-cheri-causes[xrefstyle=short] respectively.
 |==============================================================================
 
 .Encoding of CAUSE field
-[#mtval-cheri-causes,width=55%,float="center",align="center",options=header]
+[#mtval2-cheri-causes,width=55%,float="center",align="center",options=header]
 |==============================================================================
 | CHERI Cause Code              | Description
 | {cheri_excep_cause_tag}       | Tag violation
@@ -790,24 +811,6 @@ CHERI violations have the following order in priority:
 . Permission violation
 . Invalid address violation
 . Bounds violation (_Lowest_)
-
-[#mtval2,reftext="mtval2"]
-==== Machine Trap Value Register 2 (mtval2)
-
-The <<mtval2>> register is an MXLEN-bit read-write register, which is added as part of the
-Hypervisor extension. {cheri_base_ext_name} also requires the implementation of this CSR.
-
-When a CHERI fault is taken on any data memory access into into M-mode, <<mtval2>> is written
-with the MXLEN-bit effective address which caused the fault. This follows the existing rules for reporting
-load/store addresses to <<mtval>> from cite:[riscv-priv-spec].
-
-<<mtval2>> is set to zero for all other CHERI exceptions, and follows the standard rules for non-CHERI exceptions.
-
-If <<mtval>> is read-only-zero then <<mtval2>> is also read-only-zero.
-
-.Machine trap value register 2
-[#mtval2-format]
-include::img/mtval2reg.edn[]
 
 [#supervisor-level-csrs-section]
 === Supervisor-Level CSRs
@@ -1002,30 +1005,34 @@ _Reserved_
 [#stval,reftext="stval"]
 ==== Supervisor Trap Value Register (stval)
 
-The <<stval>> register is an SXLEN-bit read-write register. When a CHERI fault
-is taken into S-mode, <<stval>> is written with additional CHERI-specific
-exception information with the format shown in
-xref:stval-format[xrefstyle=short] to assist software in handling the trap.
+The <<stval>> register is an SXLEN-bit read-write register formatted as shown
+in xref:stval-format[xrefstyle=short]. When a data memory access gives rise to
+a CHERI fault taken into S-mode, <<stval>> is either zero or written with the
+SXLEN-bit effective address which caused the fault according to the existing
+rules for reporting load/store addresses from cite:[riscv-priv-spec].
 
 .Supervisor trap value register
 [#stval-format]
 include::img/stvalreg.edn[]
 
-The fields are identical to <<mtval>> for CHERI exceptions.
-
 [#stval2,reftext="stval2"]
 ==== Supervisor Trap Value Register 2 (stval2)
 
-The <<stval2>> register is an SXLEN-bit read-write register.
+The <<stval2>> register is an SXLEN-bit read-write register, which is added as
+part of {cheri_base_ext_name} when the implementation supports S-mode. Its CSR
+address is 0x14b.
 
-The CSR address is 0x24b.
+When a CHERI fault is taken into S-mode, <<stval2>> is either zero or written
+with additional CHERI-specific exception information with the format shown in
+xref:stval2-format[xrefstyle=short] to assist software in handling the trap.
+<<stval2>> is set to zero in all other cases.
 
-When a fault is taken into S-mode <<stval2>> is updated as for <<mtval2>> for all CHERI exceptions.
-It is set to zero in all other cases.
+If the hardware platform specifies that no exceptions set <<stval2>> to a
+nonzero value, then <<stval2>> is read-only zero.
 
-NOTE: This is not a standard RISC-V CSR, but <<mtval2>> is. 0x14b is the regular location for the CSR.
+The fields are idential to <<mtval2>> for CHERI exceptions.
 
-<<stval2>> holds the same set of values that <<mtval2>> can hold.
+NOTE: <<stval2>> is not a standard RISC-V CSR, but <<mtval2>> is.
 
 .Supervisor trap value register 2
 [#stval2-format]

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1011,7 +1011,7 @@ _Reserved_
 ==== Supervisor Trap Value Register (stval)
 
 The <<stval>> register is an SXLEN-bit read-write register formatted as shown
-in xref:stval-format[xrefstyle=short]. 
+in xref:stval-format[xrefstyle=short].
 
 <<stval>> is updated following the same rules as <<mtval>> for CHERI exceptions
 which are delegated to S-mode.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1204,8 +1204,8 @@ the instruction's behavior.
 . If T is invalid and A does not have infinite bounds (see
 xref:section_cap_encoding[xrefstyle=short]), then the instruction gives rise to
 a CHERI fault; the _CHERI jump or branch_ fault is reported in the TYPE field
-and invalid address violation is reported in the CAUSE field of <<mtval>> or
-<<stval>>.
+and invalid address violation is reported in the CAUSE field of <<mtval2>> or
+<<stval2>>.
 . If T is invalid and A has infinite bounds (see
 xref:section_cap_encoding[xrefstyle=short]), then A's tag is unchanged and T is
 written into A's address field. Attempting to execute the instruction at
@@ -1229,7 +1229,7 @@ instruction's behavior.
 . If any byte in R is invalid and A does not have infinite bounds (see
 xref:section_cap_encoding[xrefstyle=short]), then the instruction gives rise to
 a CHERI fault; the _CHERI data_ fault is reported in the TYPE field and invalid
-address violation is reported in the CAUSE field of <<mtval>> or <<stval>>.
+address violation is reported in the CAUSE field of <<mtval2>> or <<stval2>>.
 . If any byte in R is invalid and A has infinite bounds (see xref:section_cap_encoding[xrefstyle=short]),
 the hart will raise an access fault or page fault as is usual in RISC-V.
 . Otherwise all bytes in R are valid and the instruction behaves as normal.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -746,11 +746,16 @@ endif::[]
 
 The <<mtval>> register is an MXLEN-bit read-write register formatted as shown
 in xref:mtval-format[xrefstyle=short]. When a data memory access gives rise to
-a CHERI fault taken into M-mode, <<mtval>> is either zero or written with the
+a CHERI fault taken into M-mode, <<mtval>> is either written with the
 MXLEN-bit effective address which caused the fault according to the existing
-rules for reporting load/store addresses from cite:[riscv-priv-spec].
+rules for reporting load/store addresses from cite:[riscv-priv-spec] when
+TYPE field of <<mtval2>> shown in xref:mtval2-cheri-type[xrefstyle=short] is
+set to {cheri_excep_type_data}. For all other CHERI faults it is set to zero.
 
 The behavior of <<mtval>> is otherwise as described in cite:[riscv-priv-spec].
+
+If the hardware platform specifies that no exceptions set <<mtval>> to a
+nonzero value, then <<mtval>> is read-only zero.
 
 .Machine trap value register
 [#mtval-format]
@@ -766,12 +771,9 @@ endif::[]
 The <<mtval2>> register is an MXLEN-bit read-write register, which is added as part of the
 Hypervisor extension cite:[riscv-priv-spec]. {cheri_base_ext_name} also requires the implementation of this CSR.
 
-When a CHERI fault is taken into M-mode, <<mtval2>> is either zero or written
+When a CHERI fault is taken into M-mode, <<mtval2>> written
 with additional CHERI-specific exception information with the format shown in
 xref:mtval2-format[xrefstyle=short] to assist software in handling the trap.
-
-If the hardware platform specifies that no exceptions set <<mtval2>> to a
-nonzero value, then <<mtval2>> is read-only zero.
 
 .Machine trap value register 2
 [#mtval2-format]

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -771,7 +771,7 @@ endif::[]
 The <<mtval2>> register is an MXLEN-bit read-write register, which is added as part of the
 Hypervisor extension cite:[riscv-priv-spec]. {cheri_base_ext_name} also requires the implementation of this CSR.
 
-When a CHERI fault is taken into M-mode, <<mtval2>> written
+When a CHERI fault is taken into M-mode, <<mtval2>> is written
 with additional CHERI-specific exception information with the format shown in
 xref:mtval2-format[xrefstyle=short] to assist software in handling the trap.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -755,7 +755,7 @@ set to {cheri_excep_type_data}. For all other CHERI faults it is set to zero.
 The behavior of <<mtval>> is otherwise as described in cite:[riscv-priv-spec].
 
 If the hardware platform specifies that no exceptions set <<mtval>> to a
-nonzero value, then <<mtval>> is read-only zero.
+non-zero value, then <<mtval>> is read-only zero for all CHERI exceptions.
 
 .Machine trap value register
 [#mtval-format]
@@ -774,6 +774,9 @@ Hypervisor extension cite:[riscv-priv-spec]. {cheri_base_ext_name} also requires
 When a CHERI fault is taken into M-mode, <<mtval2>> written
 with additional CHERI-specific exception information with the format shown in
 xref:mtval2-format[xrefstyle=short] to assist software in handling the trap.
+
+If <<mtval>> is read-only zero for CHERI exceptions then <<mtval2>> is also read-only zero
+for CHERI exceptions.
 
 .Machine trap value register 2
 [#mtval2-format]
@@ -1008,10 +1011,10 @@ _Reserved_
 ==== Supervisor Trap Value Register (stval)
 
 The <<stval>> register is an SXLEN-bit read-write register formatted as shown
-in xref:stval-format[xrefstyle=short]. When a data memory access gives rise to
-a CHERI fault taken into S-mode, <<stval>> is either zero or written with the
-SXLEN-bit effective address which caused the fault according to the existing
-rules for reporting load/store addresses from cite:[riscv-priv-spec].
+in xref:stval-format[xrefstyle=short]. 
+
+<<stval>> is updated following the same rules as <<mtval>> for CHERI exceptions
+which are delegated to S-mode.
 
 .Supervisor trap value register
 [#stval-format]
@@ -1024,15 +1027,10 @@ The <<stval2>> register is an SXLEN-bit read-write register, which is added as
 part of {cheri_base_ext_name} when the implementation supports S-mode. Its CSR
 address is 0x14b.
 
-When a CHERI fault is taken into S-mode, <<stval2>> is either zero or written
-with additional CHERI-specific exception information with the format shown in
-xref:stval2-format[xrefstyle=short] to assist software in handling the trap.
-<<stval2>> is set to zero in all other cases.
+<<stval2>> is updated following the same rules as <<mtval2>> for CHERI exceptions
+which are delegated to S-mode.
 
-If the hardware platform specifies that no exceptions set <<stval2>> to a
-nonzero value, then <<stval2>> is read-only zero.
-
-The fields are idential to <<mtval2>> for CHERI exceptions.
+The fields are identical to <<mtval2>> for CHERI exceptions.
 
 NOTE: <<stval2>> is not a standard RISC-V CSR, but <<mtval2>> is.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -746,10 +746,10 @@ endif::[]
 
 The <<mtval>> register is an MXLEN-bit read-write register formatted as shown
 in xref:mtval-format[xrefstyle=short]. When a data memory access gives rise to
-a CHERI fault taken into M-mode, <<mtval>> is either written with the
+a CHERI fault taken into M-mode, <<mtval>> is written with the
 MXLEN-bit effective address which caused the fault according to the existing
-rules for reporting load/store addresses from cite:[riscv-priv-spec] when
-TYPE field of <<mtval2>> shown in xref:mtval2-cheri-type[xrefstyle=short] is
+rules for reporting load/store addresses from cite:[riscv-priv-spec]. In this case
+the TYPE field of <<mtval2>> shown in xref:mtval2-cheri-type[xrefstyle=short] is
 set to {cheri_excep_type_data}. For all other CHERI faults it is set to zero.
 
 The behavior of <<mtval>> is otherwise as described in cite:[riscv-priv-spec].


### PR DESCRIPTION
Swap the roles of xtval and xtval2 such that xtval holds the address on a CHERI fault and xtval2 holds the extra CHERI cause and type information for the exception. The following also had to change along the way:

* Update old references to xtval that must now point to xtval2
* Add `htval2` because otherwise we do not get any CHERI information in HS-mode
* Adjust diagrams and descriptions for xtval and xtval2

This PR is a follow up to https://github.com/riscv/riscv-cheri/pull/373