### PR TITLE
Clarify mtval wording

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -758,7 +758,7 @@ a CHERI fault taken into M-mode, <<mtval>> is written with the
 MXLEN-bit effective address which caused the fault according to the existing
 rules for reporting load/store addresses from cite:[riscv-priv-spec]. In this case
 the TYPE field of <<mtval2>> shown in xref:mtval2-cheri-type[xrefstyle=short] is
-set to {cheri_excep_type_data}. For all other CHERI faults it is set to zero.
+set to {cheri_excep_type_data}. For all other CHERI faults <<mtval>> is set to zero.
 
 The behavior of <<mtval>> is otherwise as described in cite:[riscv-priv-spec].
 


### PR DESCRIPTION
The wording in this sentence was a bit ambiguous whether "it" referred to `mtval` or `mtval2`. It only made sense if it referred to `mtval`, but it's better if it's explicitly clear to avoid confusion.