### PR TITLE
Update specifications status to "Stable"

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -9,15 +9,6 @@ on:
         description: 'Release version, e.g. X.Y.Z:'
         required: true
         type: string
-      revision_mark:
-        description: 'Set revision mark as Draft, Release or Stable:'
-        required: true
-        type: choice
-        options:
-          - Draft
-          - Release
-          - Stable
-        default: Draft
       prerelease:
         description: Tag as a pre-release?
         required: false
@@ -52,7 +43,6 @@ jobs:
       - name: Update environment variables for releases
         run: |
           echo "VERSION=v${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
-          echo "REVMARK=${{ github.event.inputs.revision_mark }}" >> "$GITHUB_ENV"
         if: github.event_name == 'workflow_dispatch'
 
       - name: Update environment variables for push events

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ GEN_SCRIPT   = $(SCRIPTS_DIR)/generate_tables.py
 # Version and date
 DATE    ?= $(shell date +%Y-%m-%d)
 VERSION ?= v0.9.5
-REVMARK ?= Draft
 
 # Directories and files
 BUILD_DIR   = build
@@ -84,7 +83,6 @@ ASCIIDOC_OPTIONS  = --trace --verbose                                \
                     -a compress                                      \
                     -a mathematical-format=svg                       \
                     -a revnumber=$(VERSION)                          \
-                    -a revremark=$(REVMARK)                          \
                     -a revdate=$(DATE)                               \
                     -a buildir=$(BUILD_DIR)                          \
                     -a srcdir=$(SRC_DIR)                             \

--- a/src/attributes.adoc
+++ b/src/attributes.adoc
@@ -3,7 +3,7 @@
 :company: RISC-V.org
 :revdate: 1/2023
 :revnumber: 1.0
-:revremark: This document is under development. Expect potential changes. Visit http://riscv.org/spec-state for further details.
+:revremark: This document is in Stable state.  Assume it may change.
 :revinfo:
 :url-riscv: http://riscv.org
 :doctype: book

--- a/src/riscv-cheri.adoc
+++ b/src/riscv-cheri.adoc
@@ -13,11 +13,9 @@ The latest versioned PDF release can be downloaded from https://github.com/riscv
 endif::[]
 
 [WARNING]
-.This document is in the link:http://riscv.org/spec-state[Development state]
+.This document is in the link:https://lf-riscv.atlassian.net/wiki/display/HOME/Specification+States[Stable state]
 ====
-Expect potential changes. This draft specification is likely to evolve before
-it is accepted as a standard. Implementations based on this draft
-may not conform to the future standard.
+Assume anything could still change, but limited change should be expected.
 ====
 
 [preface]


### PR DESCRIPTION
Following the completed Internal Review, the Feb 18 TG vote and the request for ARC review the specification state should now be stable.

While updating this, drop being able to set the state from the workflow run.