### PR TITLE
Fix observing CHERI execution mode code

### DIFF
--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -36,5 +36,6 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Ricki Tura <ricki.tura@codasip.com>
 * Robert N. M. Watson <robert.watson@cl.cam.ac.uk>
 * Toby Wenman <toby.wenman@codasip.com>
+* Jay Williams  <jay.williams@codasip.com>
 * Jonathan Woodruff <jonathan.woodruff@cl.cam.ac.uk>
 * Jason Zhijingcheng Yu <yu.zhi@comp.nus.edu.sg>

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -109,7 +109,7 @@ for {cheri_cap_mode_name} and {INT_MODE_VALUE} for
 
 ```
 auipc c1, 0
-gctag x1, c1
+gcmode x1, c1
 ```
 
 [#section_hybrid_ext_instructions]


### PR DESCRIPTION
The example for observing the CHERI execution mode for privilege modes other than debug incorrectly uses `gctag` instead of `gcmode`. 