### PR TITLE
Clarify scbndsr rounding

### DIFF
--- a/src/insns/scbndsr_32bit.adoc
+++ b/src/insns/scbndsr_32bit.adoc
@@ -22,8 +22,8 @@ Description::
 Capability register `cd`  is set to capability register `cs1`  with the base
 address of its bounds replaced with the value of `cs1.address` field and
 the length of its bounds set to `rs2`. The base is rounded down
-and the length is rounded up by the smallest amount needed to form a representable
-capability covering the requested bounds. In all cases, `cd.tag` is set to 0
+and the top is rounded up by the smallest amounts needed to form a representable
+capability covering the requested base and top. In all cases, `cd.tag` is set to 0
 if its bounds exceed `cs1` 's bounds, `cs1` 's tag is 0 or `cs1`  is sealed.
 
 Exceptions::


### PR DESCRIPTION
The existing wording was slightly ambiguous as it could be interpreted to allow you to return a cap with the base rounded down but the length as originally requested. The new wording avoids any potential confusion there.