### PR TITLE
Clarify CHERI PTE fault priority when 2-stage translation is in use

### DIFF
--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -37,6 +37,9 @@ Page faults are considered to be _CHERI PTE page faults_ if the `Xtval2` registe
 
 NOTE: It is possible for both a _normal_ page fault and a _CHERI PTE page fault_ to both trigger at once, as represented in the `Xtval2` value, as shown in <<mtval2-page-fault>>.
 
+NOTE: Where two stage translation is enabled, the _CHERI PTE page fault_ is only raised when
+the second stage translation has completed, and so is prioritized below guest page faults.
+
 All RV64 harts with virtual memory can raise _CHERI store/AMO PTE page faults_.
 Only harts which implement {cheri_pte_ext_name} can raise _CHERI load PTE page faults_.
 


### PR DESCRIPTION
CHERI PTE faults sometimes require a tag check which is not available until after two stage translation has completed and so can not be prioritised above guest page faults, even if other page faults are detected before completing translation.

There are occasions when a PTE permission fault can be taken, but the 2-stage translation hasn't finished, and so a load cannot have executed yet (as the physical address isn't available yet), and so the tag cannot be checked. In this case the page fault will be taken without reporting a CHERI PTE fault. It makes sense to say the same for the store.

the order is

possible page fault due to permissions
finish two-stage translation (possible guest page fault)
possible CHERI PTE fault

so it's not always possible to detect both the _normal_ and the CHERI PTE page faults at once

This affects all versions of the spec