### PR TITLE
level-ext: fix permission encoding table

### DIFF
--- a/src/level-ext.adoc
+++ b/src/level-ext.adoc
@@ -74,9 +74,9 @@ endif::[]
 11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
 |Bits[4:3]| R | W | C | LM | EL | SL  | X | ASR | Mode^1^ |
 | 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | ∞   | ✔ |  ✔  | Mode^1^  | Execute + ASR (see <<infinite-cap>>)
-| 2-3   | ✔ |   | ✔ | ✔  | ✔  | ∞   |   |     | Mode^1^  | Execute + Data & Cap RO
+| 2-3   | ✔ |   | ✔ | ✔  | ✔  | ∞   | ✔ |     | Mode^1^  | Execute + Data & Cap RO
 | 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | ∞   | ✔ |     | Mode^1^  | Execute + Data & Cap RW
-| 6-7   | ✔ | ✔ |   |    |    | N/A |   |     | Mode^1^  | Execute + Data RW
+| 6-7   | ✔ | ✔ |   |    |    | N/A | ✔ |     | Mode^1^  | Execute + Data RW
 11+| *Quadrant 2: Restricted capability data read/write*
 11+| bit[2] = write, bit[1:0] = store level. R and C implicitly granted, LM dependent on W permission.
 |Bits[4:3]| R | W | C | LM | EL | SL    | X | ASR | Mode^1^ |


### PR DESCRIPTION
All possible entries in quadrant 1 grant execute permission. Tick the X column in table 28 for all quadrant 1entries. This is consistent with the Notes and with table 4.