### PR TITLE
Update contributors.

### DIFF
--- a/src/contributors.adoc
+++ b/src/contributors.adoc
@@ -26,6 +26,7 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Jamie Melling <jamie.melling@codasip.com>
 * Stuart Menefy <stuart.menefy@codasip.com>
 * Simon W. Moore <simon.moore@cl.cam.ac.uk>
+* Prashanth Mundkur <prashanth@riscv.org>
 * Peter G. Neumann <neumann@csl.sri.com>
 * Robert Norton <robert.norton@cl.cam.ac.uk>
 * Alexander Richardson <alexrichardson@google.com>


### PR DESCRIPTION
I had worked on the Sail model of CHERI RISC-V and contributed to the Cambridge architecture document.