### PR TITLE
Fix minor typo in PTE section

### DIFF
--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -46,7 +46,7 @@ read to a new page to sweep it clean before proceeding.
 With a page-granularity generational capability read permission, we can
 eliminate the initial permission change of all PTEs.
 In addition, a page-granularity capability write control can eliminate many pages
-from the sweep what are known not to contain capabilities.
+from the sweep that are known to not contain capabilities.
 
 
 [#section_extending_pte]


### PR DESCRIPTION
what -> that, and I think "known to not contain" is a bit easier to parse than "known not to contain".