### PR TITLE
optionally simplify lm_perm

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -137,8 +137,7 @@ If a capability grants <<r_perm>> and <<c_perm>>, but no <<lm_perm>>, then a cap
 The rules specified by <<ACPERM>> are followed when <<w_perm>> and <<lm_perm>> are removed, so additional permissions may also be removed.
 Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure (e.g. a tree or linked list) without making a copy.
 
-NOTE: Implementations are allowed to propagate, but not alter, reserved permissions when performing the <<lm_perm>> check on a tagged loaded capability, which means a different rule to <<ACPERM>>.
- This simplifies the number of cases handled by the implementation as it's not required to remove _all_ permissions.
+NOTE: Implementations are allowed to retain invalid capabilities loaded from memory instead of reducing them to _no permissions_ by using <<ACPERM>> behaviour.
 
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -137,7 +137,7 @@ If a capability grants <<r_perm>> and <<c_perm>>, but no <<lm_perm>>, then a cap
 The rules specified by <<ACPERM>> are followed when <<w_perm>> and <<lm_perm>> are removed, so additional permissions may also be removed.
 Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure (e.g. a tree or linked list) without making a copy.
 
-NOTE: Implementations are allowed to retain invalid capabilities loaded from memory instead of reducing them to _no permissions_ by using <<ACPERM>> behaviour.
+NOTE: Implementations are allowed to retain invalid capability permissions loaded from memory instead of following the <<ACPERM>> behaviour of reducing them to _no permissions_.
 
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -137,6 +137,9 @@ If a capability grants <<r_perm>> and <<c_perm>>, but no <<lm_perm>>, then a cap
 The rules specified by <<ACPERM>> are followed when <<w_perm>> and <<lm_perm>> are removed, so additional permissions may also be removed.
 Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure (e.g. a tree or linked list) without making a copy.
 
+NOTE: Implementations are allowed to propagate, but not alter, reserved permissions when performing <<lm_perm>> check on a loaded capability.
+ This simplifies the number of cases handled by the implementation as it's a choice whether to remove _all_ permissions.
+
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all
 privileged (M-mode and S-mode) CSRs.

--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -137,8 +137,8 @@ If a capability grants <<r_perm>> and <<c_perm>>, but no <<lm_perm>>, then a cap
 The rules specified by <<ACPERM>> are followed when <<w_perm>> and <<lm_perm>> are removed, so additional permissions may also be removed.
 Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure (e.g. a tree or linked list) without making a copy.
 
-NOTE: Implementations are allowed to propagate, but not alter, reserved permissions when performing <<lm_perm>> check on a loaded capability.
- This simplifies the number of cases handled by the implementation as it's a choice whether to remove _all_ permissions.
+NOTE: Implementations are allowed to propagate, but not alter, reserved permissions when performing the <<lm_perm>> check on a tagged loaded capability, which means a different rule to <<ACPERM>>.
+ This simplifies the number of cases handled by the implementation as it's not required to remove _all_ permissions.
 
 [#asr_perm,reftext="ASR-permission"]
 Access System Registers Permission (ASR):: Allow read and write access to all


### PR DESCRIPTION
LM permission adds 4 cases to RV32:

output R
output RC
output original permissions
output no permissions (reserved cases only)

This note allows the implementation to propagate reserved permissions through ACPERM for improved timing in the design.
The reserved permissions cannot be used for dereferencing, and so this does not cause a security problem.

It's just an implementation defined note - no spec change (it's also ok to clear the permissions).
