### PR TITLE
cheripte: Make PTE bits reserved in guest page tables

### DIFF
--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -82,7 +82,9 @@ Generation (CRG), are added to leaf PTEs in Sv39, Sv48 and Sv57 as shown in
 xref:sv39pte[xrefstyle=short], xref:sv48pte[xrefstyle=short] and
 xref:sv57pte[xrefstyle=short] respectively. For non-leaf PTEs these bits
 remain reserved and must be cleared by software for forward compatibility,
-or else a page-fault exception is raised.
+or else a page-fault exception is raised. Additionally, if the hypervisor
+extension is enabled these bits remain reserved for leaf and non-leaf PTEs
+used in guest address translation.
 
 .Sv39 page table entry
 [#sv39pte]


### PR DESCRIPTION

The base hypervisor spec says that the format for guest page table PTEs is the same as for normal PTEs and reserves bits (e.g. the G bit) that don't have a meaning for guest address translation (yet). Do the same for the cheripte bits.