### PR TITLE
Replace bounds decoding ascii art with bytefield diagram

### DIFF
--- a/src/cap-description.adoc
+++ b/src/cap-description.adoc
@@ -445,12 +445,17 @@ Reconstituting the top two bits of T:
 T[MW - 1:MW - 2] = B[MW - 1:MW - 2] + LCout + LMSB
 ```
 
-Decoding the bounds:
+The bounds are decoded as shown in xref:top_bound_dec[xrefstyle=short] and
+xref:base_bound_dec[xrefstyle=short].
 
-```
-top:    t = { {1'b0, a[MXLEN - 1:E + MW]} + ct, T[MW - 1:0], {E{1'b0}} }
-base:   b = {        a[MXLEN - 1:E + MW]  + cb, B[MW - 1:0], {E{1'b0}} }
-```
+.Decoding of the MXLEN+1 wide top (_t_) bound
+[#top_bound_dec]
+include::img/top-bound-dec.edn[]
+
+.Decoding of the MXLEN wide base (_b_) bound
+[#base_bound_dec]
+include::img/base-bound-dec.edn[]
+
 The corrections c~t~ and c~b~ are calculated as as shown below using the
 definitions in xref:cap_encoding_ct[xrefstyle=short] and
 xref:cap_encoding_cb[xrefstyle=short].

--- a/src/img/base-bound-dec.edn
+++ b/src/img/base-bound-dec.edn
@@ -1,0 +1,16 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 25}])
+(def row-height 80)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+(draw-column-headers {:height 50 :font-size 22 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "E" "" "" "" "" "" "" "" "" "" "E+MW" "" "" "" "" "" "" "" "" "" "" "MXLEN-1"])})
+
+(draw-box "a[MXLEN - 1:E + MW] + cb" {:span 12})
+(draw-box "B[MW - 1:0]"              {:span 10})
+(draw-box "0"                        {:span 10})
+
+(draw-box "MXLEN" {:span 32 :borders {}})
+----

--- a/src/img/top-bound-dec.edn
+++ b/src/img/top-bound-dec.edn
@@ -8,7 +8,7 @@
 (def boxes-per-row 32)
 (draw-column-headers {:height 50 :font-size 22 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "E" "" "" "" "" "" "" "" "" "" "E+MW" "" "" "" "" "" "" "" "" "" "" "MXLEN"])})
 
-(draw-box "a[MXLEN - 1:E + MW] + ct" {:span 12})
+(draw-box "{1'b0, a[MXLEN - 1:E + MW]} + ct" {:span 12})
 (draw-box "T[MW - 1:0]"              {:span 10})
 (draw-box "0"                        {:span 10})
 

--- a/src/img/top-bound-dec.edn
+++ b/src/img/top-bound-dec.edn
@@ -1,0 +1,16 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 25}])
+(def row-height 80)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+(draw-column-headers {:height 50 :font-size 22 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "E" "" "" "" "" "" "" "" "" "" "E+MW" "" "" "" "" "" "" "" "" "" "" "MXLEN"])})
+
+(draw-box "a[MXLEN - 1:E + MW] + ct" {:span 12})
+(draw-box "T[MW - 1:0]"              {:span 10})
+(draw-box "0"                        {:span 10})
+
+(draw-box "MXLEN+1" {:span 32 :borders {}})
+----


### PR DESCRIPTION
Replace the ascii art with the bounds decoding diagram to make it clear how they are computed and what the resulting width of top and base.

This PR replaces this:

```
top:    t = { {1'b0, a[MXLEN - 1:E + MW]} + ct, T[MW - 1:0], {E{1'b0}} }
base:   b = {        a[MXLEN - 1:E + MW]  + cb, B[MW - 1:0], {E{1'b0}} }
```

With the bytefield figures  in the attached image.
<img width="688" alt="Screenshot 2025-02-06 at 13 34 16" src="https://github.com/user-attachments/assets/f974f385-6ce1-49bf-a72c-a83852b2ec16" />
