### PR TITLE
Remove outdated 'leg' specifier

### DIFF
--- a/src/insns/wavedrom/c-jal-format-ls.adoc
+++ b/src/insns/wavedrom/c-jal-format-ls.adoc
@@ -3,6 +3,6 @@
 {reg: [
   {bits: 2, name: 'op',     type: 8, attr: ['2','C1=01']},
   {bits: 11, name: 'imm',   type: 2, attr: ['11','offset[11|4|9:8|10|6|7|3:1|5]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3','leg: C.JAL=001']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3','int: C.JAL=001']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-css-dp-sprel.adoc
+++ b/src/insns/wavedrom/c-sp-load-css-dp-sprel.adoc
@@ -5,6 +5,6 @@
   {bits: 2, name: 'op',     type: 8, attr: ['2','C2=10']},
   {bits: 5, name: 'rs2',    type: 4, attr: ['5','src']},
   {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:3|8:6]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg: C.FLDSP=001', 'cap rv32: C.FLDSP=001']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int: C.FLDSP=001', 'cap rv32: C.FLDSP=001']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-css-dp.adoc
+++ b/src/insns/wavedrom/c-sp-load-css-dp.adoc
@@ -7,6 +7,6 @@
   {bits: 2, name: 'imm',    attr: ['2', 'offset[7:6]'], type: 2},
   {bits: 3, name: 'rs1`/cs1`',   attr: ['3', 'base'], type: 2},
   {bits: 3, name: 'imm',    attr: ['3', 'offset[5:3]'], type: 3},
-  {bits: 3, name: 'funct3', attr: ['3', 'leg C.FLD=001', 'cap rv32: C.FLD=001'], type: 8},
+  {bits: 3, name: 'funct3', attr: ['3', 'int C.FLD=001', 'cap rv32: C.FLD=001'], type: 8},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-css-fp-sprel.adoc
+++ b/src/insns/wavedrom/c-sp-load-css-fp-sprel.adoc
@@ -6,6 +6,6 @@
   {bits: 5, name: 'uimm',   type: 3, attr: ['5','offset[4:2|7:6]']},
   {bits: 5, name: 'rd',     type: 4, attr: ['5','src']},
   {bits: 1, name: 'uimm[5]',type: 3, attr: ['1','offset[5]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg rv32: C.FLWSP=011']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int rv32: C.FLWSP=011']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-css-fp.adoc
+++ b/src/insns/wavedrom/c-sp-load-css-fp.adoc
@@ -7,6 +7,6 @@
   {bits: 2, name: 'imm',    type: 2, attr: ['2', 'offset[2|6]']},
   {bits: 3, name: 'rs1\'',  type: 3, attr: ['3', 'base']},
   {bits: 3, name: 'imm',    types:3, attr: ['3', 'offset[5:3]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg rv32: C.FLW=011']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int rv32: C.FLW=011']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-store-fp.adoc
+++ b/src/insns/wavedrom/c-sp-load-store-fp.adoc
@@ -8,6 +8,6 @@
   {bits: 5, name: 'imm',    type: 5, attr: ['5', 'offset[4:2|7:6]']},
   {bits: 5, name: 'rd',     type: 5, attr: ['5','dest']},
   {bits: 1, name: 'imm',    type: 1, attr: ['1','[5]']},
-  {bits: 3, name: 'funct3', type: 3, attr: ['3', 'leg rv32: C.FLWSP=011']},
+  {bits: 3, name: 'funct3', type: 3, attr: ['3', 'int rv32: C.FLWSP=011']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-store-css-fp-dp-sprel.adoc
+++ b/src/insns/wavedrom/c-sp-store-css-fp-dp-sprel.adoc
@@ -6,6 +6,6 @@
   {bits: 2, name: 'op',     type: 8, attr: ['2','C2=10']},
   {bits: 5, name: 'rs2',    type: 4, attr: ['5','src']},
   {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:3|8:6]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg C.FSDSP=101', 'cap rv32: C.FSDSP=101']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int C.FSDSP=101', 'cap rv32: C.FSDSP=101']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-store-css-fp-dp.adoc
+++ b/src/insns/wavedrom/c-sp-store-css-fp-dp.adoc
@@ -6,6 +6,6 @@
   {bits: 2, name: 'op',     type: 8, attr: ['2','C0=00']},
   {bits: 5, name: 'rs2',    type: 4, attr: ['5','src']},
   {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:3|8:6]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg C.FSD=101', 'cap rv32: C.FSD=101']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int C.FSD=101', 'cap rv32: C.FSD=101']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-store-css-fp-sprel.adoc
+++ b/src/insns/wavedrom/c-sp-store-css-fp-sprel.adoc
@@ -6,6 +6,6 @@
   {bits: 2, name: 'op',     type: 8, attr: ['2','C2=10']},
   {bits: 5, name: 'rs2',    type: 4, attr: ['5','src']},
   {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:2|7:6]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg rv32: C.FSWSP=111']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int rv32: C.FSWSP=111']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-store-css-fp.adoc
+++ b/src/insns/wavedrom/c-sp-store-css-fp.adoc
@@ -7,6 +7,6 @@
   {bits: 2, name: 'uimm',   type: 2, attr: ['2', 'offset[2|6]']},
   {bits: 3, name: 'rs1\'',  type: 3, attr: ['3', 'base']},
   {bits: 3, name: 'uimm',   types:3, attr: ['3', 'offset[5:3]']},
-  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'leg rv32: C.FSW=111']},
+  {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int rv32: C.FSW=111']},
 ], config: {bits: 16}}
 ....


### PR DESCRIPTION
There were multiple references to "leg" (legacy mode) in the instruction encodings, which were missing when this was renamed to Integer Pointer Mode