### PR TITLE
Revert MXLEN to XLEN in RV memory description

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -26,14 +26,14 @@ privileged architecture specified in the RISC-V ISA.
 === Memory
 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
-space of 2^MXLEN^ bytes for all memory accesses. Each memory region capable of
+space of 2^XLEN^ bytes for all memory accesses. Each memory region capable of
 holding a capability also stores a tag bit for each naturally aligned CLEN bits
 (e.g. 16 bytes in RV64), so that capabilities with their tag set can only be
 stored in naturally aligned addresses. Tags must be atomically bound to the
 data they protect.
 
 The memory address space is circular, so the byte at address
-2^MXLEN^ - 1 is adjacent to the byte at address zero. A capability's
+2^XLEN^ - 1 is adjacent to the byte at address zero. A capability's
 <<section_cap_representable_check>> described in xref:section_cap_encoding[xrefstyle=short] is
 also circular, so address 0 is within the <<section_cap_representable_check>> of a capability
 where address 2^MXLEN^ - 1 is within the bounds.


### PR DESCRIPTION
The text was originally taken from RISC-V and ideally it should remain as in the Unprivileged RISC-V spec to ensure that the CHERI extension is backwards-compatible with RISC-V.