### PR TITLE
Xtval2 clarification

### DIFF
--- a/src/img/htval2reg.edn
+++ b/src/img/htval2reg.edn
@@ -8,9 +8,9 @@
 (def boxes-per-row 32)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "HSXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "CAUSE"      {:span 4})
 
 (draw-box "HSXLEN-20" {:span 12 :borders {}})

--- a/src/img/mtval2reg.edn
+++ b/src/img/mtval2reg.edn
@@ -8,9 +8,9 @@
 (def boxes-per-row 32)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "CAUSE"      {:span 4})
 
 (draw-box "MXLEN-20" {:span 12 :borders {}})

--- a/src/img/stval2reg.edn
+++ b/src/img/stval2reg.edn
@@ -8,9 +8,9 @@
 (def boxes-per-row 32)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "SXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "CAUSE"      {:span 4})
 
 (draw-box "SXLEN-20" {:span 12 :borders {}})

--- a/src/img/vstval2reg.edn
+++ b/src/img/vstval2reg.edn
@@ -8,9 +8,9 @@
 (def boxes-per-row 32)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "3" "4" "" "" "" "" "" "" "" "" "" "" "15" "16" "" "" "19" "20" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1"])})
 
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "TYPE"       {:span 4})
-(draw-box "Reserved"   {:span 12})
+(draw-box "WPRI"       {:span 12})
 (draw-box "CAUSE"      {:span 4})
 
 (draw-box "VSXLEN-20" {:span 12 :borders {}})

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -786,9 +786,12 @@ xref:mtval2-format[xrefstyle=short] to assist software in handling the trap.
 If <<mtval>> is read-only zero for CHERI exceptions then <<mtval2>> is also read-only zero
 for CHERI exceptions.
 
-.Machine trap value register 2
+.Machine trap value register 2 format for CHERI faults
 [#mtval2-format]
 include::img/mtval2reg.edn[]
+
+NOTE: <<mtval2>> is also used for Hypervisor guest physical addresses, and so the implemented bits must also cover that use case.
+ If Hypervisor is not implemented then all WPRI fields in <<mtval2-format>> are read-only-zero.
 
 TYPE is a CHERI-specific fault type that caused the exception while CAUSE
 is the cause of the fault. The possible CHERI types and causes are encoded as


### PR DESCRIPTION
reserved fields in Xtval2 should be WPRI to be consistent with RISC-V
