### PR TITLE
clarify that quad 2 and 3 entries 4 and 5 are reserved when LVLBITS=2

### DIFF
--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -109,7 +109,7 @@ CAUTION: The extension names are provisional and subject to change.
 |<<lr_sc_bh_ext,     {lr_sc_bh_ext_name}>>      | Stable    | This extension is a candidate for freezing
 |<<cheri_pte_ext,    {cheri_pte_ext_name}>>     | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level
 |<<tid_ext,          {tid_ext_name}>>           | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level
-|<<cheri_levels_ext, {cheri_levels_ext_name}>>  | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level
+|<<cheri_levels_ext, {cheri_levels_ext_name}>> with `LVLBITS=1` | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level.
 |==============================================================================
 
 {cheri_base_ext_name} is defined as the base extension which all CHERI RISC-V

--- a/src/level-ext.adoc
+++ b/src/level-ext.adoc
@@ -82,8 +82,8 @@ endif::[]
 |Bits[4:3]| R | W | C | LM | EL | SL    | X | ASR | Mode^1^ |
 | 0-2   10+| reserved
 | 3       | ✔ |   | ✔ |    |    | 0^1^  |   |     | N/A | Data & Cap R0 (without <<lm_perm>>)
-| 4       | ✔ | ✔ | ✔ | ✔  |    | _(3)_ |   |     | N/A | Reserved for `LVLBITS=2`
-| 5       | ✔ | ✔ | ✔ | ✔  |    | _(2)_ |   |     | N/A | Reserved for `LVLBITS=2`
+| 4       | ✔ | ✔ | ✔ | ✔  |    | _(3)_ |   |     | N/A | _Reserved_ when `LVLBITS=1` ^2^
+| 5       | ✔ | ✔ | ✔ | ✔  |    | _(2)_ |   |     | N/A | _Reserved_ when `LVLBITS=1` ^2^
 | 6       | ✔ | ✔ | ✔ | ✔  |    | 1     |   |     | N/A | Data & Cap RW (with store _local_, no <<el_perm>>)
 | 7       | ✔ | ✔ | ✔ | ✔  |    | 0     |   |     | N/A | Data & Cap RW (no store _local_, no <<el_perm>>)
 11+| *Quadrant 3: Capability data read/write*
@@ -92,13 +92,14 @@ endif::[]
 |Bits[4:3]| R | W | C | LM | EL | SL    | X | ASR | Mode^1^ |
 | 0-2   10+| reserved
 | 3       | ✔ |   | ✔ | ✔  | ✔  | 0^1^  |   |     | N/A | Data & Cap R0
-| 4       | ✔ | ✔ | ✔ | ✔  | ✔  | _(3)_ |   |     | N/A | Reserved for `LVLBITS=2`
-| 5       | ✔ | ✔ | ✔ | ✔  | ✔  | _(2)_ |   |     | N/A | Reserved for `LVLBITS=2`
+| 4       | ✔ | ✔ | ✔ | ✔  | ✔  | _(3)_ |   |     | N/A | _Reserved_ when `LVLBITS=1` ^2^
+| 5       | ✔ | ✔ | ✔ | ✔  | ✔  | _(2)_ |   |     | N/A | _Reserved_ when `LVLBITS=1` ^2^
 | 6       | ✔ | ✔ | ✔ | ✔  | ✔  | 1     |   |     | N/A | Data & Cap RW (with store _local_)
 | 7       | ✔ | ✔ | ✔ | ✔  | ✔  | 0     |   |     | N/A | Data & Cap RW (no store _local_)
 |==============================================================================
 
-^1^ SL isn't applicable in these cases, but this value is reported by <<GCPERM>> to simplify the rules followed by <<ACPERM>>
+^1^ SL isn't applicable in these cases, but this value is reported by <<GCPERM>> to simplify the rules followed by <<ACPERM>> +
+^2^ These entries are reserved when `LVLBITS=1` and in use when `LVLBITS=2`
 
 [#section_cap_level_change]
 === Changing capability levels and permissions


### PR DESCRIPTION
also note that Zcherilevels with LVLBITS=1 is in the prototype phase, I think LVLBITS=2 will need more analysis to prove that the spec is correct (at least for the ACPERM rules).