### PR TITLE
Attempt to create consistency regarding commas around e.g. and i.e.

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -320,7 +320,7 @@ For {cheri_base_ext_name} the CT field is one bit wide and maps 1:1 to the capab
 ifdef::cheri_v9_annotations[]
 NOTE: *CHERI v9 Note:* The bounds mantissa width is different in MXLEN=32.
 Also, the old IE bit is renamed to Exponent Format (EF); the function of IE
-is the inverse of EF i.e. IE=0 has the same effect as EF=1.
+is the inverse of EF, i.e., IE=0 has the same effect as EF=1.
 
 NOTE: *CHERI v9 Note:* The mantissa width for RV32 was increased to 10.
 
@@ -532,7 +532,7 @@ image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 
 A capability has _infinite_ bounds if its bounds cover the entire address space
 such that the base address _b_=0 and the top address _t_&#8805;2^MXLEN^,
-i.e. _t_ is an MXLEN + 1 bit value. However, _b_ is an
+i.e., _t_ is an MXLEN + 1 bit value. However, _b_ is an
 MXLEN bit value and the size mismatch introduces additional complications
 when decoding, so the following condition is required to correct _t_ for
 capabilities whose <<section_cap_representable_check>> wraps the edge of the address
@@ -623,7 +623,7 @@ expanded base is 0 and top is 2^MXLEN^.
 | Reserved | zeros  | All reserved fields
 |==============================================================================
 
-^1^ This field may be zero bits wide (i.e. omitted) if {cheri_0levels_ext_name} is implemented.
+^1^ This field may be zero bits wide (i.e., omitted) if {cheri_0levels_ext_name} is implemented.
 
 [#section_infinite_cap_encoding]
 ==== Infinite Capability Encoding
@@ -663,7 +663,7 @@ NOTE: Future extension to the capability format may use a "multi-root" format wh
 * For MXLEN=32, the <<m_bit>> is set to {INT_MODE_VALUE} in the AP field, giving the value 0x9
 * For MXLEN=64, the <<m_bit>> is set to {INT_MODE_VALUE} in a separate M field which is _not shown_ in the table above.
 
-^2^ This field may be zero bits wide (i.e. omitted) if {cheri_0levels_ext_name} is implemented.
+^2^ This field may be zero bits wide (i.e., omitted) if {cheri_0levels_ext_name} is implemented.
 
 === Memory space
 
@@ -728,9 +728,9 @@ bounds are formed of two or three sections:
 .Composition of the decoded top address bound
 [#comp_addr_bounds,options=header,align="center",cols="2,4,2,2"]
 |==============================================================================
-| Configuration  | Upper Section (if E + MW < MXLEN) | Middle Section | Lower Section
-| EF=0           | address[MXLEN-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
-| EF=1, i.e. E=0 | address[MXLEN-1:MW] + ct   2+| T[MW - 1:0]
+| Configuration   | Upper Section (if E + MW < MXLEN) | Middle Section | Lower Section
+| EF=0            | address[MXLEN-1:E + MW] + ct | T[MW - 1:0] | {E{1'b0}}
+| EF=1, i.e., E=0 | address[MXLEN-1:MW] + ct   2+| T[MW - 1:0]
 |==============================================================================
 
 The _representable range_ defines the range of addresses which do not corrupt
@@ -822,7 +822,7 @@ Considering for an example `<<cheri_lvlbits>>=2`:
 |3 | As low as `~0b11=0` | Authorizes stores of capabilities with any level
 |2 | As low as `~0b10=1` | Strip tag for level 0 (most _local_), keep for 1,2,3
 |1 | As low as `~0b01=2` | Strip tag for level 0&1, keep for 2&3
-|0 | As low as `~0b00=3` | Strip tag for level 0,1,2, i.e. only the most _global_ can be stored
+|0 | As low as `~0b00=3` | Strip tag for level 0,1,2, i.e., only the most _global_ can be stored
 |===
 
 NOTE: While this extra negation is non-intuitive, it is required such that <<ACPERM>> can use a monotonically decreasing operation for both <<section_cap_level,CL>> <<sl_perm>>.

--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -670,7 +670,7 @@ NOTE: Future extension to the capability format may use a "multi-root" format wh
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
 space of 2^XLEN^ bytes for all memory accesses. Each memory region capable of
 holding a capability also stores a tag bit for each naturally aligned CLEN bits
-(e.g. 16 bytes in RV64), so that capabilities with their tag set can only be
+(e.g., 16 bytes in RV64), so that capabilities with their tag set can only be
 stored in naturally aligned addresses. Tags must be atomically bound to the
 data they protect.
 

--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -13,7 +13,7 @@ For existing RISC-V instructions, note that:
 
 . In {cheri_int_mode_name}, every byte of each memory access is bounds checked against <<ddc>>
 . In {cheri_int_mode_name}, a minimum length instruction at the target of all indirect jumps is bounds checked against <<pcc>>
-. In {cheri_cap_mode_name} a minimum length instruction at the target of all indirect jumps is bounds checked against `cs1` (e.g. <<JALR_CHERI>>)
+. In {cheri_cap_mode_name} a minimum length instruction at the target of all indirect jumps is bounds checked against `cs1` (e.g., <<JALR_CHERI>>)
 . A minimum length instruction at the taken target of all jumps and conditional branches is bounds checked against <<pcc>> regardless of
 CHERI execution mode
 

--- a/src/cheri/cheri-pte-ext.adoc
+++ b/src/cheri/cheri-pte-ext.adoc
@@ -27,7 +27,7 @@ NOTE: The description below assumes that {cheri_priv_crg_ext} has been implement
  If that is _not_ the case then PTE.CRG and <<sstatusreg_pte,sstatus>>.UCRG should be taken as read-only-zero for purpose of the description in the remainder of this chapter only.
  PTE.CRG and <<sstatusreg_pte,sstatus>>.UCRG remain reserved in this case.
 
-The minimum level of PTE support is to set CW to 1 in all PTEs intended for storing capabilities (i.e. private anonymous mappings) and leave <<sstatusreg_pte,sstatus>>.UCRG and CRG in all PTEs set to 0, which will allow capabilities with their tags set to be loaded and stored successfully.
+The minimum level of PTE support is to set CW to 1 in all PTEs intended for storing capabilities (i.e., private anonymous mappings) and leave <<sstatusreg_pte,sstatus>>.UCRG and CRG in all PTEs set to 0, which will allow capabilities with their tags set to be loaded and stored successfully.
 
 NOTE: Hardware initiated memory accesses from the page-table walker are not checked by a capability.
 
@@ -104,7 +104,7 @@ The PTE update must be
 atomic with respect to other accesses to the PTE, and must atomically check
 that the PTE is valid and grants sufficient permissions. Updates to the CW bit
 and CRG bit
-must be exact (i.e. not speculative), and observed in program order by the
+must be exact (i.e., not speculative), and observed in program order by the
 local hart. Furthermore, the PTE update must appear in the global memory order
 no later than the explicit memory access, or any subsequent explicit memory
 access to that virtual page by the local hart.  The ordering on loads and

--- a/src/cheri/insns/acperm_32bit.adoc
+++ b/src/cheri/insns/acperm_32bit.adoc
@@ -46,7 +46,7 @@ IMPORTANT: The <<el_perm,EL>>, <<sl_perm,SL>> and <<section_cap_level,CL>> field
 [#acperm_bit_field]
 include::../img/acperm_bit_field.edn[]
 
-NOTE: If a future extension adds a new permission that overlaps with an existing permission (e.g. finer-grained <<asr_perm>>), then clearing the original must also clear the new permission.
+NOTE: If a future extension adds a new permission that overlaps with an existing permission (e.g., finer-grained <<asr_perm>>), then clearing the original must also clear the new permission.
 This ensures software forward-compatibility: for example, a kernel that does not know about finer-grained <<asr_perm>> subsets must still be able to prevent all access to privileged instructions and CSRs by clearing <<asr_perm>>.
 
 [#section_cap_level_change]

--- a/src/cheri/insns/gclen_32bit.adoc
+++ b/src/cheri/insns/gclen_32bit.adoc
@@ -20,8 +20,8 @@ include::wavedrom/gclen.adoc[]
 
 Description::
 Calculate the length of `cs1` 's bounds and write the result in `rd`. The length
-is defined as the difference between the decoded bounds' top and base addresses
-i.e. `top - base`. It is not required that the input capability `cs1`  has its
+is defined as the difference between the decoded bounds' top and base addresses,
+i.e., `top - base`. It is not required that the input capability `cs1`  has its
 tag set to 1. <<GCLEN>> outputs 0 if `cs1` 's bounds are malformed (see
 xref:section_cap_malformed[xrefstyle=short]), and 2^MXLEN^-1 if the length of
 `cs1` is 2^MXLEN^.

--- a/src/cheri/insns/gcperm_32bit.adoc
+++ b/src/cheri/insns/gcperm_32bit.adoc
@@ -37,8 +37,8 @@ include::../img/acperm_bit_field.edn[]
 NOTE: When {cheri_0levels_ext_name} is implemented, the `CL`, `SL`, and `EL` fields always report 1.
 This ensures forwards-compatibility with {cheri_1levels_ext_name} since loads/stores on a core without dynamic levels behave as if these permissions are always present.
 
-NOTE: Any future extension that defines new permission that are a refinement of existing permissions (e.g. finer-grained <<asr_perm>>) must be allocated to the bits that are currently reported as 1 to ensure forward-compatibility.
-Completely new permissions (e.g. sealing) should use the bits that are reported as zero in the current specification.
+NOTE: Any future extension that defines new permission that are a refinement of existing permissions (e.g., finer-grained <<asr_perm>>) must be allocated to the bits that are currently reported as 1 to ensure forward-compatibility.
+Completely new permissions (e.g., sealing) should use the bits that are reported as zero in the current specification.
 
 Operation::
 +

--- a/src/cheri/insns/prefetch.r.adoc
+++ b/src/cheri/insns/prefetch.r.adoc
@@ -30,7 +30,7 @@ Encoding::
 A PREFETCH.R instruction indicates to hardware that the cache block whose
 effective address is the sum of the base address specified in `cs1` and the
 sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
-likely to be accessed by a data read (i.e. load) in the near future. The
+likely to be accessed by a data read (i.e., load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorizing capability for this
 operation is `cs1`. This instruction does not throw any exceptions. However,
 in following xref:CHERI_SPEC[xrefstyle=short], this instruction does not
@@ -40,7 +40,7 @@ perform a prefetch if it is not authorized by `cs1`.
 A PREFETCH.R instruction indicates to hardware that the cache block whose
 effective address is the sum of the base address specified in `rs1` and the
 sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
-likely to be accessed by a data read (i.e. load) in the near future. The
+likely to be accessed by a data read (i.e., load) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorizing capability for this
 operation is <<ddc>>.
 

--- a/src/cheri/insns/prefetch.w.adoc
+++ b/src/cheri/insns/prefetch.w.adoc
@@ -30,7 +30,7 @@ Encoding::
 A PREFETCH.W instruction indicates to hardware that the cache block whose
 effective address is the sum of the base address specified in `cs1` and the
 sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
-likely to be accessed by a data write (i.e. store) in the near future. The
+likely to be accessed by a data write (i.e., store) in the near future. The
 encoding is only valid if imm[4:0]=0. The authorizing capability for this
 operation is `cs1`. This instruction does not throw any exceptions. However,
 following xref:CHERI_SPEC[xrefstyle=short], this instruction does not perform a
@@ -40,7 +40,7 @@ prefetch if it is not authorized by `cs1`.
 A PREFETCH.W instruction indicates to hardware that the cache block whose
 effective address is the sum of the base address specified in `rs1` and the
 sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
-likely to be accessed by a data write (i.e. store) in the near future.  The
+likely to be accessed by a data write (i.e., store) in the near future.  The
 encoding is only valid if imm[4:0]=0. The authorizing capability for this
 operation is <<ddc>>.
 

--- a/src/cheri/insns/sceq_32bit.adoc
+++ b/src/cheri/insns/sceq_32bit.adoc
@@ -19,7 +19,7 @@ Encoding::
 include::wavedrom/sceq.adoc[]
 
 Description::
-`rd` is set to 1 if all bits (i.e. CLEN bits and the valid tag) of capabilities `cs1`
+`rd` is set to 1 if all bits (i.e., CLEN bits and the valid tag) of capabilities `cs1`
 and `cs2`  are equal, otherwise `rd` is set to 0.
 
 Operation::

--- a/src/cheri/insns/schi_32bit.adoc
+++ b/src/cheri/insns/schi_32bit.adoc
@@ -19,7 +19,7 @@ Encoding::
 include::wavedrom/schi.adoc[]
 
 Description::
-Copy `cs1`  to `cd` , replace the capability metadata (i.e. bits
+Copy `cs1`  to `cd` , replace the capability metadata (i.e., bits
 [CLEN-1:MXLEN]) with `rs2`  and set `cd.tag` to 0.
 
 Operation::

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -44,7 +44,7 @@ RISC-V.
 <<tid_ext,{tid_ext_name}>>:: Extension for supporting thread identifiers. This extension
 improves software compartmentalization on CHERI systems.
 <<section_cap_level,{cheri_0levels_ext_name}/{cheri_1levels_ext_name}>>:: Extension for supporting capability flow control.
-This extension allows limiting storing of capabilities to specific regions and can be used e.g. for safer data sharing between compartments.
+This extension allows limiting storing of capabilities to specific regions and can be used, e.g., for safer data sharing between compartments.
 {cheri_0levels_ext_name} imposes no restrictions on capability flow, {cheri_1levels_ext_name} enables a 1-bit flow control level.
 
 The following two extensions are useful independent of CHERI:

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -120,7 +120,7 @@ xref:default-csrnames-added[xrefstyle=short].
 <<ddc>> is a read-write, user mode accessible capability CSR.
 It does not require <<asr_perm>> in <<pcc>> for writes or reads.
 Similarly to <<pcc>> authorizing all control flow and instruction fetches, this capability register is implicitly checked to authorize all data memory accesses  when the current CHERI mode is {cheri_int_mode_name}.
-On startup <<ddc>> bounds and permissions must be set such that the program can run successfully (e.g. by setting it to <<infinite-cap>> to ensure _all_ data references are in bounds).
+On startup <<ddc>> bounds and permissions must be set such that the program can run successfully (e.g., by setting it to <<infinite-cap>> to ensure _all_ data references are in bounds).
 
 .Unprivileged default data capability register
 include::img/ddcreg.edn[]
@@ -214,10 +214,10 @@ For example, the `jvt` CSR is extended to `jvtc`, the `c` suffix indicating that
 It is referred to as `jvt` if only accessing the address or `jvtc` if accessing the whole capability.
 
 * In {cheri_cap_mode_name} <<CSRRW_CHERI>> _always_ read/writes the entire CLEN bits of all CLEN-width CSRs, i.e. it accesses `jvtc`.
-* In {cheri_int_mode_name} <<CSRRW_CHERI>> _only_ accesses XLEN bits of extended CSRs (e.g. `jvt`, for compatibility) and all CLEN-bits of CSRs added by CHERI extensions (e.g. <<ddc>>).
+* In {cheri_int_mode_name} <<CSRRW_CHERI>> _only_ accesses XLEN bits of extended CSRs (e.g., `jvt`, for compatibility) and all CLEN-bits of CSRs added by CHERI extensions (e.g., <<ddc>>).
 ** <<CSRRW_CHERI>> in {cheri_int_mode_name} can only update the address field of `jvt`, but it can write a full value into <<ddc>>.
 ** {cheri_cap_mode_name} always accesses `jvtc`, never `jvt`.
-* when only writing XLEN bits to an extended CSR (e.g. `jvt`), the CSR value is updated using <<SCADDR>> semantics.
+* when only writing XLEN bits to an extended CSR (e.g., `jvt`), the CSR value is updated using <<SCADDR>> semantics.
 
 IMPORTANT: need to resolve how to cross-reference the privileged spec to have a list of the new and extended CSRs
 

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -55,7 +55,7 @@ NOTE: The CHERI execution mode is always {cheri_cap_mode_name} on implementation
 
 The _<<cheri_execution_mode>>_ is determined by a bit in the metadata of the <<pcc>> called the <<m_bit>>.
 {cheri_default_ext_name} adds a new _<<cheri_execution_mode>>_ field (M) to the capability format.
-Although always present, it only takes effect in code capabilities, i.e. when the <<x_perm>> is set.
+Although always present, it only takes effect in code capabilities, i.e., when the <<x_perm>> is set.
 The exact location of the M-bit in the capability format for XLEN=32 and XLEN=64 is described in <<app_cap_description>>.
 
 * Mode (M)={CAP_MODE_VALUE} indicates {cheri_cap_mode_name}.
@@ -213,7 +213,7 @@ WARNING: This assumes that the Zcmt CSR is extended to be a capability when the 
 For example, the `jvt` CSR is extended to `jvtc`, the `c` suffix indicating that it's a capability.
 It is referred to as `jvt` if only accessing the address or `jvtc` if accessing the whole capability.
 
-* In {cheri_cap_mode_name} <<CSRRW_CHERI>> _always_ read/writes the entire CLEN bits of all CLEN-width CSRs, i.e. it accesses `jvtc`.
+* In {cheri_cap_mode_name} <<CSRRW_CHERI>> _always_ read/writes the entire CLEN bits of all CLEN-width CSRs, i.e., it accesses `jvtc`.
 * In {cheri_int_mode_name} <<CSRRW_CHERI>> _only_ accesses XLEN bits of extended CSRs (e.g., `jvt`, for compatibility) and all CLEN-bits of CSRs added by CHERI extensions (e.g., <<ddc>>).
 ** <<CSRRW_CHERI>> in {cheri_int_mode_name} can only update the address field of `jvt`, but it can write a full value into <<ddc>>.
 ** {cheri_cap_mode_name} always accesses `jvtc`, never `jvt`.
@@ -271,7 +271,7 @@ The following rules apply:
 * When accessing a CSR added by a CHERI extension:
 ** CLEN bits are read from the CSR and written to an output *c* register.
 
-//NOTE: For all non-capability CSRs (i.e. XLEN-width CSRs) XLEN bits are read/written regardless of <<cheri_execution_mode>>.
+//NOTE: For all non-capability CSRs (i.e., XLEN-width CSRs) XLEN bits are read/written regardless of <<cheri_execution_mode>>.
 
 ifdef::cheri_v9_annotations[]
 NOTE: *CHERI v9 Note:* CSpecialRW is removed. Its role is assumed by <<CSRRW_CHERI>>.

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -571,7 +571,7 @@ in connection with the <<section_cheri_disable,CRE>> and the <<cheri_execution_m
 ^1^ M-bit is irrelevant when CRE=0. +
 ^2^ See xref:legacy_mnemonics[xrefstyle=short] for a list of remapped
 instructions. +
-^3^ The hart is fully compatible with standard RISC-V when CRE=0 provided that <<pcc>>, <<mtvecc>>, <<mepcc>>, <<stvecc>>, <<sepcc>>, <<vstvecc>>, <<vsepcc>> and <<ddc>> have not been changed from the default reset state (i.e. hold the <<infinite-cap>> capability).
+^3^ The hart is fully compatible with standard RISC-V when CRE=0 provided that <<pcc>>, <<mtvecc>>, <<mepcc>>, <<stvecc>>, <<sepcc>>, <<vstvecc>>, <<vsepcc>> and <<ddc>> have not been changed from the default reset state (i.e., hold the <<infinite-cap>> capability).
 
 
 [#section_cheri_dyn_xlen]
@@ -593,7 +593,7 @@ Similarly, *pc* bits above XLEN are ignored, and when the *pc* is written, it is
 The integer writing rule from CHERI is followed, so that every register write also zeroes the metadata and tag of the
 destination register.
 +
-However, CHERI operations and security checks will continue using the entire hardware register (i.e. CLEN bits) to correctly decode capability bounds.
+However, CHERI operations and security checks will continue using the entire hardware register (i.e., CLEN bits) to correctly decode capability bounds.
 
 Changing endianness::
 Setting the MBE, SBE, or UBE field to a value that is not the reset value of MBE disables most CHERI features and instructions, as described in xref:section_cheri_disable[xrefstyle=short], while in that privilege mode.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -88,7 +88,7 @@ If the valid tag is set, the capability is valid and can be dereferenced (contin
 
 The capability is invalid if the valid tag is clear.
 Using an invalid capability to dereference memory or authorize any operation raises an exception.
-All capabilities derived from invalid capabilities are themselves invalid i.e. their valid tags are 0.
+All capabilities derived from invalid capabilities are themselves invalid, i.e., their valid tags are 0.
 
 All locations in registers or memory able to hold a capability are CLEN-bits wide including the valid tag bit.
 Those locations are referred as being _YLEN-bit_ or _capability_-wide in this specification.
@@ -188,7 +188,7 @@ NOTE: extensions may add non-privileged CSRs which require <<ASR-permission>>
 Store Level Permission (SL):: This is a variable width field that allows limiting the propagation of capabilities using the following logic: capabilities with a <<section_cap_level>> less than the inverse of the authorizing capability's <<sl_perm>> will be stored with the valid tag cleared.
 With `LVLBITS=1` there is a single bit comparison, so it behaves as follows:
 - If this field (as well as <<c_perm>> and <<w_perm>>) is set to 1 then capabilities may be stored via this capability regardless of their associated <<section_cap_level>>.
-- If this field is zero, then any capability with a <<section_cap_level>> of zero (i.e. _local_), will be stored with the valid tag cleared.
+- If this field is zero, then any capability with a <<section_cap_level>> of zero (i.e., _local_), will be stored with the valid tag cleared.
 
 NOTE: For `LVLBITS=1` this permission is equivalent to _StoreLocal_ in CHERI v9, Morello and CHERIoT.
 
@@ -303,7 +303,7 @@ This means the following state is added by {cheri_base_ext_name}:
 The <<gprs,XLEN-wide integer registers>> (e.g., `sp`, `a0`) are all extended with another XLEN bits of capability metadata plus a valid tag bit.
 When referring to the extended register, the `x` prefix is replaced with a `c`: i.e. the capability extended version of `x0` becomes `c0`.
 The existing integer register names refer to the address part of the capability.
-For the ABI register names the `c` prefix is added, i.e. `csp`, `ca0`.
+For the ABI register names the `c` prefix is added, i.e., `csp`, `ca0`.
 The zero register is extended with zero metadata and a cleared valid tag: this is called the <<null-cap>> capability.
 
 NOTE: Instruction encodings refer to *c* registers when they use `cs1`, `cd`, etc. instead of `rs1`, `rd` (which reads/writes the XLEN-bit subset of the register).

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -173,7 +173,7 @@ Execute Permission (X):: Allow instruction execution.
 [#lm_perm,reftext="LM-permission"]
 Load Mutable Permission (LM):: Allow preserving the <<w_perm>> of capabilities loaded from memory.
 If a capability grants <<r_perm>> and <<c_perm>>, but no <<lm_perm>>, then a capability loaded via this authorizing capability will have <<w_perm>> and <<lm_perm>> removed.
-Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure (e.g. a tree or linked list) without making a copy.
+Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure (e.g., a tree or linked list) without making a copy.
 
 NOTE: The permission stripping behavior only applies to loaded capabilities that have their valid tag set and are not sealed; loaded capabilities that are sealed or invalid do not have their permissions changed.
   This ensures that capability loads/stores of non-capability data do not modify the stored value.
@@ -205,7 +205,7 @@ endif::[]
 ==== Capability Level (CL)
 
 The _Capability Level_ (CL) is a variable width field that allows enforcing invariants on capability propagation.
-For example, the _Capability Level_ can be used to ensure that a callee can only write a copy of the passed-in argument capability to specific locations in memory (e.g. the callee's stack frame but not the heap).
+For example, the _Capability Level_ can be used to ensure that a callee can only write a copy of the passed-in argument capability to specific locations in memory (e.g., the callee's stack frame but not the heap).
 It can also be used to avoid sharing of compartment-local data (such as pointers to a stack object) between compartments.
 
 NOTE: This specification only defines the architectural mechanics of this feature, for further information on how this can be used by software please refer to cite:[cheri-v9-spec].
@@ -253,7 +253,7 @@ Future extensions are permitted to add more levels.
 [#sec_cap_sdp]
 ==== Software-Defined Permissions (SDP)
 The metadata also contains an encoding-dependent number of software-defined permission (SDP) bits.
-They can be inspected by the kernel or application programs to enforce restrictions on API calls (e.g. permit/deny system calls, memory allocation, etc.), but are not interpreted by the CPU otherwise.
+They can be inspected by the kernel or application programs to enforce restrictions on API calls (e.g., permit/deny system calls, memory allocation, etc.), but are not interpreted by the CPU otherwise.
 
 NOTE: While these bits are not interpreted by the hardware, modification follows the same rules as architectural permissions: SDP bits can only be cleared and never set.
 This property is required to ensure restricted programs cannot forge capabilities that would pass the software-enforced checks.
@@ -300,7 +300,7 @@ This means the following state is added by {cheri_base_ext_name}:
 ----
 
 ==== Extended general purpose integer registers
-The <<gprs,XLEN-wide integer registers>> (e.g. `sp`, `a0`) are all extended with another XLEN bits of capability metadata plus a valid tag bit.
+The <<gprs,XLEN-wide integer registers>> (e.g., `sp`, `a0`) are all extended with another XLEN bits of capability metadata plus a valid tag bit.
 When referring to the extended register, the `x` prefix is replaced with a `c`: i.e. the capability extended version of `x0` becomes `c0`.
 The existing integer register names refer to the address part of the capability.
 For the ABI register names the `c` prefix is added, i.e. `csp`, `ca0`.
@@ -332,7 +332,7 @@ failing check causes a CHERI exception.
 * The capability must grant execute permission
 * All bytes of the instruction must be in bounds
 
-On startup <<pcc>> bounds and permissions must be set such that the program can run successfully (e.g. by setting it to <<infinite-cap>> to ensure _all_ instructions are in bounds).
+On startup <<pcc>> bounds and permissions must be set such that the program can run successfully (e.g., by setting it to <<infinite-cap>> to ensure _all_ instructions are in bounds).
 
 NOTE: Operations that update <<pcc>>, such as changing privilege or executing jump instructions, unseal capabilities prior to writing.
 Therefore, implementations do not need to check that that <<pcc>> is unsealed when executing each instruction.
@@ -377,27 +377,27 @@ No other exception paths are added by {cheri_base_ext_name}: in particular, capa
 {cheri_base_ext_name} adds new instructions to interact with the extended registers.
 These added instructions can be split into the following categories:
 
-Capability manipulations (e.g. <<SCBNDS>>, <<ACPERM>>)::
+Capability manipulations (e.g., <<SCBNDS>>, <<ACPERM>>)::
 For security, capabilities can only be modified in restricted ways.
 Special instructions are provided to copy capabilities or perform these allowed operations, for example _shrinking_ the bounds or _reducing_ the permissions.
 Any attempt to manipulate capabilities without using the instructions clears the valid tag, rendering them unusable for accessing memory.
 They do not cause exceptions.
 
-Pointer arithmetic (e.g. <<CADD>>, <<CADDI>>)::
+Pointer arithmetic (e.g., <<CADD>>, <<CADDI>>)::
 To update where a capability points new capability instructions must be used instead of an integer ADD/ADDI.
 These instructions include a check that the result can be <<section_cap_representable_check,represented exactly>>, therefore is still valid for the current metadata.
 Invalid (e.g., significantly out-of-bounds) updates clear the valid tag.
 
-Capability inspection (e.g. <<GCBASE>>, <<GCPERM>>)::
+Capability inspection (e.g., <<GCBASE>>, <<GCPERM>>)::
 Capability fields (for example the _bounds_ describing what addresses the capability gives access to) are stored compressed in registers and memory.
 These instructions give convenient access to allow software to query them.
   They do not cause exceptions.
 
-Memory access instructions (e.g. <<LC>>, <<SC>>)::
+Memory access instructions (e.g., <<LC>>, <<SC>>)::
 Capabilities must be read from and written to memory atomically along with their valid tag.
 Instructions are added to perform these capability-width accesses, allowing capabilities to flow between the memory and the register file.
 
-Miscellaneous instructions (e.g. <<SCSS>>)::
+Miscellaneous instructions (e.g., <<SCSS>>)::
 These instructions either compare capabilities or allow software to determine the alignment of bounds.
 They do not cause exceptions.
 
@@ -535,7 +535,7 @@ The rules for modifying the behavior of such instructions are:
 * Whenever the PC is handled, it is _always_ the <<pcc>>.
 * Any instruction that has a base address register (generally `rs1`) reads the full capability register instead.
 ** This capability register is used to <<sec_cap_checks,check whether the access should be permitted>>.
-* Any instruction writes back an address (e.g. <<AUIPC_CHERI>>), writes a full capability register instead.
+* Any instruction writes back an address (e.g., <<AUIPC_CHERI>>), writes a full capability register instead.
 * Whenever the address field of any capability (including the <<pcc>>) is modified, it is _always_ updated using <<SCADDR>> semantics.
 ** This includes adding an offset to the <<pcc>> from jumps and branches for both the target address and the link register.
  In this case, for example, `new_pcc = SCADDR(old_pcc, offset)`
@@ -545,7 +545,7 @@ The rules for modifying the behavior of such instructions are:
 
 These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_cap_base_summary>>.
 
-IMPORTANT: These rules also apply to instructions added by other extensions (e.g. floating-point/vector loads/stores or the shift-and-add instruction from <<zba,Zba>>).
+IMPORTANT: These rules also apply to instructions added by other extensions (e.g., floating-point/vector loads/stores or the shift-and-add instruction from <<zba,Zba>>).
 
 //TODO: <<app_cheri_instructions>> has listings for all unprivileged instructions that change behavior when {cheri_base_ext_name} is used as the base ISA.
 

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -14,7 +14,7 @@ There are two types of bus connections used in SoCs which contain CHERI CPUs:
 . Tag-aware busses, where the bus protocol is extended to carry the valid tag along with the data.  This is typically done using user defined bits in the protocol.
 .. These busses will read tags from memory (if tags are present in the target memory) and return them to the requestor.
 .. These busses will write the valid tag to memory as an extension of the data write.
-. Non-tag aware busses, i.e. current non-CHERI aware busses.
+. Non-tag aware busses, i.e., current non-CHERI aware busses.
 .. Reads of tagged memory will not read the valid tag.
 .. Writes to tagged memory will clear the valid tag of any CLEN-aligned CLEN-wide memory location where any byte matches the memory write.
 

--- a/src/cheri/tables.adoc
+++ b/src/cheri/tables.adoc
@@ -63,7 +63,7 @@ include::generated/csr_alias_action_table_body.adoc[]
 
 ^*^ The vector range check is to ensure that vectored entry to the handler
  is within bounds of the capability written to `Xtvecc`. The check on writing
- must include the lowest (0 offset) and highest possible offset (e.g. 64 * MXLEN bits where HICAUSE=16).
+ must include the lowest (0 offset) and highest possible offset (e.g., 64 * MXLEN bits where HICAUSE=16).
 
 XLEN bits of extended capability CSRs are written when executing
 <<CSRRWI_CHERI>>, <<CSRRC_CHERI>>, <<CSRRS_CHERI>>, <<CSRRCI_CHERI>> or <<CSRRSI_CHERI>> regardless of the


### PR DESCRIPTION
Overwhelmingly, "e.g." and "i.e." are used with commas in the existing specs. I tried to catch all inconsistencies introduced by CHERI files, but did not touch other files.