### PR TITLE
do mtvecc rep check with MODE field zeroed

### DIFF
--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -511,8 +511,9 @@ change on writing. If the MODE field is non-zero after any WARL conversion,
 then the address used for the exception vector (which has **mtvecc.address[1:0]=2'b00**)
 will not match the value read by software from the CSR.
 
-In this situation, the same capability can have more than one address.
-When updating the CSR _all possible_ values of the address must be in the
+In this situation, the same capability can effectively have more than one address.
+When updating the CSR _all possible_ values of the address visible either by CSR read,
+or which are used as the <<pcc>> on exception launch, must be in the
 <<section_cap_representable_check>>, and the tag cleared if _any_ are not.
 
 The capability is always written using <<SCADDR>> semantics to update the address field,
@@ -520,11 +521,11 @@ even when writing the full capability, and so sealed capabilities will always ha
 their tags cleared.
 
 Additionally, when MODE=Vectored the capability has its tag bit cleared if the
-capability address + 4 x HICAUSE is not within the <<section_cap_representable_check>>.
+capability address~3 + 4xHICAUSE is not within the <<section_cap_representable_check>>.
 HICAUSE is the largest interrupt cause value that the implementation can write
 to <<mcause>> or <<scause>>/<<vscause>> when an interrupt is taken.
 
-NOTE: When MODE=Vectored, it is only required that address + 4 x HICAUSE is
+NOTE: When MODE=Vectored, it is only required that the capability address + 4xHICAUSE is
 within the <<section_cap_representable_check>> instead of the capability's bounds.
 This ensures
 that software is not forced to allocate a capability granting access to more
@@ -532,7 +533,7 @@ memory for the trap-vector than necessary to handle the trap causes that
 actually occur in the system.
 
 NOTE: When MODE=Vectored, if either the capability address _or_ the capability
-address + 4 x HICAUSE are invalid then the <<section_invalid_addr_conv>> rules
+address + 4xHICAUSE are invalid then the <<section_invalid_addr_conv>> rules
 are followed which may require the tag to be cleared. In particular, if any part
 of the range is in the invalid address space then clearing the tag is strongly
 recommended.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -507,7 +507,7 @@ its address incremented by four times the interrupt cause number.
 
 Capabilities written to <<mtvecc>> also include writing the MODE field in
 **mtvecc.address[1:0]**, which is a WARL field, meaning that the capability address can
-change on writing. If the MODE field is non-zero after any legalization,
+be legalized. If the MODE field is non-zero after any legalization,
 then the address used for the exception vector (which has **mtvecc.address[1:0]=2'b00**)
 will not match the value read by software from the CSR.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -521,11 +521,11 @@ even when writing the full capability, and so sealed capabilities will always ha
 their tags cleared.
 
 Additionally, when MODE=Vectored the capability has its tag bit cleared if the
-capability address~3 + 4xHICAUSE is not within the <<section_cap_representable_check>>.
+`(capability address & ~3) + 4 * HICAUSE` is not within the <<section_cap_representable_check>>.
 HICAUSE is the largest interrupt cause value that the implementation can write
 to <<mcause>> or <<scause>>/<<vscause>> when an interrupt is taken.
 
-NOTE: When MODE=Vectored, it is only required that the capability address + 4xHICAUSE is
+NOTE: When MODE=Vectored, it is only required that the capability address + `4 *  HICAUSE` is
 within the <<section_cap_representable_check>> instead of the capability's bounds.
 This ensures
 that software is not forced to allocate a capability granting access to more
@@ -533,7 +533,7 @@ memory for the trap-vector than necessary to handle the trap causes that
 actually occur in the system.
 
 NOTE: When MODE=Vectored, if either the capability address _or_ the capability
-address + 4xHICAUSE are invalid then the <<section_invalid_addr_conv>> rules
+address + `4 * HICAUSE` are invalid then the <<section_invalid_addr_conv>> rules
 are followed which may require the tag to be cleared. In particular, if any part
 of the range is in the invalid address space then clearing the tag is strongly
 recommended.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -506,13 +506,17 @@ interrupts cause the <<pcc>> to be set to the capability with
 its address incremented by four times the interrupt cause number.
 
 Capabilities written to <<mtvecc>> also include writing the MODE field in
-**mtvecc.address[1:0]**, even though it is not actually part of the exception vector address.
-The capability is _always_ written using <<SCADDR>> semantics to update the address field,
-and so sealed capabilities will always have their tags cleared and the <<section_cap_representable_check>>
-is always checked with **mtvecc.address[1:0]=2'b00**.
+**mtvecc.address[1:0]**, which is a WARL field, meaning that the capability address can
+change on writing. If the MODE field is non-zero after any WARL conversion,
+then the address used for the exception vector (which has **mtvecc.address[1:0]=2'b00**)
+will not match the value read by software from the CSR.
 
-NOTE: The representability check must be done on the same address used as the exception vector
- otherwise it is possible to change the capability address without re-checking the <<section_cap_representable_check>>.
+In this situation, the same capability can have more than one address.
+When updating the CSR _all possible_ values of the address must be in the
+<<section_cap_representable_check>>, and the tag cleared if _any_ are not.
+
+The capability is written using <<SCADDR>> semantics to update the address field,
+and so sealed capabilities will always have their tags cleared.
 
 Additionally, when MODE=Vectored the capability has its tag bit cleared if the
 capability address + 4 x HICAUSE is not within the <<section_cap_representable_check>>.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -515,8 +515,9 @@ In this situation, the same capability can have more than one address.
 When updating the CSR _all possible_ values of the address must be in the
 <<section_cap_representable_check>>, and the tag cleared if _any_ are not.
 
-The capability is written using <<SCADDR>> semantics to update the address field,
-and so sealed capabilities will always have their tags cleared.
+The capability is always written using <<SCADDR>> semantics to update the address field,
+even when writing the full capability, and so sealed capabilities will always have
+their tags cleared.
 
 Additionally, when MODE=Vectored the capability has its tag bit cleared if the
 capability address + 4 x HICAUSE is not within the <<section_cap_representable_check>>.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -507,7 +507,7 @@ its address incremented by four times the interrupt cause number.
 
 Capabilities written to <<mtvecc>> also include writing the MODE field in
 **mtvecc.address[1:0]**. As a result, a representability and sealing check is
-performed on the capability with the legalized (WARL) MODE field included in
+performed on the capability with the MODE field zeroed in
 the address. The tag of the capability written to <<mtvecc>> is cleared if
 either check fails.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -511,7 +511,6 @@ be legalized. If the MODE field is non-zero after any legalization,
 then the address used for the exception vector (which has **mtvecc.address[1:0]=2'b00**)
 will not match the value read by software from the CSR.
 
-In this situation, the same capability can effectively have more than one address.
 When updating the CSR _all possible_ values of the address visible either by CSR read,
 or which are used as the <<pcc>> on exception launch, must be in the
 <<section_cap_representable_check>>, and the tag cleared if _any_ are not.

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -507,7 +507,7 @@ its address incremented by four times the interrupt cause number.
 
 Capabilities written to <<mtvecc>> also include writing the MODE field in
 **mtvecc.address[1:0]**, which is a WARL field, meaning that the capability address can
-change on writing. If the MODE field is non-zero after any WARL conversion,
+change on writing. If the MODE field is non-zero after any legalization,
 then the address used for the exception vector (which has **mtvecc.address[1:0]=2'b00**)
 will not match the value read by software from the CSR.
 

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -506,10 +506,13 @@ interrupts cause the <<pcc>> to be set to the capability with
 its address incremented by four times the interrupt cause number.
 
 Capabilities written to <<mtvecc>> also include writing the MODE field in
-**mtvecc.address[1:0]**. As a result, a representability and sealing check is
-performed on the capability with the MODE field zeroed in
-the address. The tag of the capability written to <<mtvecc>> is cleared if
-either check fails.
+**mtvecc.address[1:0]**, even though it is not actually part of the exception vector address.
+The capability is _always_ written using <<SCADDR>> semantics to update the address field,
+and so sealed capabilities will always have their tags cleared and the <<section_cap_representable_check>>
+is always checked with **mtvecc.address[1:0]=2'b00**.
+
+NOTE: The representability check must be done on the same address used as the exception vector
+ otherwise it is possible to change the capability address without re-checking the <<section_cap_representable_check>>.
 
 Additionally, when MODE=Vectored the capability has its tag bit cleared if the
 capability address + 4 x HICAUSE is not within the <<section_cap_representable_check>>.


### PR DESCRIPTION
We must do the rep check on the value which is actually used on exception launch, otherwise it's possible to jump to a value outside the rep range by clearing the LSB of mtvecc in vectored mode

fixes https://github.com/riscv/riscv-cheri/issues/540

This effects all versions of the spec from at least version 0.9.0