### PR TITLE
Minor wording fix for mtvecc vectored check

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -513,7 +513,7 @@ either check fails.
 
 Additionally, when MODE=Vectored the capability has its tag bit cleared if the
 capability address + 4 x HICAUSE is not within the <<section_cap_representable_check>>.
-HICAUSE is the largest exception cause value that the implementation can write
+HICAUSE is the largest interrupt cause value that the implementation can write
 to <<mcause>> or <<scause>>/<<vscause>> when an interrupt is taken.
 
 NOTE: When MODE=Vectored, it is only required that address + 4 x HICAUSE is


### PR DESCRIPTION
The word `exception` is erroneous here, `HICAUSE` should be the highest _interrupt_ cause, not exception cause.