### PR TITLE
Extended Zcherihybrid to reflect that access is not allowed to CHERI instructions

### DIFF
--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -324,7 +324,7 @@ it is not possible to disable CHERI checks completely.
 endif::[]
 
 {cheri_default_ext_name} includes functions to disable explicit access to CHERI
-registers.  The following occurs when executing code in a privilege mode that
+registers and instructions.  The following occurs when executing code in a privilege mode that
 has CHERI register access disabled:
 
 * The CHERI instructions in xref:section_cap_instructions[xrefstyle=short] and
@@ -462,8 +462,9 @@ xref:menvcfgmodereg[xrefstyle=short].
 include::img/menvcfgmodereg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether less privileged levels can
-perform explicit accesses to CHERI registers. When <<menvcfg>>.CRE=1 and <<mseccfg>>.CRE=1,
-CHERI registers can be read and written by less privileged levels. When <<menvcfg>>.CRE=0,
+perform explicit accesses to CHERI registers and execute CHERI instructions.
+When <<menvcfg>>.CRE=1 and <<mseccfg>>.CRE=1, CHERI registers can be read and
+written by less privileged levels. When <<menvcfg>>.CRE=0,
 CHERI registers are disabled in less privileged levels as described in
 xref:section_cheri_disable[xrefstyle=short].
 
@@ -495,8 +496,9 @@ xref:senvcfgreg[xrefstyle=short].
 include::img/senvcfgreg.edn[]
 
 The CHERI Register Enable (CRE) bit controls whether U-mode can perform
-explicit accesses to CHERI registers. When <<senvcfg>>.CRE=1 and <<menvcfg>>.CRE=1 and
-<<mseccfg>>.CRE=1 CHERI registers can be read and written by U-mode. When <<senvcfg>>.CRE=0,
+explicit accesses to CHERI registers and execute CHERI instructions. When
+<<senvcfg>>.CRE=1 and <<menvcfg>>.CRE=1 and <<mseccfg>>.CRE=1 CHERI registers
+can be read and written by U-mode. When <<senvcfg>>.CRE=0,
 CHERI registers are disabled in U-mode as described in
 xref:section_cheri_disable[xrefstyle=short].
 


### PR DESCRIPTION
The text in most cases only considered CHERI registers, but `CRE` also prevents executing CHERI instructions.