### PR TITLE
Remove redundant c.addi4spn link

### DIFF
--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -3,6 +3,7 @@
 This RISC-V specification has been contributed to directly or indirectly by:
 
 [%hardbreaks]
+* Thomas Aird <thomas.aird@codasip.com>
 * Hesham Almatary <hesham.almatary@cl.cam.ac.uk>
 * Andres Amaya Garcia <andres.amaya@codasip.com>
 * John Baldwin <jhb61@cl.cam.ac.uk>

--- a/src/insns/addi4spn_16bit.adoc
+++ b/src/insns/addi4spn_16bit.adoc
@@ -3,8 +3,6 @@
 [#C_ADDI4SPN,reftext="C.ADDI4SPN"]
 ==== C.ADDI4SPN
 
-See <<C.ADDI4SPN>>.
-
 Synopsis::
 Stack pointer increment in blocks of 4 (C.ADDI4SPN), 16-bit encoding
 

--- a/src/riscv-cheri.adoc
+++ b/src/riscv-cheri.adoc
@@ -1,5 +1,5 @@
 = RISC-V Specification for CHERI Extensions
-Authors: Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu
+Authors: Thomas Aird, Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu
 include::attributes.adoc[]
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `C.ADDI4SPN` page currently links to itself. It looks like this was leftover when the `CINCOFFSET` instructions were renamed.