### PR TITLE
amo: amoswap: offset must be 0

### DIFF
--- a/src/insns/amo_32bit.adoc
+++ b/src/insns/amo_32bit.adoc
@@ -14,16 +14,16 @@ Synopsis::
 Atomic Operations (AMO<OP>.W, AMO<OP>.D), 32-bit encodings
 
 {cheri_cap_mode_name} Mnemonics (RV64)::
-`amo<op>.[w|d] rd, rs2, offset(cs1)`
+`amo<op>.[w|d] rd, rs2, 0(cs1)`
 
 {cheri_cap_mode_name} Mnemonics (RV32)::
-`amo<op>.w rd, rs2, offset(cs1)`
+`amo<op>.w rd, rs2, 0(cs1)`
 
 {cheri_int_mode_name} Mnemonics (RV64)::
-`amo<op>.[w|d] rd, rs2, offset(rs1)`
+`amo<op>.[w|d] rd, rs2, 0(rs1)`
 
 {cheri_int_mode_name} Mnemonics (RV32)::
-`amo<op>.w rd, rs2, offset(rs1)`
+`amo<op>.w rd, rs2, 0(rs1)`
 
 Encoding::
 include::wavedrom/amo.adoc[]

--- a/src/insns/amoswap_32bit_cap.adoc
+++ b/src/insns/amoswap_32bit_cap.adoc
@@ -7,10 +7,10 @@ Synopsis::
 Atomic Operation (AMOSWAP.C), 32-bit encoding
 
 {cheri_cap_mode_name} Mnemonic::
-`amoswap.c cd, cs2, offset(cs1)`
+`amoswap.c cd, cs2, 0(cs1)`
 
 {cheri_int_mode_name} Mnemonic::
-`amoswap.c cd, cs2, offset(rs1)`
+`amoswap.c cd, cs2, 0(rs1)`
 
 Encoding::
 include::wavedrom/amoswap_cap.adoc[]


### PR DESCRIPTION
The amo<op>.[w|d] and amoswap.c instructions need the exact address and do not support an offset. Their encodings have no offset field.

Set the offset to 0 in the Mnemonics. This is what we already do for lr and sc instructions.