### PR TITLE
Add SL description to all store cap instructions

### DIFF
--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -10,6 +10,7 @@ If the authorizing capability does not grant <<lm_perm>>, and the tag of `cd` is
 +
 If the authorizing capability does not grant <<el_perm>>, and the tag of `cd` is 1, then an implicit <<ACPERM>> clearing <<el_perm>> and restricting <<section_cap_level>> to the level of the authorizing capability is performed to obtain the final permissions on `cd` (see <<LC>>).
 +
+The stored tag is also set to zero if the authorizing capability does not have <<sl_perm>> set but the stored data has a <<section_cap_level>> of 0 (see <<SC>>).
 endif::[]
 ifndef::cap_atomic[]
 Requires <<r_perm>> and <<w_perm>> in the authorising capability.

--- a/src/insns/store_16bit_cap_sprel.adoc
+++ b/src/insns/store_16bit_cap_sprel.adoc
@@ -24,11 +24,22 @@ include::xlen_variable_warning.adoc[]
 Encoding::
 include::wavedrom/c-sp-store-cap.adoc[]
 
-include::store_cap_cap_description.adoc[]
+{cheri_cap_mode_name} Description::
+Store the CLEN+1 bit value in `cs2'` to memory. The capability in `cs1/csp`
+authorizes the operation. The effective address of the memory access is
+obtained by adding the address of `cs1/csp` to the sign-extended 12-bit offset.
 
 NOTE: These mnemonics do not exist in {cheri_int_mode_name}.
 
-:cap_store:
+Tag of the written capability value::
+
+The capability written to memory has the tag set to 0 if the tag of `cs2'` is 0 or if the authorizing capability (`cs1/csp`) does not grant <<c_perm>>.
++
+The stored tag is also set to zero if the authorizing capability does not have <<sl_perm>> set but the stored data has a <<section_cap_level>> of 0 (_local_).
+
+include::malformed_no_check.adoc[]
+
+:has_cap_data:
 include::store_exceptions.adoc[]
 
 Prerequisites::

--- a/src/insns/store_cap_cap_description.adoc
+++ b/src/insns/store_cap_cap_description.adoc
@@ -1,2 +1,0 @@
-{cheri_cap_mode_name} Description::
-Store capability instruction, authorised by the capability in `cs1`. Take a store/AMO address misaligned exception if not naturally aligned.

--- a/src/insns/store_cond_cap_32bit.adoc
+++ b/src/insns/store_cond_cap_32bit.adoc
@@ -27,6 +27,8 @@ Store conditional instructions, authorised by the capability in <<ddc>>.
 
 :store_cond:
 
+include::store_tag_perms.adoc[]
+
 include::malformed_no_check.adoc[]
 
 include::store_exceptions.adoc[]


### PR DESCRIPTION
The SL tag-clearing rules were missing from `sc.c` and `amoswap.c` instruction descriptions. This adds them following the same convention used for the EL rules with the load cap instructions.