### PR TITLE
remove false comments from RV32 permission encoding table

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -194,13 +194,13 @@ Quadrant 1 encodes permissions for executable capabilities and the <<m_bit>>.
 | 4-5   | ✔ | ✔ | ✔ | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RW
 | 6-7   | ✔ | ✔ |   |   | ✔ |     | Mode^1^  | Execute + Data RW
 9+| *Quadrant 2: Restricted capability data read/write*
-9+| bit[2] - write. R and C implicitly granted, LM dependent on W permission.
+9+| R and C implicitly granted, LM dependent on W permission.
 9+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
 | 0-2   8+| reserved
 | 3       | ✔ |   | ✔ |   |   |     | N/A | Data & Cap RO (no LM)
 | 4-7   8+| reserved
 9+| *Quadrant 3: Capability data read/write*
-9+| [2] - write. R and C implicitly granted.
+9+| R and C implicitly granted.
 9+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
 | 0-2   8+| reserved
 | 3       | ✔ |   | ✔ | ✔ |   |     | N/A | Data & Cap RO

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -196,11 +196,12 @@ Quadrant 1 encodes permissions for executable capabilities and the <<m_bit>>.
 9+| *Quadrant 2: Restricted capability data read/write*
 9+| R and C implicitly granted, LM dependent on W permission.
 9+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
+9+| _bit[2] is reserved to mean write for future encodings_
 | 0-2   8+| reserved
 | 3       | ✔ |   | ✔ |   |   |     | N/A | Data & Cap RO (no LM)
 | 4-7   8+| reserved
 9+| *Quadrant 3: Capability data read/write*
-9+| R and C implicitly granted.
+9+| bit[2] - write, R and C implicitly granted.
 9+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
 | 0-2   8+| reserved
 | 3       | ✔ |   | ✔ | ✔ |   |     | N/A | Data & Cap RO


### PR DESCRIPTION
quadrants 2 and 3 has a false comment copy/pasted from quadrant 0 most likely