### PR TITLE
Reserve redundant SCBNDSI encodings

### DIFF
--- a/src/insns/scbnds_32bit.adoc
+++ b/src/insns/scbnds_32bit.adoc
@@ -42,6 +42,8 @@ tag is 0  or `cs1` is sealed.
 +
 `immediate = ZeroExtend(s ? uimm<<4 : uimm)`
 
+NOTE: The <<SCBNDSI>> encoding with `s=1` and `uimm ≤ 1` is RESERVED since these immediates can also be encoded with `s=0`.
+
 include::malformed_clear_tag.adoc[]
 
 Exceptions::

--- a/src/insns/wavedrom/scbnds_32bit.adoc
+++ b/src/insns/wavedrom/scbnds_32bit.adoc
@@ -18,7 +18,7 @@
   {bits: 5,  name: 'cd',      attr: ['5', 'dest'], type: 2},
   {bits: 3,  name: 'funct3',  attr: ['3', 'SCBNDSI=101'], type: 8},
   {bits: 5,  name: 'cs1',     attr: ['5', 'src'], type: 4},
-  {bits: 5,  name: 'uimm',    attr: ['5', 'uimm'], type: 3},
+  {bits: 5,  name: 'uimm',    attr: ['5', 'uimm', '(> 1 if s=1)'], type: 3},
   {bits: 1,  name: 's',       attr: ['1', 'scaled'], type: 3},
   {bits: 6,  name: 'funct6',  attr: ['6', 'SCBNDSI','=000001'], type: 3},
 ]}


### PR DESCRIPTION
These encodings could be used for larger values such as 512 in the future.

See https://github.com/riscv/riscv-cheri/issues/402

CC: @nwf @davidchisnall