### PR TITLE
If CRE=0, PTE bits are reserved

### DIFF
--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -28,7 +28,7 @@ The minimum level of PTE support is to set CW to 1 in all PTEs intended for stor
 
 If <<section_cheri_disable,CRE>>=0 then the PTE.CW, PTE.CRG bits become _reserved_ when checking PTE permissions on memory accesses.
 
-NOTE: Hardware initiated memory accesses from the page-table walker are not checked by a capability, and also do not consider PTE.CW, PTE.CRG bits to be _reserved_.
+NOTE: Hardware initiated memory accesses from the page-table walker are not checked by a capability.
 
 [#cheri_pte_fault]
 === CHERI PTE page faults

--- a/src/cheri-pte-ext.adoc
+++ b/src/cheri-pte-ext.adoc
@@ -26,7 +26,9 @@ NOTE: The description below assumes that {cheri_pte_ext_name} has been implement
 
 The minimum level of PTE support is to set CW to 1 in all PTEs intended for storing capabilities (i.e. private anonymous mappings) and leave <<sstatusreg_pte,sstatus>>.UCRG and CRG in all PTEs set to 0, which will allow capabilities with their tags set to be loaded and stored successfully.
 
-NOTE: Hardware initiated memory accesses from the page-table walker are not checked by a capability.
+If <<section_cheri_disable,CRE>>=0 then the PTE.CW, PTE.CRG bits become _reserved_ when checking PTE permissions on memory accesses.
+
+NOTE: Hardware initiated memory accesses from the page-table walker are not checked by a capability, and also do not consider PTE.CW, PTE.CRG bits to be _reserved_.
 
 [#cheri_pte_fault]
 === CHERI PTE page faults

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -37,7 +37,7 @@ reported in the CAUSE field of <<mtval2>>, <<stval2>> or <<vstval2>>:
 |==============================================================================
 +
 If virtual memory is enabled on an RV64 hart, then the state of <<cheri_pte_ext,PTE>>.CW,
-and,  if {cheri_pte_ext_name} is implemented, <<cheri_pte_ext,PTE>>.CRG from the current virtual memory page may
+and, if {cheri_pte_ext_name} is implemented, <<cheri_pte_ext,PTE>>.CRG from the current virtual memory page may
 cause a <<cheri_pte_ext,CHERI PTE store/AMO page fault>> exception in addition to a normal RISC-V page fault
 when operating in user mode.
 See <<mtval2-page-fault>> for the exception reporting in this case.

--- a/src/insns/atomic_exceptions.adoc
+++ b/src/insns/atomic_exceptions.adoc
@@ -25,9 +25,7 @@ All misaligned atomics cause a store/AMO address misaligned exception to allow s
 When these instructions cause CHERI exceptions, _CHERI data fault_
 is reported in the TYPE field and the following codes may be
 reported in the CAUSE field of <<mtval2>>, <<stval2>> or <<vstval2>>:
-
-<<<
-
++
 [%autowidth,options=header,align=center]
 |==============================================================================
 | CAUSE                 | Reason
@@ -37,5 +35,13 @@ reported in the CAUSE field of <<mtval2>>, <<stval2>> or <<vstval2>>:
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]
 | Bounds violation      | At least one byte accessed is outside the authority capability bounds, or the capability has <<section_cap_malformed,malformed>> bounds
 |==============================================================================
-
++
+If virtual memory is enabled on an RV64 hart, then the state of <<cheri_pte_ext,PTE>>.CW,
+and,  if {cheri_pte_ext_name} is implemented, <<cheri_pte_ext,PTE>>.CRG from the current virtual memory page may
+cause a <<cheri_pte_ext,CHERI PTE store/AMO page fault>> exception in addition to a normal RISC-V page fault
+when operating in user mode.
+See <<mtval2-page-fault>> for the exception reporting in this case.
++
+If the effective <<section_cheri_disable,CRE>>=0 then <<cheri_pte_ext,PTE>>.CW and <<cheri_pte_ext,PTE>>.CRG are _reserved_.
++
 :!cap_atomic:

--- a/src/insns/load_exceptions.adoc
+++ b/src/insns/load_exceptions.adoc
@@ -23,10 +23,12 @@ listed below; in this case, _CHERI data fault_ is reported in the <<mtval2>>,
 
 |==============================================================================
 +
-If virtual memory is enabled on an RV64 hart, and {cheri_pte_ext_name} is implemented,
-then the state of <<cheri_pte_ext,PTE>>.CW, <<cheri_pte_ext,PTE>>.CRG, <<cheri_pte_ext,PTE>>.U and <<sstatusreg_pte,sstatus>>.UCRG,
+If virtual memory is enabled on an RV64 hart, then the state of <<cheri_pte_ext,PTE>>.CW,
+and, if {cheri_pte_ext_name} is implemented, <<cheri_pte_ext,PTE>>.CRG, <<cheri_pte_ext,PTE>>.U and <<sstatusreg_pte,sstatus>>.UCRG,
 may cause a <<cheri_pte_ext,CHERI PTE load page fault>> exception in addition to a normal RISC-V page fault exception.
 See <<mtval2-page-fault>> for the exception reporting in this case.
++
+If the effective <<section_cheri_disable,CRE>>=0 then <<cheri_pte_ext,PTE>>.CW and <<cheri_pte_ext,PTE>>.CRG are _reserved_.
 +
 :!load_res:
 :!has_cap_data:

--- a/src/insns/store_exceptions.adoc
+++ b/src/insns/store_exceptions.adoc
@@ -28,5 +28,7 @@ cause a <<cheri_pte_ext,CHERI PTE store/AMO page fault>> exception in addition t
 when operating in user mode.
 See <<mtval2-page-fault>> for the exception reporting in this case.
 +
+If the effective <<section_cheri_disable,CRE>>=0 then <<cheri_pte_ext,PTE>>.CW and <<cheri_pte_ext,PTE>>.CRG are _reserved_.
++
 :!store_cond:
 :!has_cap_data:

--- a/src/riscv-hybrid-integration.adoc
+++ b/src/riscv-hybrid-integration.adoc
@@ -344,6 +344,7 @@ instruction exception
  (see xref:csr-numbers-section[xrefstyle=short]) only allows XLEN access.
 * All allowed instructions execute as if the CHERI execution mode is {cheri_int_mode_name}.
 The mode bit in <<pcc>> is treated as if it was zero while CHERI register access is disabled.
+* Any added <<cheri_pte_ext,PTE>> bits become _reserved_.
 
 CHERI register access is disabled if
 


### PR DESCRIPTION
Fixes https://github.com/riscv/riscv-cheri/issues/558