### PR TITLE
Update extension stability table

### DIFF
--- a/src/introduction.adoc
+++ b/src/introduction.adoc
@@ -107,8 +107,8 @@ CAUTION: The extension names are provisional and subject to change.
 |<<cheri_default_ext,{cheri_default_ext_name}>> | Stable    | This extension is a candidate for freezing
 |<<sh4add_ext,       {sh4add_ext_name}>>        | Stable    | This extension is a candidate for freezing
 |<<lr_sc_bh_ext,     {lr_sc_bh_ext_name}>>      | Stable    | This extension is a candidate for freezing
-|<<cheri_pte_ext,    {cheri_pte_ext_name}>>     | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level
-|<<tid_ext,          {tid_ext_name}>>           | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level
+|<<cheri_pte_ext,    {cheri_pte_ext_name}>>     | Stabilizing | This extension is a candidate for freeze, software evaluation currently ongoing
+|<<tid_ext,          {tid_ext_name}>>           | Stabilizing | This extension is a candidate for freeze, software evaluation currently ongoing
 |<<cheri_levels_ext, {cheri_levels_ext_name}>> with `LVLBITS=1` | Prototype | This extension is a prototype, software is being developed to use it to increase the maturity level.
 |==============================================================================
 


### PR DESCRIPTION
Clarify that tid and pte extensions are candidates for freeze.