### PR TITLE
Fix encoding of C.FSD instruction

### DIFF
--- a/src/insns/wavedrom/c-sp-store-css-fp-dp-sprel.adoc
+++ b/src/insns/wavedrom/c-sp-store-css-fp-dp-sprel.adoc
@@ -1,4 +1,4 @@
-//c-sp load and store, css format--is this correct?
+//c-sp load and store, css format
 
 [wavedrom, ,svg]
 ....

--- a/src/insns/wavedrom/c-sp-store-css-fp-dp.adoc
+++ b/src/insns/wavedrom/c-sp-store-css-fp-dp.adoc
@@ -3,9 +3,11 @@
 [wavedrom, ,svg]
 ....
 {reg: [
-  {bits: 2, name: 'op',     type: 8, attr: ['2','C0=00']},
-  {bits: 5, name: 'rs2',    type: 4, attr: ['5','src']},
-  {bits: 6, name: 'imm',    type: 3, attr: ['6','offset[5:3|8:6]']},
+  {bits: 2, name: 'op',     type: 8, attr: ['2', 'C0=00']},
+  {bits: 3, name: 'rs2\'',  type: 3, attr: ['3', 'src']},
+  {bits: 2, name: 'uimm',   type: 2, attr: ['2', 'offset[7:6]']},
+  {bits: 3, name: 'rs1\'',  type: 3, attr: ['3', 'base']},
+  {bits: 3, name: 'uimm',   types:3, attr: ['3', 'offset[5:3]']},
   {bits: 3, name: 'funct3', type: 8, attr: ['3', 'int C.FSD=101', 'cap rv32: C.FSD=101']},
 ], config: {bits: 16}}
 ....


### PR DESCRIPTION
The encoding diagram for `C.FSD` was completely wrong, it seem to have been a bad copy paste from `C.FSDSP`