### PR TITLE
Deleted incorrect statement about ASR needed for all M and S mode CSRs

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -831,7 +831,7 @@ CHERI violations have the following order in priority:
 === Supervisor-Level CSRs
 
 {cheri_base_ext_name} extends some of the existing RISC-V CSRs to be able to
-hold capabilities or with other new functions.
+hold capabilities or with other new functions. <<asr-perm>> in the <<pcc>> is typically required for access.
 
 [#stvec,reftext="stvec"]
 ==== Supervisor Trap Vector Base Address Register (stvec)

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -425,7 +425,7 @@ include::generated/csr_renamed_purecap_mode_u_table_body.adoc[]
 === Machine-Level CSRs
 
 {cheri_base_ext_name} extends some M-mode CSRs to hold capabilities or
-otherwise add new functions.
+otherwise add new functions. <<asr-perm>> in the <<pcc>> is typically required for access.
 
 [#mstatus,reftext="mstatus"]
 ==== Machine Status Registers (mstatus and mstatush)

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1049,7 +1049,8 @@ include::img/stval2reg.edn[]
 
 === Unprivileged CSRs
 
-Unlike machine and supervisor level CSRs, {cheri_base_ext_name} does not require
+In {cheri_base_ext_name} only writing the <<utidc>> register requires
+<<pcc>> to grant <<asr_perm>>, all other unprivileged CSRs do not require
 <<pcc>> to grant <<asr_perm>> to access unprivileged CSRs.
 
 === CHERI Exception handling

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -1049,8 +1049,8 @@ include::img/stval2reg.edn[]
 
 === Unprivileged CSRs
 
-In {cheri_base_ext_name} only writing the <<utidc>> register requires
-<<pcc>> to grant <<asr_perm>>, all other unprivileged CSRs do not require
+In {cheri_base_ext_name}, the only register that requires <<asr_perm>> is <<utidc>>
+(for updates but not for reads), and all other unprivileged CSRs do not require
 <<pcc>> to grant <<asr_perm>> to access unprivileged CSRs.
 
 === CHERI Exception handling

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -425,8 +425,7 @@ include::generated/csr_renamed_purecap_mode_u_table_body.adoc[]
 === Machine-Level CSRs
 
 {cheri_base_ext_name} extends some M-mode CSRs to hold capabilities or
-otherwise add new functions. <<pcc>> must grant <<asr_perm>> to access M-mode
-CSRs regardless of the RISC-V privilege mode.
+otherwise add new functions.
 
 [#mstatus,reftext="mstatus"]
 ==== Machine Status Registers (mstatus and mstatush)
@@ -832,8 +831,7 @@ CHERI violations have the following order in priority:
 === Supervisor-Level CSRs
 
 {cheri_base_ext_name} extends some of the existing RISC-V CSRs to be able to
-hold capabilities or with other new functions. <<pcc>> must grant <<asr_perm>>
-to access S-mode CSRs regardless of the RISC-V privilege mode.
+hold capabilities or with other new functions.
 
 [#stvec,reftext="stvec"]
 ==== Supervisor Trap Vector Base Address Register (stvec)


### PR DESCRIPTION
The `mtidc` and `stidc` registers do not require `ASR` permission when read. This makes the deleted statements wrong.