### PR TITLE
CSR cleanup

### DIFF
--- a/src/debug-integration.adoc
+++ b/src/debug-integration.adoc
@@ -169,7 +169,8 @@ include::img/dscratch1creg.edn[]
 [#dinfc,reftext="dinfc"]
 ==== Debug Infinite Capability Register (dinfc)
 
-The <<dinfc>> register is a CLEN-bit plus tag bit CSR only accessible in debug mode.
+<<dinfc>> is a debug mode accessible capability CSR. The address and access details are shown in
+xref:default-csrnames-added[xrefstyle=short].
 
 The reset value is the <<infinite-cap>> capability.
 

--- a/src/insns/csrr_32bit.adoc
+++ b/src/insns/csrr_32bit.adoc
@@ -49,7 +49,8 @@ include::wavedrom/csr-instr.adoc[]
 
 Description::
 These are standard RISC-V CSR instructions with extended functionality for
-accessing capability CSRs, such as <<mtvec>>/<<mtvecc>>.
+accessing capability CSRs (see xref:all_capability_CSRs[xrefstyle=short]),
+including extended CSRs with actions as shown in
 +
 For capability CSRs, the full capability is read into `cd` in {cheri_cap_mode_name}.
 In {cheri_int_mode_name}, the address field is instead read into `rd`.

--- a/src/insns/csrrw_32bit.adoc
+++ b/src/insns/csrrw_32bit.adoc
@@ -22,20 +22,24 @@ Encoding::
 include::wavedrom/csrw-instr.adoc[]
 
 Description::
-This is a standard RISC-V CSR instructions with extended functionality for
-accessing CLEN-wide CSRs, such as <<mtvec>>/<<mtvecc>>.
+These are standard RISC-V CSR instructions with extended functionality for
+accessing capability CSRs (see xref:all_capability_CSRs[xrefstyle=short]).
 +
-See xref:aliased_CSRs[xrefstyle=short] for a list of CLEN-wide CSRs and
+See xref:aliased_CSRs[xrefstyle=short] for a list of CSRs extended to capabilities and
 xref:extended_CSR_writing[xrefstyle=short] for the action taken on writing each one.
 +
+Capability CSRs and the action taken on accessing them is shown in xref:new_cap_CSR_writing[xrefstyle=short].
++
 CSRRW writes `cs1` to extended CSRs in {cheri_cap_mode_name}, and reads a full capability into `cd`.
++
+CSRRW writes `cs1` to capability CSRs in both modes, and reads a full capability into `cd`.
 +
 CSRRW writes `rs1` to extended CSRs in {cheri_int_mode_name}, and reads the address field into `rd`.
 +
 If `cd` is `c0` (or `rd` is `x0`), then the instruction shall not read the CSR
 and shall not cause any of the side effects that might occur on a CSR read.
 +
-The assembler pseudoinstruction to write a capability CSR in {cheri_cap_mode_name},
+The assembler pseudoinstruction to write a capability CSR
 `csrw csr, cs1`, is encoded as `csrrw c0, csr, cs1`.
 +
 Access to XLEN-wide CSRs from other extensions is as specified by RISC-V.

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -296,9 +296,9 @@ and the requirement to support them in debug mode is also new.
 endif::[]
 
 [#dddc,reftext="dddc"]
-=== Debug Default Data Capability (dddc)
+=== Debug Default Data Capability CSR (dddc)
 
-<<dddc>> is a register that is able to hold a capability. The address is shown in
+<<dddc>> is a debug mode accessible capability CSR. The address is shown in
 xref:default-csrnames-added[xrefstyle=short].
 
 {TAG_RESET_CSR}
@@ -382,13 +382,13 @@ NOTE: xref:cheri_behavior_cre_mode[xrefstyle=short] summarizes the behavior of
 a hart in connection with the <<section_cheri_disable,CRE>> and the
 <<m_bit,CHERI execution mode>>.
 
-=== Added CLEN-wide CSRs
+=== Added Capability CSRs
 
-{cheri_default_ext_name} adds the CLEN-wide CSRs shown in
+{cheri_default_ext_name} adds the capability CSRs shown in
 xref:default-csrnames-added[xrefstyle=short].
 
 [[default-csrnames-added]]
-.CLEN-wide CSRs added in {cheri_default_ext_name}
+.Capability CSRs added in {cheri_default_ext_name}
 [%autowidth,float="center",align="center",cols="<,<,<,<,<",options="header"]
 |===
 include::generated/csr_added_hybrid_table_body.adoc[]
@@ -487,11 +487,14 @@ xref:section_cheri_disable[xrefstyle=short].
 The reset value is 0.
 
 [#ddc,reftext="ddc"]
-==== Default Data Capability (ddc)
+==== Default Data Capability CSR (ddc)
 
-The <<ddc>> CSR is a read-write capability register implicitly used as an
+<<ddc>> is a capability CSR. The address is shown in
+xref:default-csrnames-added[xrefstyle=short].
+
+<<ddc>> is a read-write, user mode accessible capability CSR implicitly used as an
 operand to authorize all data memory accesses when the current CHERI mode is
-{cheri_int_mode_name}. This register must be readable in any implementation. Its reset value
+{cheri_int_mode_name}. This CSR must be readable in any implementation. Its reset value
 is the <<infinite-cap>> capability.
 
 {REQUIRE_CRE_CSR}

--- a/src/riscv-integration.adoc
+++ b/src/riscv-integration.adoc
@@ -332,14 +332,14 @@ two tag bits in memory.
 are now able to hold capabilities. Therefore, such registers are
 extended to CLEN+1 bits in {cheri_base_ext_name} and a `c` suffix is added (e.g. <<mtvec>> is extended to <<mtvecc>>).
 
-Reading or writing any part of a CLEN-bit CSR may cause
+Reading or writing any part of a capability CSR may cause
 side effects. For example, the CSR's tag bit may be cleared if a new address
 is outside the <<section_cap_representable_check>> of a CSR capability being written.
 
 This section describes how the CSR instructions operate on these CSRs in
 {cheri_base_ext_name}.
 
-The CLEN-bit CSRs are summarized in xref:clen_csr_summary[xrefstyle=short].
+The capability CSRs are summarized in xref:clen_csr_summary[xrefstyle=short].
 
 [#zicsr-section-purecap]
 ==== CSR Instructions
@@ -357,7 +357,7 @@ When the <<CSRRW>> instruction is accessing a capability width CSR, then the sou
 and destination operands are *c* registers and it atomically swaps the values in the
 whole CSR with the CLEN width register operand.
 
-There are special rules for updating specific CLEN-wide CSRs as shown in <<extended_CSR_writing>>.
+There are special rules for updating specific capability CSRs as shown in <<extended_CSR_writing>>.
 
 When <<CSRRS>> and <<CSRRC>> instructions are accessing a capability width CSR,
 such as <<mtvecc>>, then the destination operand is a *c* register and the

--- a/src/tables.adoc
+++ b/src/tables.adoc
@@ -62,14 +62,14 @@ include::generated/Zcheri_hybrid_insns_table_body.adoc[]
 [#clen_csr_summary]
 == Capability Width CSR Summary
 
-.CSRs renamed and extended to capability width
+.CSRs aliased and extended to capability width
 [#aliased_CSRs]
 [width="100%",options=header,cols="1,1,1"]
 |==============================================================================
 include::generated/csr_aliases_table_body.adoc[]
 |==============================================================================
 
-.Action taken on writing to extended CSRs^**^
+.Action taken on writing to extended CSRs
 [#extended_CSR_writing]
 [width="100%",options=header,cols="1,2,2"]
 |==============================================================================
@@ -80,21 +80,21 @@ include::generated/csr_alias_action_table_body.adoc[]
  is within bounds of the capability written to `Xtvecc`. The check on writing
  must include the lowest (0 offset) and highest possible offset (e.g. 64 * MXLEN bits where HICAUSE=16).
 
-^**^ XLEN bits of extended capability CSRs are written when executing
+XLEN bits of extended capability CSRs are written when executing
 <<CSRRWI>>, <<CSRRC>>, <<CSRRS>>, <<CSRRCI>> or <<CSRRSI>> regardless of the
 CHERI execution mode. When using <<CSRRW>>, CLEN bits are written when the
 CHERI execution mode is {cheri_cap_mode_name} and XLEN bits are written when
 the mode is {cheri_int_mode_name}; therefore, writing XLEN bits with <<CSRRW>>
 is only possible when {cheri_default_ext_name} is implemented.
 
-.Action taken on writing to new capability CSRs^+^
+.Action taken on writing to capability CSRs
 [#new_cap_CSR_writing]
 [width="100%",options=header,cols="1,2,2"]
 |==============================================================================
 include::generated/new_csr_write_action_table_body.adoc[]
 |==============================================================================
 
-^+^ XLEN bits of new capability CSRs added in {cheri_default_ext_name} are
+XLEN bits of capability CSRs added in {cheri_default_ext_name} are
 written when executing <<CSRRWI>>, <<CSRRC>>, <<CSRRS>>, <<CSRRCI>> or
 <<CSRRSI>> regardless of the CHERI execution mode. CLEN bits are always written
 when using <<CSRRW>> regardless of the CHERI execution mode.
@@ -103,7 +103,7 @@ NOTE: Implementations which allow misa.C to be writable need to legalize *Xepcc*
  on _reading_ if the misa.C value has changed since the value was written as this
  can cause the read value of bit [1] to change state.
 
-.CLEN-wide CSRs storing code pointers or data pointers
+.Capability CSRs storing code pointers or data pointers
 [#CSR_exevectors]
 [width="100%",options=header,cols="1,1,1,1"]
 |==============================================================================
@@ -117,17 +117,10 @@ the address must be converted to another invalid address that the CSR is capable
 CSRs that store fewer address bits are also subject to the invalid address
 check in <<section_invalid_addr_conv>> on writing.
 
-.CLEN-wide CSRs which store all CLEN+1 bits
-[#CSR_metadata]
-[width="100%",options=header,cols="1,1"]
-|==============================================================================
-include::generated/csr_metadata_table_body.adoc[]
-|==============================================================================
+xref:all_capability_CSRs[xrefstyle=short] shows all capability CSRs.
 
-xref:CSR_metadata[xrefstyle=short] shows which CLEN-wide CSRs store all CLEN+1 bits. No other CLEN-wide CSRs store any reserved bits. All CLEN-wide CSRs store _all_ non-reserved metadata fields.
-
-.All CLEN-wide CSRs. {cheri_base_ext_name} is a prerequisite for all CSRs in this table
-[#extended_CSRs]
+.All capability CSRs.
+[#all_capability_CSRs]
 [width="100%",options=header,cols="2,1,1,2,2,4"]
 |==============================================================================
 include::generated/csr_permission_table_body.adoc[]


### PR DESCRIPTION
Includes fix for https://github.com/riscv/riscv-cheri/issues/555
Tidy up CSR* instruction pages as they were inaccurate
Remove option not to store full metadata in CSRs
Remove CLEN-wide CSR/CLEN+1-bit wide CSR phrases in favour of capability CSR (all were used previously)
