### PR TITLE
Write note about traps for capability stores

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -224,8 +224,9 @@ capability written to memory is cleared if the authorizing capability does not
 grant permission to write capabilities (i.e. both <<w_perm>> and <<c_perm>>
 must be set in AP).
 
-WARNING: #TODO: these cases may cause exceptions in the future - we need a way
-for software to discover and/or control the behavior#
+NOTE: Future extensions to {cheri_base_ext_name} may add mechanisms that cause
+stores to raise exceptions when the authorizing capability does not grant both
+<<w_perm>> and <<c_perm>>.
 
 [#section_existing_riscv_insns]
 === Existing RISC-V Instructions


### PR DESCRIPTION
Add a note indicating that capability stores may trap in future extensions when the authorizing capability does not grant capability write permissions. Also remove outdated TODO.

Fixes https://github.com/riscv/riscv-cheri/issues/476