### PR TITLE
Improve consistency of CSR descriptions

### DIFF
--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -97,8 +97,7 @@ include::img/dpcreg.edn[]
 [#dpcc,reftext="dpcc"]
 ==== Debug Program Counter Capability (dpcc)
 
-The <<dpcc>> register is a renamed extension to <<dpc>> that is able to hold a
-capability.
+The <<dpcc>> register extends <<dpc>> to hold a capability.
 
 {TAG_RESET_CSR}
 
@@ -140,8 +139,7 @@ include::img/dscratch0reg.edn[]
 [#dscratch0c,reftext="dscratch0c"]
 ==== Debug Scratch Register 0 Capability (dscratch0c)
 
-The <<dscratch0c>> register is a CLEN-bit plus tag bit renamed extension to
-<<dscratch0>> that is able to hold a capability.
+The <<dscratch0c>> register extends <<dscratch0>> to hold a capability.
 
 {TAG_RESET_CSR}
 
@@ -161,8 +159,7 @@ include::img/dscratch1reg.edn[]
 [#dscratch1c,reftext="dscratch1c"]
 ==== Debug Scratch Register 1 Capability (dscratch1c)
 
-The <<dscratch1c>> register is a CLEN-bit plus tag bit renamed extension to
-<<dscratch1>> that is able to hold a capability.
+The <<dscratch1c>> register extends <<dscratch1>> to hold a capability.
 
 {TAG_RESET_CSR}
 

--- a/src/hypervisor-integration.adoc
+++ b/src/hypervisor-integration.adoc
@@ -83,8 +83,8 @@ include::img/vstvecreg.edn[]
 [#vstvecc,reftext="vstvecc"]
 === Virtual Supervisor Trap Vector Base Address Capability Register (vstvecc)
 
-The <<vstvecc>> register is a renamed extension of <<vstvec>> that is able to
-hold a capability. Its reset value is the <<infinite-cap>> capability.
+The <<vstvecc>> register extends <<vstvec>> to hold a capability.
+Its reset value is the <<infinite-cap>> capability.
 
 .Virtual supervisor trap vector base address capability register
 include::img/vstveccreg.edn[]
@@ -105,8 +105,7 @@ include::img/vsscratchreg.edn[]
 [#vsscratchc,reftext="vsscratchc"]
 === Virtual Supervisor Scratch Register (vsscratchc)
 
-The <<vsscratchc>> register is a renamed version of <<vsscratch>> that is able
-to hold a capability.
+The <<vsscratchc>> register extends <<vsscratch>> to hold a capability.
 
 {TAG_RESET_CSR}
 
@@ -127,8 +126,8 @@ include::img/vsepcreg.edn[]
 [#vsepcc,reftext="vsepcc"]
 === Virtual Supervisor Exception Program Counter Capability (vsepcc)
 
-The <<vsepcc>> register is a renamed extension of <<vsepc>> that is able to
-hold a capability. Its reset value is the <<infinite-cap>> capability.
+The <<vsepcc>> register extends <<vsepc>> to hold a capability.
+Its reset value is the <<infinite-cap>> capability.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<vsepcc>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
 Additionally, the capability in <<vsepcc>> is unsealed when it is installed in

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -12,7 +12,7 @@ CSRs enabling CHERI features. The remainder of this section describes
 these features in detail as well as their integration with the primary base
 integer variants of the RISC-V ISA (RV32I and RV64I).
 
-[#section-cheri-execution-mode]
+[#section-cheri-execution-mode,reftext="CHERI Execution Mode"]
 === CHERI Execution Mode
 
 {cheri_default_ext_name} adds CHERI execution modes to ensure backwards

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -330,8 +330,7 @@ two tag bits in memory.
 
 {cheri_base_ext_name} requires that RISC-V CSRs intended to hold addresses,
 are now able to hold capabilities. Therefore, such registers are
-extended to CLEN+1 bits in {cheri_base_ext_name} and a `c` suffix is added such
-as <<mtvec>> is extended to <<mtvecc>>.
+extended to CLEN+1 bits in {cheri_base_ext_name} and a `c` suffix is added (e.g. <<mtvec>> is extended to <<mtvecc>>).
 
 Reading or writing any part of a CLEN-bit CSR may cause
 side effects. For example, the CSR's tag bit may be cleared if a new address

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -329,8 +329,9 @@ two tag bits in memory.
 === Zicsr, Control and Status Register (CSR) Instructions
 
 {cheri_base_ext_name} requires that RISC-V CSRs intended to hold addresses,
-like <<mtvec>>, are now able to hold capabilities. Therefore, such registers are
-renamed and extended to CLEN+1 bits in {cheri_base_ext_name}.
+are now able to hold capabilities. Therefore, such registers are
+extended to CLEN+1 bits in {cheri_base_ext_name} and a `c` suffix is added such
+as <<mtvec>> is extended to <<mtvecc>>.
 
 Reading or writing any part of a CLEN-bit CSR may cause
 side effects. For example, the CSR's tag bit may be cleared if a new address

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -330,7 +330,7 @@ two tag bits in memory.
 
 {cheri_base_ext_name} requires that RISC-V CSRs intended to hold addresses,
 like <<mtvec>>, are now able to hold capabilities. Therefore, such registers are
-renamed and extended to CLEN-bit in {cheri_base_ext_name}.
+renamed and extended to CLEN+1 bits in {cheri_base_ext_name}.
 
 Reading or writing any part of a CLEN-bit CSR may cause
 side effects. For example, the CSR's tag bit may be cleared if a new address
@@ -388,6 +388,7 @@ xref:vscsrnames-renamed[xrefstyle=short] and
 xref:ucsrnames-renamed[xrefstyle=short] from the base RISC-V ISA and its
 extensions. The CSRs are renamed to reflect the fact that they are extended to
 CLEN+1 bits wide, as the *x* registers are renamed to *c* registers.
+Even though the name changes, the CSR index remains identical and the <<section-cheri-execution-mode>> determines whether CLEN+1 or XLEN bits are returned (see <<CSRRW>>).
 
 [[dcsrnames-renamed]]
 .Renamed debug-mode CSRs in {cheri_base_ext_name}
@@ -486,9 +487,8 @@ include::img/mtvecreg.edn[]
 [#mtvecc,reftext="mtvecc"]
 ==== Machine Trap Vector Base Address Capability Register (mtvecc)
 
-The <<mtvecc>> register is a renamed extension of <<mtvec>> that holds a
-capability.  Its reset value is the <<infinite-cap>> capability. The capability
-represents a code pointer.
+The <<mtvecc>> register extends <<mtvec>> to hold a code capability.
+Its reset value is the <<infinite-cap>> capability.
 
 .Machine-mode trap-vector base-capability register
 include::img/mtveccreg.edn[]
@@ -528,6 +528,8 @@ are followed which may require the tag to be cleared. In particular, if any part
 of the range is in the invalid address space then clearing the tag is strongly
 recommended.
 
+As shown in xref:CSR_exevectors[xrefstyle=short], <<mtvecc>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
+
 [#mscratch, reftext="mscratch"]
 ==== Machine Scratch Register (mscratch)
 
@@ -543,8 +545,7 @@ include::img/mscratchreg.edn[]
 [#mscratchc, reftext="mscratchc"]
 ==== Machine Scratch Capability Register (mscratchc)
 
-The <<mscratchc>> register is a renamed extension of <<mscratch>> that is able to
-hold a capability.
+The <<mscratchc>> register extends <<mscratch>> to hold a capability.
 
 {TAG_RESET_CSR}
 
@@ -565,8 +566,8 @@ include::img/mepcreg.edn[]
 [#mepcc,reftext="mepcc"]
 ==== Machine Exception Program Counter Capability (mepcc)
 
-The <<mepcc>> register is a renamed extension of <<mepc>> that is able to hold a
-capability. Its reset value is the <<infinite-cap>> capability.
+The <<mepcc>> register extends <<mepc>> to hold a capability.
+Its reset value is the <<infinite-cap>> capability.
 
 .Machine exception program counter capability register
 include::img/mepccreg.edn[]
@@ -913,11 +914,8 @@ include::img/stvecreg.edn[]
 [#stvecc,reftext="stvecc"]
 ==== Supervisor Trap Vector Base Address Capability Register (stvecc)
 
-The <<stvec>> register is an SXLEN-bit WARL read/write register that holds the
-trap vector configuration, consisting of a vector base address (BASE) and a
-vector mode (MODE). The <<stvecc>> register is a renamed extension of <<stvec>>
-that is able to hold a capability. Its reset value is the <<infinite-cap>>
-capability.
+The <<stvecc>> register extends <<stvec>> that is able to hold a capability.
+Its reset value is the <<infinite-cap>> capability.
 
 .Supervisor trap-vector base-capability register
 include::img/stveccreg.edn[]
@@ -940,8 +938,7 @@ include::img/sscratchreg.edn[]
 [#sscratchc, reftext="sscratchc"]
 ==== Supervisor Scratch Capability Register (sscratchc)
 
-The <<sscratchc>> register is a renamed extension of <<sscratch>> that is able to
-hold a capability.
+The <<sscratchc>> register extends <<sscratch>> to hold a capability.
 
 {TAG_RESET_CSR}
 
@@ -962,8 +959,8 @@ include::img/sepcreg.edn[]
 [#sepcc,reftext="sepcc"]
 ==== Supervisor Exception Program Counter Capability (sepcc)
 
-The <<sepcc>> register is a renamed extension of <<sepc>> that is able to hold a
-capability. Its reset value is the <<infinite-cap>> capability.
+The <<sepcc>> register extends <<sepc>> to hold a capability.
+Its reset value is the <<infinite-cap>> capability.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<sepcc>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
 Additionally, the capability in <<sepcc>> is unsealed when it is installed in

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -389,7 +389,9 @@ xref:vscsrnames-renamed[xrefstyle=short] and
 xref:ucsrnames-renamed[xrefstyle=short] from the base RISC-V ISA and its
 extensions. The CSRs are renamed to reflect the fact that they are extended to
 CLEN+1 bits wide, as the *x* registers are renamed to *c* registers.
-Even though the name changes, the CSR index remains identical and the <<section-cheri-execution-mode>> determines whether CLEN+1 or XLEN bits are returned (see <<CSRRW>>).
+Even though the CSR is extended, the CSR index remains identical.
+
+NOTE: If {cheri_default_ext_name} is supported then the <<section-cheri-execution-mode>> determines whether CLEN+1 or XLEN bits are returned (see <<CSRRW>>).
 
 [[dcsrnames-renamed]]
 .Renamed debug-mode CSRs in {cheri_base_ext_name}

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -139,7 +139,7 @@ include::generated/csr_permission_table_body.adoc[]
 
 xref:cap_mode_insns[xrefstyle=short], xref:legacy_mode_insns[xrefstyle=short]
 and xref:both_mode_insns[xrefstyle=short] summarize on which
-<<section-cheri-execution-mode,CHERI execution mode>> each instruction may be
+<<section-cheri-execution-mode>> each instruction may be
 executed in.
 
 .Instructions valid for execution in {cheri_cap_mode_name} only
@@ -193,10 +193,10 @@ include::generated/illegal_insns_table_body.adoc[]
 xref:cheri_behavior_cre_mode[xrefstyle=short] summarizes the behavior of a hart
 supporting both {cheri_base_ext_name} and {cheri_default_ext_name} in
 connection with the <<section_cheri_disable,CRE>> and the
-<<section-cheri-execution-mode,CHERI execution mode>> while in a privilege
+<<section-cheri-execution-mode>> while in a privilege
 other than debug mode.
 
-.Hart's behavior depending on the effective <<section_cheri_disable,CRE>> and <<section-cheri-execution-mode,CHERI execution mode>>
+.Hart's behavior depending on the effective <<section_cheri_disable,CRE>> and <<section-cheri-execution-mode>>
 [#cheri_behavior_cre_mode,width=100%,options=header,align=center,%autowidth,cols="8,8,15,12,12,15,15,15"]
 |==============================================================================
 // Header

--- a/src/tid-ext.adoc
+++ b/src/tid-ext.adoc
@@ -103,8 +103,7 @@ extended as follows:
 [#mtidc,reftext="mtidc"]
 ==== Machine Thread Identifier Capability (mtidc)
 
-The <<mtidc>> register is an CLEN-bit read-write capability register.
-It is the capability extension of the <<mtid>> register.
+The <<mtidc>> register extends <<mtid>> to hold a capability.
 It is used to identify the current software thread in machine mode.
 On reset the tag of <<mtidc>> will be set to 0 and the remainder
 of the data is UNSPECIFIED.
@@ -115,8 +114,7 @@ include::img/mtidcreg.edn[]
 [#stidc,reftext="stidc"]
 ==== Supervisor Thread Identifier Capability (stidc)
 
-The <<stidc>> register is an CLEN-bit read-write capability register.
-It is the capability extension of the <<stid>> register.
+The <<stidc>> register extends <<stid>> to hold a capability.
 It is used to identify the current software thread in supervisor mode.
 On reset the tag of <<stidc>> will be set to 0 and the remainder
 of the data is UNSPECIFIED.
@@ -127,9 +125,8 @@ include::img/stidcreg.edn[]
 [#vstidc,reftext="vstidc"]
 ==== Virtual Supervisor Thread Identifier Capability (vstidc)
 
-The <<vstidc>> register is a CLEN-bit read-write capability register.
-It is the capability extension of the <<vstid>> register used to
-identify the current software thread in virtual supervisor mode.
+The <<vstidc>> register extends <<vstid>>  to hold a capability.
+It is used to identify the current software thread in virtual supervisor mode.
 As other Virtual Supervisor registers when V=1, <<vstidc>> substitutes
 for <<stidc>>, so that instructions that normally read or modify
 <<stidc>> actually access <<vstidc>> instead.
@@ -144,8 +141,7 @@ include::img/vstidcreg.edn[]
 [#utidc,reftext="utidc"]
 ==== User Thread Identifier Capability (utidc)
 
-The <<utidc>> register is an CLEN-bit read-write capability register.
-It is the capability extension of the <<utid>> register.
+The <<utidc>> register extends <<utid>> to hold a capability.
 It is used to identify the current software thread in user mode.
 On reset the tag of <<utidc>> will be set to 0 and the remainder
 of the data is UNSPECIFIED.

--- a/src/tid-ext.adoc
+++ b/src/tid-ext.adoc
@@ -125,7 +125,7 @@ include::img/stidcreg.edn[]
 [#vstidc,reftext="vstidc"]
 ==== Virtual Supervisor Thread Identifier Capability (vstidc)
 
-The <<vstidc>> register extends <<vstid>>  to hold a capability.
+The <<vstidc>> register extends <<vstid>> to hold a capability.
 It is used to identify the current software thread in virtual supervisor mode.
 As other Virtual Supervisor registers when V=1, <<vstidc>> substitutes
 for <<stidc>>, so that instructions that normally read or modify


### PR DESCRIPTION
Drop the "renamed extension" wording and make the descriptions consistent.