### PR TITLE
Add table and notes about CRE

### DIFF
--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -358,9 +358,16 @@ checks.  The last capability installed in <<pcc>> and <<ddc>> before disabling
 CHERI register access will be used to authorise instruction execution and data
 memory accesses.
 
-NOTE: Disabling CHERI register access prevents low-privileged {cheri_int_mode_name} software
+[NOTE]
+====
+Disabling CHERI register access prevents low-privileged {cheri_int_mode_name} software
 from interfering with the correct operation of higher-privileged {cheri_int_mode_name} software
 that do not perform <<ddc>> switches on trap entry and return.
+
+Disable CHERI register access also allows harts supporting CHERI to be fully
+compatible with standard RISC-V, so CHERI instructions, such as <<CRAM>>, that
+do not change the state of CHERI CSRs raise exceptions when CRE=0.
+====
 
 NOTE: xref:cheri_behavior_cre_mode[xrefstyle=short] summarizes the behavior of
 a hart in connection with the <<section_cheri_disable,CRE>> and the

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -362,6 +362,10 @@ NOTE: Disabling CHERI register access prevents low-privileged {cheri_int_mode_na
 from interfering with the correct operation of higher-privileged {cheri_int_mode_name} software
 that do not perform <<ddc>> switches on trap entry and return.
 
+NOTE: xref:cheri_behavior_cre_mode[xrefstyle=short] summarizes the behavior of
+a hart in connection with the <<section_cheri_disable,CRE>> and the
+<<m_bit,CHERI execution mode>>.
+
 === Added CLEN-wide CSRs
 
 {cheri_default_ext_name} adds the CLEN-wide CSRs shown in

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -181,3 +181,43 @@ if it does not implement the {cheri_default_ext_name} extension.
 |==============================================================================
 include::generated/illegal_insns_table_body.adoc[]
 |==============================================================================
+
+<<<
+
+xref:cheri_behavior_cre_mode[xrefstyle=short] summarizes the behavior of a hart
+supporting both {cheri_base_ext_name} and {cheri_default_ext_name} in
+connection with the <<section_cheri_disable,CRE>> and the
+<<section-cheri-execution-mode,CHERI execution mode>> while in a privilege
+other than debug mode.
+
+.Hart's behavior depending on the effective <<section_cheri_disable,CRE>> and <<section-cheri-execution-mode,CHERI execution mode>>
+[#cheri_behavior_cre_mode]
+[width=100%,options=header,align=center,cols="10,45,45"]
+|==============================================================================
+| | <<section_cheri_disable,CRE>>=0 | <<section_cheri_disable,CRE>>=1
+
+| <<pcc>>.<<m_bit,m>>={INT_MODE_VALUE}
+.2+| **_Fully compatibility with standard RISC-V:^*^_** +
+- All memory accesses authorized by <<ddc>> and <<pcc>> as if the mode is {cheri_int_mode_name} +
+- Accesses to <<zicsr-section-default,new CHERI CSRs>> raise illegal instruction exceptions +
+- Accesses to <<zicsr-section-default,extended CHERI CSRs>> read/write XLEN bits +
+- CHERI instructions raise illegal instruction exceptions +
+| **{cheri_int_mode_name}:** +
+- All memory accesses authorized by <<ddc>> and <<pcc>> +
+- Accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted +
+- Accesses to <<zicsr-section-default,extended CHERI CSRs>> read/write XLEN bits +
+- CHERI instructions are permitted and only these instructions have capability operands
+
+| <<pcc>>.<<m_bit,m>>={CAP_MODE_VALUE}
+| **{cheri_cap_mode_name}:** +
+- All memory accesses authorized by each instruction's capability operands +
+- Accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted +
+- Accesses to <<zicsr-section-default,extended CHERI CSRs>> read/write CLEN bits +
+- CHERI instructions are permitted +
+- Some compressed instruction encodings are remapped (see xref:legacy_mnemonics[xrefstyle=short])
+|==============================================================================
+
+^*^ The hart is fully compatible with standard RISC-V when
+<<section_cheri_disable,CRE>>=0 and <<pcc>>.<<m_bit,m>>={INT_MODE_VALUE}
+provided that <<pcc>>, <<mtvecc>>, <<mepcc>>, <<stvecc>>, <<sepcc>>,
+<<vstvecc>>, <<vsepcc>> and <<ddc>>  hold the <<infinite-cap>> capability.

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -196,22 +196,22 @@ other than debug mode.
 // Header
 | <<section_cheri_disable,CRE>>
 | <<pcc>>.<<m_bit,m>>
-| Authorizing capability^*^
-| <<zicsr-section-default,New CHERI CSRs>>^**^
-| <<zicsr-section-default,Extended CHERI CSRs>>^+^
-| CHERI instructions^†^
-| <<legacy_mnemonics,Compressed instructions remapped>>^‡^
+| Authorizing capability^1^
+| <<zicsr-section-default,New CHERI CSRs>>^2^
+| <<zicsr-section-default,Extended CHERI CSRs>>^3^
+| CHERI instructions^4^
+| <<legacy_mnemonics,Compressed instructions remapped>>^5^
 | Note
 
 // Body
 | 0
-| X^¶^
+| X^6^
 | <<ddc>> or <<pcc>>
 | ✘
 | XLEN
 | ✘
 | No
-| **_Fully RISC-V compatible_**^§^
+| **_Fully RISC-V compatible_**^7^
 
 | 1
 | 0
@@ -232,24 +232,24 @@ other than debug mode.
 | **{cheri_cap_mode_name}**
 |==============================================================================
 
-^*^ Authorizing capability for memory access instructions.
+^1^ Authorizing capability for memory access instructions.
 
-^**^ Whether accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted
+^2^ Whether accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted
 or raise illegal instruction exceptions. If permitted, then the bit width of
 the CSR read/write with <<CSRRW>> is indicated.
 
-^+^ The bit width of accesses to <<zicsr-section-default,extended CHERI CSRs>>
+^3^ The bit width of accesses to <<zicsr-section-default,extended CHERI CSRs>>
 using <<CSRRW>>.
 
-^†^ Whether CHERI instructions are permitted or raise illegal instruction
+^4^ Whether CHERI instructions are permitted or raise illegal instruction
 exceptions.
 
-^‡^ See xref:legacy_mnemonics[xrefstyle=short] for a list of remapped
+^5^ See xref:legacy_mnemonics[xrefstyle=short] for a list of remapped
 instructions.
 
-^¶^ <<pcc>>.<<m_bit,m>> is irrelevant when <<section_cheri_disable,CRE>>=0.
+^6^ <<pcc>>.<<m_bit,m>> is irrelevant when <<section_cheri_disable,CRE>>=0.
 
-^§^ The hart is fully compatible with standard RISC-V when
+^7^ The hart is fully compatible with standard RISC-V when
 <<section_cheri_disable,CRE>>=0 provided that <<pcc>>, <<mtvecc>>, <<mepcc>>,
 <<stvecc>>, <<sepcc>>, <<vstvecc>>, <<vsepcc>> and <<ddc>>  hold the
 <<infinite-cap>> capability.

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -191,33 +191,65 @@ connection with the <<section_cheri_disable,CRE>> and the
 other than debug mode.
 
 .Hart's behavior depending on the effective <<section_cheri_disable,CRE>> and <<section-cheri-execution-mode,CHERI execution mode>>
-[#cheri_behavior_cre_mode]
-[width=100%,options=header,align=center,cols="10,45,45"]
+[#cheri_behavior_cre_mode,width=100%,options=header,align=center,%autowidth,cols="8,8,15,12,12,15,15,15"]
 |==============================================================================
-| | <<section_cheri_disable,CRE>>=0 | <<section_cheri_disable,CRE>>=1
+// Header
+| <<section_cheri_disable,CRE>>
+| <<pcc>>.<<m_bit,m>>
+| Authorizing capability^*^
+| <<zicsr-section-default,New CHERI CSRs>>^**^
+| <<zicsr-section-default,Extended CHERI CSRs>>^+^
+| CHERI instructions^†^
+| <<legacy_mnemonics,Compressed instructions remapped>>^‡^
+| Note
 
-| <<pcc>>.<<m_bit,m>>={INT_MODE_VALUE}
-.2+| **_Fully compatibility with standard RISC-V:^*^_** +
-- All memory accesses authorized by <<ddc>> and <<pcc>> as if the mode is {cheri_int_mode_name} +
-- Accesses to <<zicsr-section-default,new CHERI CSRs>> raise illegal instruction exceptions +
-- Accesses to <<zicsr-section-default,extended CHERI CSRs>> read/write XLEN bits +
-- CHERI instructions raise illegal instruction exceptions +
-| **{cheri_int_mode_name}:** +
-- All memory accesses authorized by <<ddc>> and <<pcc>> +
-- Accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted +
-- Accesses to <<zicsr-section-default,extended CHERI CSRs>> read/write XLEN bits +
-- CHERI instructions are permitted and only these instructions have capability operands
+// Body
+| 0
+| X^¶^
+| <<ddc>> or <<pcc>>
+| ✘
+| XLEN
+| ✘
+| No
+| **_Fully RISC-V compatible_**^§^
 
-| <<pcc>>.<<m_bit,m>>={CAP_MODE_VALUE}
-| **{cheri_cap_mode_name}:** +
-- All memory accesses authorized by each instruction's capability operands +
-- Accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted +
-- Accesses to <<zicsr-section-default,extended CHERI CSRs>> read/write CLEN bits +
-- CHERI instructions are permitted +
-- Some compressed instruction encodings are remapped (see xref:legacy_mnemonics[xrefstyle=short])
+| 1
+| 0
+| <<ddc>> or <<pcc>>
+| CLEN
+| XLEN
+| ✔
+| No
+| **{cheri_int_mode_name}**
+
+| 1
+| 1
+| Instruction's capability operand
+| CLEN
+| CLEN
+| ✔
+| Yes
+| **{cheri_cap_mode_name}**
 |==============================================================================
 
-^*^ The hart is fully compatible with standard RISC-V when
-<<section_cheri_disable,CRE>>=0 and <<pcc>>.<<m_bit,m>>={INT_MODE_VALUE}
-provided that <<pcc>>, <<mtvecc>>, <<mepcc>>, <<stvecc>>, <<sepcc>>,
-<<vstvecc>>, <<vsepcc>> and <<ddc>>  hold the <<infinite-cap>> capability.
+^*^ Authorizing capability for memory access instructions.
+
+^**^ Whether accesses to <<zicsr-section-default,new CHERI CSRs>> are permitted
+or raise illegal instruction exceptions. If permitted, then the bit width of
+the CSR read/write with <<CSRRW>> is indicated.
+
+^+^ The bit width of accesses to <<zicsr-section-default,extended CHERI CSRs>>
+using <<CSRRW>>.
+
+^†^ Whether CHERI instructions are permitted or raise illegal instruction
+exceptions.
+
+^‡^ See xref:legacy_mnemonics[xrefstyle=short] for a list of remapped
+instructions.
+
+^¶^ <<pcc>>.<<m_bit,m>> is irrelevant when <<section_cheri_disable,CRE>>=0.
+
+^§^ The hart is fully compatible with standard RISC-V when
+<<section_cheri_disable,CRE>>=0 provided that <<pcc>>, <<mtvecc>>, <<mepcc>>,
+<<stvecc>>, <<sepcc>>, <<vstvecc>>, <<vsepcc>> and <<ddc>>  hold the
+<<infinite-cap>> capability.


### PR DESCRIPTION
Fixes #334

* Add a table summarizing the hart's behavior in connection with the effective CRE and the CHERI execution mode
    * There are 3 cases CHERI disabled, Integer pointer mode and Capability pointer mode
* Add a note describing why CRAM is disabled when CRE=0