### PR TITLE
removed redundant word "possible" in the text

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -30,7 +30,7 @@ specifications must provide key primitives, such as permissions and bounds,
 from this specification while using a different encoding that, for example,
 changes the granularity of bounds or adds new features. For simplicity of
 expression, the text is written as if this was the only possible capability
-encoding possible for CHERI RISC-V.
+encoding for CHERI RISC-V.
 
 [#section_cap_encoding]
 === Capability Encoding


### PR DESCRIPTION
## Description
This PR intends to improve a minor sentence in the text of **_Anatomy of Capabilities in Zcheripurecap_** as a **_NOTE_**.

### Changes Made
The word _"possible"_ was redundant, so it was removed to improve conciseness.