### PR TITLE
Update for ratified spec: Zilsd, Zclsd

### DIFF
--- a/src/insns/load_16bit.adoc
+++ b/src/insns/load_16bit.adoc
@@ -38,10 +38,10 @@ Standard load instructions, authorized by the capability in <<ddc>>.
 include::load_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} C.LD::
-RV64 or RV32 and Ziclsd, and {c_cheri_base_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_base_ext_names}
 
 Prerequisites for {cheri_int_mode_name} C.LD::
-RV64 or RV32 and Ziclsd, {c_cheri_default_ext_names}
+RV64 or RV32 and Zclsd, {c_cheri_default_ext_names}
 
 Prerequisites {cheri_cap_mode_name} C.LW::
 {c_cheri_base_ext_names}

--- a/src/insns/load_16bit.adoc
+++ b/src/insns/load_16bit.adoc
@@ -38,7 +38,7 @@ Standard load instructions, authorized by the capability in <<ddc>>.
 include::load_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} C.LD::
-RV64 or RV32 and Zclsd, and {c_cheri_base_ext_names}
+RV64 or RV32 with Zclsd, and {c_cheri_base_ext_names}
 
 Prerequisites for {cheri_int_mode_name} C.LD::
 RV64 or RV32 and Zclsd, {c_cheri_default_ext_names}

--- a/src/insns/load_16bit.adoc
+++ b/src/insns/load_16bit.adoc
@@ -10,32 +10,20 @@ See <<C_LW>>.
 Synopsis::
 Load (C.LD, C.LW), 16-bit encodings
 
-{cheri_cap_mode_name} Mnemonics (RV64)::
+{cheri_cap_mode_name} Mnemonics::
 `c.ld rd', offset(cs1')` +
 `c.lw rd', offset(cs1')`
 
-{cheri_cap_mode_name} Expansions (RV64)::
+{cheri_cap_mode_name} Expansions::
 `ld rd', offset(cs1')` +
 `lw rd', offset(cs1')`
 
-{cheri_int_mode_name} Mnemonics (RV64)::
+{cheri_int_mode_name} Mnemonics::
 `c.ld rd', offset(rs1')` +
 `c.lw rd', offset(rs1')`
 
-{cheri_int_mode_name} Expansions (RV64)::
+{cheri_int_mode_name} Expansions::
 `ld rd', offset(rs1')` +
-`lw rd', offset(rs1')`
-
-{cheri_cap_mode_name} Mnemonic (RV32)::
-`c.lw rd', offset(cs1')`
-
-{cheri_cap_mode_name} Expansion (RV32)::
-`lw rd', offset(cs1')`
-
-{cheri_int_mode_name} Mnemonic (RV32)::
-`c.lw rd', offset(rs1')`
-
-{cheri_int_mode_name} Expansion (RV32)::
 `lw rd', offset(rs1')`
 
 Encoding::
@@ -50,10 +38,10 @@ Standard load instructions, authorized by the capability in <<ddc>>.
 include::load_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} C.LD::
-RV64, and {c_cheri_base_ext_names}
+RV64 or RV32 and Ziclsd, and {c_cheri_base_ext_names}
 
 Prerequisites for {cheri_int_mode_name} C.LD::
-RV64, {c_cheri_default_ext_names}
+RV64 or RV32 and Ziclsd, {c_cheri_default_ext_names}
 
 Prerequisites {cheri_cap_mode_name} C.LW::
 {c_cheri_base_ext_names}

--- a/src/insns/load_16bit_sprel.adoc
+++ b/src/insns/load_16bit_sprel.adoc
@@ -11,29 +11,17 @@ See <<C_LDSP>>.
 Synopsis::
 Load (C.LWSP, C.LDSP), 16-bit encodings
 
-{cheri_cap_mode_name} Mnemonics (RV64)::
+{cheri_cap_mode_name} Mnemonics::
 `c.ld/c.lw rd, offset(csp)`
 
-{cheri_cap_mode_name} Expansions (RV64)::
+{cheri_cap_mode_name} Expansions::
 `ld/lw rd, offset(csp)`
 
-{cheri_int_mode_name} Mnemonics (RV64)::
+{cheri_int_mode_name} Mnemonics::
 `c.ld/c.lw rd, offset(sp)`
 
-{cheri_int_mode_name} Expansions (RV64)::
+{cheri_int_mode_name} Expansions::
 `ld/lw rd, offset(sp)`
-
-{cheri_cap_mode_name} Mnemonic (RV32)::
-`c.lw rd, offset(csp)`
-
-{cheri_cap_mode_name} Expansion (RV32)::
-`lw rd, offset(csp)`
-
-{cheri_int_mode_name} Mnemonic (RV32)::
-`c.lw rd, offset(sp)`
-
-{cheri_int_mode_name} Expansion (RV32)::
-`lw rd, offset(sp)`
 
 Encoding::
 include::wavedrom/c-sp-load-store.adoc[]
@@ -47,10 +35,10 @@ Standard stack pointer relative load instructions, authorized by the capability 
 include::load_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} C.LDSP::
-RV64, and {c_cheri_base_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_base_ext_names}
 
 Prerequisites for {cheri_int_mode_name} C.LDSP::
-RV64, and {c_cheri_default_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_default_ext_names}
 
 Prerequisites for {cheri_cap_mode_name} C.LWSP::
 {c_cheri_base_ext_names}

--- a/src/insns/load_32bit.adoc
+++ b/src/insns/load_32bit.adoc
@@ -32,25 +32,15 @@ See <<LB>>.
 Synopsis::
 Load (LD, LW[U], LH[U], LB[U])
 
-{cheri_cap_mode_name} Mnemonics (RV64)::
+{cheri_cap_mode_name} Mnemonics::
 `ld    rd, offset(cs1)` +
 `lw[u] rd, offset(cs1)` +
 `lh[u] rd, offset(cs1)` +
 `lb[u] rd, offset(cs1)`
 
-{cheri_int_mode_name} Mnemonics (RV64)::
+{cheri_int_mode_name} Mnemonics::
 `ld    rd, offset(rs1)` +
 `lw[u] rd, offset(rs1)` +
-`lh[u] rd, offset(rs1)` +
-`lb[u] rd, offset(rs1)`
-
-{cheri_cap_mode_name} Mnemonics (RV32)::
-`lw    rd, offset(cs1)` +
-`lh[u] rd, offset(cs1)` +
-`lb[u] rd, offset(cs1)`
-
-{cheri_int_mode_name} Mnemonics (RV32)::
-`lw    rd, offset(rs1)` +
 `lh[u] rd, offset(rs1)` +
 `lb[u] rd, offset(rs1)`
 
@@ -74,10 +64,10 @@ operation is <<ddc>>. A copy of the loaded value is written to `rd`.
 include::load_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} LD::
-RV64, {cheri_base_ext_name}
+RV64 or RV32 and Zilsd, {cheri_base_ext_name}
 
 Prerequisites for {cheri_int_mode_name} LD::
-RV64, {cheri_default_ext_name}
+RV64 or RV32 and Zilsd, {cheri_default_ext_name}
 
 Prerequisites for {cheri_cap_mode_name} LW[U], LH[U], LB[U]::
 {cheri_base_ext_name}, OR +

--- a/src/insns/store_16bit.adoc
+++ b/src/insns/store_16bit.adoc
@@ -11,32 +11,20 @@ See <<C.SW>>.
 Synopsis::
 Stores (C.SD, C.SW), 16-bit encodings
 
-{cheri_cap_mode_name} Mnemonics (RV64)::
+{cheri_cap_mode_name} Mnemonics::
 `c.sd rs2', offset(cs1')` +
 `c.sw rs2', offset(cs1')`
 
-{cheri_cap_mode_name} Expansions (RV64)::
+{cheri_cap_mode_name} Expansions::
 `sd rs2', offset(cs1')` +
 `sw rs2', offset(cs1')`
 
-{cheri_int_mode_name} Mnemonics (RV64)::
+{cheri_int_mode_name} Mnemonics::
 `c.sd rs2', offset(rs1')` +
 `c.sw rs2', offset(rs1')`
 
-{cheri_int_mode_name} Expansions (RV64)::
+{cheri_int_mode_name} Expansions::
 `sd rs2', offset(rs1')` +
-`sw rs2', offset(rs1')`
-
-{cheri_cap_mode_name} Mnemonic (RV32)::
-`c.sw rs2', offset(cs1')`
-
-{cheri_cap_mode_name} Expansion (RV32)::
-`sw rs2', offset(cs1')`
-
-{cheri_int_mode_name} Mnemonic (RV32)::
-`c.sw rs2', offset(rs1')`
-
-{cheri_int_mode_name} Expansion (RV32)::
 `sw rs2', offset(rs1')`
 
 Encoding::
@@ -51,10 +39,10 @@ Standard store instructions, authorized by the capability in <<ddc>>.
 include::store_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} C.SD::
-RV64, and {c_cheri_base_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_base_ext_names}
 
 Prerequisites for {cheri_int_mode_name} C.SD::
-RV64, and {c_cheri_default_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_default_ext_names}
 
 Prerequisites for {cheri_cap_mode_name} C.SW::
 {c_cheri_base_ext_names}

--- a/src/insns/store_16bit_sprel.adoc
+++ b/src/insns/store_16bit_sprel.adoc
@@ -11,32 +11,20 @@ See <<C_SDSP>>.
 Synopsis::
 Stack pointer relative stores (C.SWSP, C.SDSP), 16-bit encodings
 
-{cheri_cap_mode_name} Mnemonics (RV64)::
+{cheri_cap_mode_name} Mnemonics::
 `c.sd rs2, offset(csp)` +
 `c.sw rs2, offset(csp)`
 
-{cheri_cap_mode_name} Expansions (RV64)::
+{cheri_cap_mode_name} Expansions::
 `sd rs2, offset(csp)` +
 `sw rs2, offset(csp)`
 
-{cheri_int_mode_name} Mnemonics (RV64)::
+{cheri_int_mode_name} Mnemonics::
 `c.sd rs2, offset(sp)` +
 `c.sw rs2, offset(sp)`
 
-{cheri_int_mode_name} Expansions (RV64)::
+{cheri_int_mode_name} Expansions::
 `sd rs2, offset(sp)` +
-`sw rs2, offset(sp)`
-
-{cheri_cap_mode_name} Mnemonic (RV32)::
-`c.sw rs2, offset(csp)`
-
-{cheri_cap_mode_name} Expansion (RV32)::
-`sw rs2, offset(csp)`
-
-{cheri_int_mode_name} Mnemonic (RV32)::
-`c.sw rs2, offset(sp)`
-
-{cheri_int_mode_name} Expansion (RV32)::
 `sw rs2, offset(sp)`
 
 Encoding::
@@ -51,10 +39,10 @@ Standard stack pointer relative store instructions, authorized by the capability
 include::store_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} C.SDSP::
-RV64, and {c_cheri_base_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_base_ext_names}
 
 Prerequisites for {cheri_int_mode_name} C.SDSP::
-RV64, and {c_cheri_default_ext_names}
+RV64 or RV32 and Zclsd, and {c_cheri_default_ext_names}
 
 Prerequisites for {cheri_cap_mode_name} C.SWSP::
 {c_cheri_base_ext_names}

--- a/src/insns/store_32bit.adoc
+++ b/src/insns/store_32bit.adoc
@@ -20,24 +20,14 @@ See <<SB>>
 Synopsis::
 Stores (SD, SW, SH, SB)
 
-{cheri_cap_mode_name} Mnemonics (RV64)::
+{cheri_cap_mode_name} Mnemonics::
 `sd rs2, offset(cs1)` +
 `sw rs2, offset(cs1)` +
 `sh rs2, offset(cs1)` +
 `sb rs2, offset(cs1)`
 
-{cheri_int_mode_name} Mnemonics (RV64)::
+{cheri_int_mode_name} Mnemonics::
 `sd rs2, offset(rs1)` +
-`sw rs2, offset(rs1)` +
-`sh rs2, offset(rs1)` +
-`sb rs2, offset(rs1)`
-
-{cheri_cap_mode_name} Mnemonics (RV32)::
-`sw rs2, offset(cs1)` +
-`sh rs2, offset(cs1)` +
-`sb rs2, offset(cs1)`
-
-{cheri_int_mode_name} Mnemonics (RV32)::
 `sw rs2, offset(rs1)` +
 `sh rs2, offset(rs1)` +
 `sb rs2, offset(rs1)`
@@ -66,10 +56,10 @@ naturally aligned to CLEN/8 is cleared.
 include::store_exceptions.adoc[]
 
 Prerequisites for {cheri_cap_mode_name} SD::
-RV64, {cheri_base_ext_name}
+RV64 or RV32 and Zilsd, {cheri_base_ext_name}
 
 Prerequisites for {cheri_int_mode_name} SD::
-RV64, {cheri_default_ext_name}
+RV64 or RV32 and Zilsd, {cheri_default_ext_name}
 
 Prerequisites for {cheri_cap_mode_name} SW, SH, SB::
 {cheri_base_ext_name}

--- a/src/insns/wavedrom/c-cs-format-ls.adoc
+++ b/src/insns/wavedrom/c-cs-format-ls.adoc
@@ -9,6 +9,6 @@
   {bits: 2, name: 'uimm',         type: 2, attr: ['2', 'offset[2|6]','offset[7:6]']},
   {bits: 3, name: 'rs1\'/cs1\'',  type: 3, attr: ['3', 'base']},
   {bits: 3, name: 'uimm',         types:3, attr: ['3', 'offset[5:3]']},
-  {bits: 3, name: 'funct3',       type: 8, attr: ['3', 'C.SW=110', 'rv64: C.SD=111']},
+  {bits: 3, name: 'funct3',       type: 8, attr: ['3', 'C.SW=110', 'C.SD=111']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-store-css.adoc
+++ b/src/insns/wavedrom/c-sp-load-store-css.adoc
@@ -6,6 +6,6 @@
   {bits: 2, name: 'op',      type: 8, attr: ['2','C2=10']},
   {bits: 5, name: 'rs2/cs2', type: 4, attr: ['5','src']},
   {bits: 6, name: 'imm',     type: 3, attr: ['6','offset[5:3|8:6]', 'offset[5:2|7:6]']},
-  {bits: 3, name: 'funct3',  type: 8, attr: ['3', 'rv64: C.SDSP=111', 'C.SWSP=110']},
+  {bits: 3, name: 'funct3',  type: 8, attr: ['3', 'C.SDSP=111', 'C.SWSP=110']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/c-sp-load-store.adoc
+++ b/src/insns/wavedrom/c-sp-load-store.adoc
@@ -9,6 +9,6 @@
   {bits: 5, name: 'imm',    type: 5, attr: ['5', 'offset[4:2|7:6]','offset[4:3|8:6]']},
   {bits: 5, name: 'rd',     type: 5, attr: ['5','dest!=0']},
   {bits: 1, name: 'imm',    type: 1, attr: ['1','[5]']},
-  {bits: 3, name: 'funct3', type: 3, attr: ['3', 'C.LWSP=010', 'rv64: C.LDSP=011']},
+  {bits: 3, name: 'funct3', type: 3, attr: ['3', 'C.LWSP=010', 'C.LDSP=011']},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/load.adoc
+++ b/src/insns/wavedrom/load.adoc
@@ -5,7 +5,7 @@
 {reg: [
   {bits: 7,  name: 'opcode',    attr: ['7', 'LOAD=0000011'], type: 8},
   {bits: 5,  name: 'rd',        attr: ['5', 'dest'], type: 2},
-  {bits: 3,  name: 'funct3',    attr: ['3', 'width', 'LB=000', 'LH=001', 'LW=010', 'LBU=100', 'LHU=101', 'rv64: LWU=110', 'rv64: LD=011'], type: 8},
+  {bits: 3,  name: 'funct3',    attr: ['3', 'width', 'LB=000', 'LH=001', 'LW=010', 'LBU=100', 'LHU=101', 'rv64: LWU=110', 'LD=011'], type: 8},
   {bits: 5,  name: 'rs1/cs1!=0',attr: ['5', 'base'], type: 4},
   {bits: 12, name: 'imm[11:0]', attr: ['12', 'offset[11:0]'], type: 3},
 ]}

--- a/src/insns/wavedrom/reg-based-ldnstr.adoc
+++ b/src/insns/wavedrom/reg-based-ldnstr.adoc
@@ -8,6 +8,6 @@
   {bits: 2, name: 'imm',         attr: ['2', 'offset[2|6]','offset[7:6]'], type: 2},
   {bits: 3, name: 'rs1\'/cs1\'', attr: ['3', 'base'], type: 2},
   {bits: 3, name: 'imm',         attr: ['3', 'offset[5:3]'], type: 3},
-  {bits: 3, name: 'funct3',      attr: ['3', 'C.LW=010', 'rv64: C.LD=011',], type: 8},
+  {bits: 3, name: 'funct3',      attr: ['3', 'C.LW=010', 'C.LD=011',], type: 8},
 ], config: {bits: 16}}
 ....

--- a/src/insns/wavedrom/store.adoc
+++ b/src/insns/wavedrom/store.adoc
@@ -5,7 +5,7 @@
 {reg: [
   {bits: 7,  name: 'opcode',   attr: ['7', 'STORE=0100011'], type: 8},
   {bits: 5,  name: 'imm[4:0]', attr: ['5', 'offset[4:0]'], type: 3},
-  {bits: 3,  name: 'funct3', attr: ['3', 'SB=000','SH=001','SW=010','rv64: SD=011'], type: 8},
+  {bits: 3,  name: 'funct3', attr: ['3', 'SB=000','SH=001','SW=010','SD=011'], type: 8},
   {bits: 5,  name: 'rs1/cs1!=0', attr: ['5', 'base'], type: 4},
   {bits: 5,  name: 'rs2', attr: ['5', 'src'], type: 4},
   {bits: 7, name: 'imm[11:5]', attr: ['7', 'offset[11:5]'], type: 3},

--- a/src/instructions.adoc
+++ b/src/instructions.adoc
@@ -132,7 +132,7 @@ include::insns/store_32bit_fp.adoc[]
 One group of 16-bit encodings are remapped to different instructions dependent
 upon the CHERI execution mode, MXLEN and which extensions are supported.
 
-NOTE: Zcf and Zilsd are incompatible
+NOTE: Zcf and Zclsd are incompatible
 
 NOTE: Zcd and <<Zcmp>>/<<Zcmt>> incompatible
 
@@ -144,16 +144,16 @@ NOTE: Zcd and <<Zcmp>>/<<Zcmt>> incompatible
 [width="100%",options=header]
 |==============================================================================
 2+|Encoding    5+| Supported Extensions
-|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
-|111    |00      | N/A    | C.FSW   | N/A | N/A        | C.SD
-|011    |00      | N/A    | C.FLW   | N/A | N/A        | C.LD
-|111    |10      | N/A    | C.FSWSP | N/A | N/A        | C.SDSP
-|011    |10      | N/A    | C.FLWSP | N/A | N/A        | C.LDSP
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zclsd
+|111    |00      | N/A    | <<C.FSW>>   | N/A | N/A        | <<C.SD>>
+|011    |00      | N/A    | <<C.FLW>>   | N/A | N/A        | <<C.LD>>
+|111    |10      | N/A    | <<C.FSWSP>> | N/A | N/A        | <<C.SDSP>>
+|011    |10      | N/A    | <<C.FLWSP>> | N/A | N/A        | <<C.LDSP>>
 
-|101    |00      | N/A    | N/A     | C.FSD    | reserved^1^       | N/A
-|001    |00      | N/A    | N/A     | C.FLD    | reserved^1^       | N/A
-|101    |10      | N/A    | N/A     | C.FSDSP  | <<Zcmp>>/<<Zcmt>> | N/A
-|001    |10      | N/A    | N/A     | C.FLDSP  | reserved^1^       | N/A
+|101    |00      | N/A    | N/A     | <<C.FSD>>    | reserved^1^       | N/A
+|001    |00      | N/A    | N/A     | <<C.FLD>>    | reserved^1^       | N/A
+|101    |10      | N/A    | N/A     | <<C.FSDSP>>  | <<Zcmp>>/<<Zcmt>> | N/A
+|001    |10      | N/A    | N/A     | <<C.FLDSP>>  | reserved^1^       | N/A
 |==============================================================================
 
 ^1^ reserved for future standard Zcm extensions
@@ -163,11 +163,11 @@ NOTE: Zcd and <<Zcmp>>/<<Zcmt>> incompatible
 [width="100%",options=header]
 |==============================================================================
 2+|Encoding    5+| Supported Extensions
-|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
-|111    |00    5+| C.SC
-|011    |00    5+| C.LC
-|111    |10    5+| C.SCSP
-|011    |10    5+| C.LCSP
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zclsd
+|111    |00    5+| <<C.SC>>
+|011    |00    5+| <<C.LC>>
+|111    |10    5+| <<C.SCSP>>
+|011    |10    5+| <<C.LCSP>>
 
 |101    |00      | N/A    | N/A     | C.FSD    | reserved^1^       | N/A
 |001    |00      | N/A    | N/A     | C.FLD    | reserved^1^       | N/A
@@ -185,16 +185,16 @@ NOTE: Zcd and <<Zcmp>>/<<Zcmt>> incompatible
 [width="100%",options=header]
 |==============================================================================
 2+|Encoding    5+| Supported Extensions
-|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
-|111    |00      | C.SD   | N/A     | N/A | N/A        | N/A
-|011    |00      | C.LD   | N/A     | N/A | N/A        | N/A
-|111    |10      | C.SDSP | N/A     | N/A | N/A        | N/A
-|011    |10      | C.LDSP | N/A     | N/A | N/A        | N/A
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zclsd
+|111    |00      | <<C.SD>>   | N/A     | N/A | N/A        | N/A
+|011    |00      | <<C.LD>>   | N/A     | N/A | N/A        | N/A
+|111    |10      | <<C.SDSP>> | N/A     | N/A | N/A        | N/A
+|011    |10      | <<C.LDSP>> | N/A     | N/A | N/A        | N/A
 
-|101    |00      | N/A    | N/A     | C.FSD    | reserved^1^       | N/A
-|001    |00      | N/A    | N/A     | C.FLD    | reserved^1^       | N/A
-|101    |10      | N/A    | N/A     | C.FSDSP  | <<Zcmp>>/<<Zcmt>> | N/A
-|001    |10      | N/A    | N/A     | C.FLDSP  | reserved^1^       | N/A
+|101    |00      | N/A    | N/A     | <<C.FSD>>    | reserved^1^       | N/A
+|001    |00      | N/A    | N/A     | <<C.FLD>>    | reserved^1^       | N/A
+|101    |10      | N/A    | N/A     | <<C.FSDSP>>  | <<Zcmp>>/<<Zcmt>> | N/A
+|001    |10      | N/A    | N/A     | <<C.FLDSP>>  | reserved^1^       | N/A
 |==============================================================================
 
 .16-bit instruction remapping in {cheri_cap_mode_name}
@@ -202,16 +202,16 @@ NOTE: Zcd and <<Zcmp>>/<<Zcmt>> incompatible
 [width="100%",options=header]
 |==============================================================================
 2+|Encoding    5+| Supported Extensions
-|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zilsd
-|111    |00      | C.SD   | N/A     | N/A | N/A        | N/A
-|011    |00      | C.LD   | N/A     | N/A | N/A        | N/A
-|111    |10      | C.SDSP | N/A     | N/A | N/A        | N/A
-|011    |10      | C.LDSP | N/A     | N/A | N/A        | N/A
+|[15:13]|[1:0]   | Zca    | Zcf     | Zcd | Zcmp/ Zcmt | Zclsd
+|111    |00      | <<C.SD>>   | N/A     | N/A | N/A        | N/A
+|011    |00      | <<C.LD>>   | N/A     | N/A | N/A        | N/A
+|111    |10      | <<C.SDSP>> | N/A     | N/A | N/A        | N/A
+|011    |10      | <<C.LDSP>> | N/A     | N/A | N/A        | N/A
 
-|101    |00    5+| C.SC
-|001    |00    5+| C.LC
-|101    |10    5+| C.SCSP
-|001    |10    5+| C.LCSP
+|101    |00    5+| <<C.SC>>
+|001    |00    5+| <<C.LC>>
+|101    |10    5+| <<C.SCSP>>
+|001    |10    5+| <<C.LCSP>>
 |==============================================================================
 
 include::insns/condbr_16bit.adoc[]


### PR DESCRIPTION
Zilsd/Zclsd mean that LD, SD, C.LD, C.SD, C.LDSP, C.SCSP are available in RV32