### PR TITLE
clean up spec of LC/SC/LR.C/SC.C

### DIFF
--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -38,7 +38,7 @@ NOTE: Missing <<el_perm>> also affects the level of sealed capabilities since no
 +
 NOTE: While the implicit <<ACPERM>> introduces a dependency on the loaded data, implementations can avoid this by deferring the actual masking of permissions until the loaded capability is dereferenced or the metadata bits are inspected using <<GCPERM>> or <<GCHI>>. Additionally, metadata modifications are only possible if the access is naturally aligned, and so on the read path from a data cache, the modification typically happens in parallel with data alignment multiplexers.
 +
-When sending load data to a trace interface, implementations trace the final value written to `cd` which may not match the value in memory.
+When sending load data to a trace interface, implementations trace the final value written to `cd` which may not match the value in memory. #This is change relative to 0.9.5 which gives the choice#
 +
 :has_cap_data:
 include::load_exceptions.adoc[]

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -14,31 +14,19 @@ include::wavedrom/loadcap.adoc[]
 
 include::load_store_c0.adoc[]
 
+
 Description::
 Calculate the effective address of the memory access by adding the address of `cs1` to the sign-extended 12-bit offset.
 +
 Authorize the memory access with the capability in `cs1`.
 +
-Load a CLEN-bit value from memory, conditionally update it as specified below, and write the final version to `cd`.
+Load a naturally aligned CLEN-bit data value and the associated valid tag from memory.
++
+Write the CLEN-bit data and the valid tag to `cd` and conditionally update it as specified below.
 +
 include::malformed_no_check.adoc[]
 
-Determining the final value of `cd`::
-If the valid tag of the memory location loaded is 0, or the authorizing capability (`cs1`) does not grant <<c_perm>> then set `cd.tag=0`. In this case the CLEN-bit memory data is written directly to `cd` and the steps below do not apply.
-+
-If `cd.tag=1`, `cd` is not sealed and `cs1` does not grant <<lm_perm>>, then an implicit <<ACPERM>> is performed to clear <<w_perm>> and <<lm_perm>> from `cd`.
-+
-If `cd.tag=1`, `cd` is not sealed and `cs1` does not grant <<el_perm>>, then an implicit <<ACPERM>> is performed restricting the <<section_cap_level>> of `cd` to the level of `cs1` and to remove <<el_perm>>.
-+
-If `cd.tag=1`, `cd` is sealed and `cs1` does not grant <<el_perm>>, then an implicit <<ACPERM>> is performed restricting the <<section_cap_level>> of `cd` to the level of `cs1`
-+
-If {cheri_1levels_ext_name} is implemented, then also see <<cap_level_load_summary>>.
-+
-NOTE: Missing <<el_perm>> also affects the level of sealed capabilities since notionally the <<section_cap_level>> of a capability is not a permission but rather a data flow label attached to the loaded value.
-+
-NOTE: While the implicit <<ACPERM>> introduces a dependency on the loaded data, implementations can avoid this by deferring the actual masking of permissions until the loaded capability is dereferenced or the metadata bits are inspected using <<GCPERM>> or <<GCHI>>. Additionally, metadata modifications are only possible if the access is naturally aligned, and so on the read path from a data cache, the modification typically happens in parallel with data alignment multiplexers.
-+
-When sending load data to a trace interface, implementations trace the final value written to `cd` which may not match the value in memory. #This is change relative to 0.9.5 which gives the choice#
+include::load_tag_perms.adoc[]
 +
 :has_cap_data:
 include::load_exceptions.adoc[]

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -12,17 +12,37 @@ Mnemonic::
 Encoding::
 include::wavedrom/loadcap.adoc[]
 
-Load a CLEN-bit value from memory and writes it to `cd`. The capability in `cs1` authorizes the operation. The effective address of the memory access is obtained by adding the address of `cs1` to the sign-extended 12-bit offset.
-
 include::load_store_c0.adoc[]
 
-include::load_tag_perms.adoc[]
-
+Description::
+Calculate the effective address of the memory access by adding the address of `cs1` to the sign-extended 12-bit offset.
++
+Authorize the memory access with the capability in `cs1`.
++
+Load a CLEN-bit value from memory, conditionally update it as specified below, and write the final version to `cd`.
++
 include::malformed_no_check.adoc[]
 
+Determining the final value of `cd`::
+If the valid tag of the memory location loaded is 0, or the authorizing capability (`cs1`) does not grant <<c_perm>> then set `cd.tag=0`. In this case the CLEN-bit memory data is written directly to `cd` and the steps below do not apply.
++
+If `cd.tag=1`, `cd` is not sealed and `cs1` does not grant <<lm_perm>>, then an implicit <<ACPERM>> is performed to clear <<w_perm>> and <<lm_perm>> from `cd`.
++
+If `cd.tag=1`, `cd` is not sealed and `cs1` does not grant <<el_perm>>, then an implicit <<ACPERM>> is performed restricting the <<section_cap_level>> of `cd` to the level of `cs1` and to remove <<el_perm>>.
++
+If `cd.tag=1`, `cd` is sealed and `cs1` does not grant <<el_perm>>, then an implicit <<ACPERM>> is performed restricting the <<section_cap_level>> of `cd` to the level of `cs1`
++
+If {cheri_1levels_ext_name} is implemented, then also see <<cap_level_load_summary>>.
++
+NOTE: Missing <<el_perm>> also affects the level of sealed capabilities since notionally the <<section_cap_level>> of a capability is not a permission but rather a data flow label attached to the loaded value.
++
+NOTE: While the implicit <<ACPERM>> introduces a dependency on the loaded data, implementations can avoid this by deferring the actual masking of permissions until the loaded capability is dereferenced or the metadata bits are inspected using <<GCPERM>> or <<GCHI>>. Additionally, metadata modifications are only possible if the access is naturally aligned, and so on the read path from a data cache, the modification typically happens in parallel with data alignment multiplexers.
++
+When sending load data to a trace interface, implementations trace the final value written to `cd` which may not match the value in memory.
++
 :has_cap_data:
 include::load_exceptions.adoc[]
-
++
 LC Operation::
 +
 sail::execute[clause="LoadCapImm(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -22,7 +22,7 @@ Authorize the memory access with the capability in `cs1`.
 +
 Load a naturally aligned CLEN-bit data value and the associated valid tag from memory.
 +
-Write the CLEN-bit data and the valid tag to `cd` and conditionally update it as specified below.
+Write the CLEN-bit data and the valid tag to `cd` and conditionally update them as specified below.
 +
 include::malformed_no_check.adoc[]
 

--- a/src/cheri/insns/load_exceptions.adoc
+++ b/src/cheri/insns/load_exceptions.adoc
@@ -1,15 +1,15 @@
 Exceptions::
-ifdef::load_res[]
-#ARC feedback: this needs to be an access fault#
-+
-All misaligned load reservations cause a load address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a load access fault exception.
-+
-endif::[]
 ifdef::has_cap_data[]
 #ARC feedback: needs to be an access fault as it can't be emulated#
 +
 Misaligned address fault exception when the effective address is not aligned to CLEN/8.
 +
+endif::[]
+ifndef::has_cap_data[]
+ ifdef::load_res[]
+All misaligned load reservations cause a load address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a load access fault exception.
++
+ endif::[]
 endif::[]
 #ARC suggestion: consider software check fault#
 +

--- a/src/cheri/insns/load_exceptions.adoc
+++ b/src/cheri/insns/load_exceptions.adoc
@@ -6,7 +6,7 @@ All misaligned load reservations cause a load address misaligned exception to al
 +
 endif::[]
 ifdef::has_cap_data[]
-#ARC feedback: needs to be an access fault#
+#ARC feedback: needs to be an access fault as it can't be emulated#
 +
 Misaligned address fault exception when the effective address is not aligned to CLEN/8.
 +

--- a/src/cheri/insns/load_exceptions.adoc
+++ b/src/cheri/insns/load_exceptions.adoc
@@ -1,12 +1,18 @@
 Exceptions::
 ifdef::load_res[]
+#ARC feedback: this needs to be an access fault#
++
 All misaligned load reservations cause a load address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a load access fault exception.
 +
 endif::[]
 ifdef::has_cap_data[]
+#ARC feedback: needs to be an access fault#
++
 Misaligned address fault exception when the effective address is not aligned to CLEN/8.
 +
 endif::[]
+#ARC suggestion: consider software check fault#
++
 CHERI fault exception when one of the checks below fail (see <<sec_cheri_exception_handling,_CHERI Exception handling_ in the privileged specification>> for further details):
 +
 [%autowidth,options=header,align=center]

--- a/src/cheri/insns/load_res_cap_32bit.adoc
+++ b/src/cheri/insns/load_res_cap_32bit.adoc
@@ -16,10 +16,21 @@ Encoding::
 include::wavedrom/load_res_cap.adoc[]
 
 Description::
-Load reserved instructions, authorized by the capability in `cs1`.
- All misaligned load reservations cause a load address misaligned exception to allow software emulation (Zam extension, see cite:[riscv-unpriv-spec]).
+Calculate the effective address of the memory access by adding the address of `cs1` to the sign-extended 12-bit offset.
++
+Authorize the memory access with the capability in `cs1`.
++
+Load a naturally aligned CLEN-bit data value and the associated valid tag from memory.
++
+Set the reservation as for LR.W/D.
++
+Write the CLEN-bit data and the valid tag to `cd` and conditionally update it as specified below.
++
+//All misaligned load reservations cause a load address misaligned exception to allow software emulation (Zam extension, see cite://[riscv-unpriv-spec]).
 +
 include::load_store_c0.adoc[]
+
+include::malformed_no_check.adoc[]
 
 //{cheri_int_mode_name} Description::
 //Load reserved instructions, authorized by the capability in <<ddc>>.
@@ -28,10 +39,8 @@ include::load_store_c0.adoc[]
 include::load_tag_perms.adoc[]
 
 :cap_load:
-
-include::malformed_no_check.adoc[]
-
-//include::load_exceptions.adoc[]
+:load_res:
+include::load_exceptions.adoc[]
 
 Prerequisites::
 {cheri_base_ext_name}, and A or Zalrsc

--- a/src/cheri/insns/load_res_cap_32bit.adoc
+++ b/src/cheri/insns/load_res_cap_32bit.adoc
@@ -24,7 +24,7 @@ Load a naturally aligned CLEN-bit data value and the associated valid tag from m
 +
 Set the reservation as for LR.W/D.
 +
-Write the CLEN-bit data and the valid tag to `cd` and conditionally update it as specified below.
+Write the CLEN-bit data and the valid tag to `cd` and conditionally update them as specified below.
 +
 //All misaligned load reservations cause a load address misaligned exception to allow software emulation (Zam extension, see cite://[riscv-unpriv-spec]).
 +

--- a/src/cheri/insns/load_tag_perms.adoc
+++ b/src/cheri/insns/load_tag_perms.adoc
@@ -1,18 +1,18 @@
-Resulting value of `cd`::
-The valid tag value written to `cd` is 0 if the valid tag of the memory location loaded is
-0 or the authorizing capability (`cs1`) does not grant <<c_perm>>.
+Determining the final value of `cd`::
+If the valid tag of the memory location loaded is 0, or the authorizing capability (`cs1`) does not grant <<c_perm>> then set `cd.tag=0`. In this case the steps below do not apply.
 +
-If the authorizing capability does not grant <<lm_perm>>, and the valid tag of `cd` is 1 and `cd` is not sealed, then an implicit <<ACPERM>> clearing <<w_perm>> and <<lm_perm>> is performed to obtain the intermediate permissions on `cd`.
+If `cd.tag=1`, `cd` is not sealed and `cs1` does not grant <<lm_perm>>, then an implicit <<ACPERM>> is performed to clear <<w_perm>> and <<lm_perm>> from `cd`.
 +
-If the authorizing capability does not grant <<el_perm>>, and the valid tag of `cd` is 1, then an implicit <<ACPERM>> restricting the <<section_cap_level>> to the level of the authorizing capability is performed.
-If `cd` is not sealed, this implicit <<ACPERM>> also clears <<el_perm>> to obtain the final permissions on `cd` (see <<cap_level_load_summary>>).
+If `cd.tag=1`, `cd` is not sealed and `cs1` does not grant <<el_perm>>, then an implicit <<ACPERM>> is performed restricting the <<section_cap_level>> of `cd` to the level of `cs1` and to remove <<el_perm>>.
 +
-NOTE: Missing <<lm_perm>> does not affect untagged values since this could result in surprising bit patterns when copying non-capability data.
-Similarly, sealed capabilities are not modified as they are not directly dereferenceable.
+If `cd.tag=1`, `cd` is sealed and `cs1` does not grant <<el_perm>>, then an implicit <<ACPERM>> is performed restricting the <<section_cap_level>> of `cd` to the level of `cs1`
++
+If {cheri_1levels_ext_name} is implemented, then also see <<cap_level_load_summary>>.
 +
 NOTE: Missing <<el_perm>> also affects the level of sealed capabilities since notionally the <<section_cap_level>> of a capability is not a permission but rather a data flow label attached to the loaded value.
-However, untagged values are not affected by <<el_perm>>.
 +
-NOTE: While the implicit <<ACPERM>> introduces a dependency on the loaded data, implementations can avoid this by deferring the actual masking of permissions until the loaded capability is dereferenced or the metadata bits are inspected using <<GCPERM>> or <<GCHI>>.
+NOTE: While the implicit <<ACPERM>> introduces a dependency on the loaded data, implementations can avoid this by deferring the actual masking of permissions until the loaded capability is dereferenced or the metadata bits are inspected using <<GCPERM>> or <<GCHI>>. Additionally, metadata modifications  are on naturally aligned data, and so on the read path from a data cache, the modification typically happens in parallel with data alignment multiplexers.
 +
-NOTE: When sending load data to a trace interface implementations can choose whether to trace the value before or after <<ACPERM>> has modified the data. The recommendation is to trace the value after <<ACPERM>>.
+#ARC feedback: this is change relative to 0.9.5 so that the choice is removed. Choosing the other option would need to be a future extension#
++
+When sending load data to a trace interface, implementations trace the final value written to `cd` which may not match the value in memory.

--- a/src/cheri/insns/load_tag_perms.adoc
+++ b/src/cheri/insns/load_tag_perms.adoc
@@ -6,13 +6,13 @@ If the authorizing capability does not grant <<lm_perm>>, and the valid tag of `
 +
 If the authorizing capability does not grant <<el_perm>>, and the valid tag of `cd` is 1, then an implicit <<ACPERM>> restricting the <<section_cap_level>> to the level of the authorizing capability is performed.
 If `cd` is not sealed, this implicit <<ACPERM>> also clears <<el_perm>> to obtain the final permissions on `cd` (see <<cap_level_load_summary>>).
-
++
 NOTE: Missing <<lm_perm>> does not affect untagged values since this could result in surprising bit patterns when copying non-capability data.
 Similarly, sealed capabilities are not modified as they are not directly dereferenceable.
-
++
 NOTE: Missing <<el_perm>> also affects the level of sealed capabilities since notionally the <<section_cap_level>> of a capability is not a permission but rather a data flow label attached to the loaded value.
 However, untagged values are not affected by <<el_perm>>.
-
++
 NOTE: While the implicit <<ACPERM>> introduces a dependency on the loaded data, implementations can avoid this by deferring the actual masking of permissions until the loaded capability is dereferenced or the metadata bits are inspected using <<GCPERM>> or <<GCHI>>.
-
++
 NOTE: When sending load data to a trace interface implementations can choose whether to trace the value before or after <<ACPERM>> has modified the data. The recommendation is to trace the value after <<ACPERM>>.

--- a/src/cheri/insns/malformed_no_check.adoc
+++ b/src/cheri/insns/malformed_no_check.adoc
@@ -1,2 +1,2 @@
-NOTE: This instruction can propagate tagged capabilities which have <<section_cap_malformed,malformed>> bounds,
+This instruction can propagate tagged capabilities which have <<section_cap_malformed,malformed>> bounds,
 have reserved bits set or have a permission field which cannot be produced by <<ACPERM>>.

--- a/src/cheri/insns/store_32bit_cap.adoc
+++ b/src/cheri/insns/store_32bit_cap.adoc
@@ -12,15 +12,18 @@ Mnemonic::
 Encoding::
 include::wavedrom/storecap.adoc[]
 
-Store the CLEN-bit value in `cs2` to memory. The capability in `cs1`
-authorizes the operation. The effective address of the memory access is
-obtained by adding the address of `cs1` to the sign-extended 12-bit offset.
+Description::
+Calculate the effective address of the memory access by adding the address of `cs1` to the sign-extended 12-bit offset.
++
+Authorize the memory access with the capability in `cs1`.
++
+Store a naturally aligned CLEN-bit data value in `cs2` to memory and the associated valid tag in `cs2`.
++
+include::malformed_no_check.adoc[]
 
 include::load_store_c0.adoc[]
 
 include::store_tag_perms.adoc[]
-
-include::malformed_no_check.adoc[]
 
 :has_cap_data:
 include::store_exceptions.adoc[]

--- a/src/cheri/insns/store_cond_cap_32bit.adoc
+++ b/src/cheri/insns/store_cond_cap_32bit.adoc
@@ -6,32 +6,37 @@
 Synopsis::
 Store Conditional (SC.C), 32-bit encoding
 
-{cheri_cap_mode_name} Mnemonic::
+Mnemonic::
 `sc.c rd, cs2, 0(cs1)`
 
-{cheri_int_mode_name} Mnemonic::
-`sc.c rd, cs2, 0(rs1)`
+//{cheri_int_mode_name} Mnemonic::
+//`sc.c rd, cs2, 0(rs1)`
 
 Encoding::
 include::wavedrom/store_cond_cap.adoc[]
 
-{cheri_cap_mode_name} Description::
-Store conditional instructions, authorized by the capability in `cs1`.
- All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (Zam extension, see cite:[riscv-unpriv-spec]).
+Description::
+Calculate the effective address of the memory access by adding the address of `cs1` to the sign-extended 12-bit offset.
++
+Authorize the memory access with the capability in `cs1`.
++
+Conditionally store, following the same rules as SC.W, a naturally aligned CLEN-bit data value in `cs2` to memory and the associated valid tag in `cs2`.
++
+Set rd to 1 for success or 0 for failure.
 +
 include::load_store_c0.adoc[]
 
-{cheri_int_mode_name} Description::
-Store conditional instructions, authorized by the capability in <<ddc>>.
- All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (Zam extension, see cite:[riscv-unpriv-spec]).
-
-:store_cond:
+//{cheri_int_mode_name} Description::
+//Store conditional instructions, authorized by the capability in <<ddc>>.
+// All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (Zam extension, see cite:[riscv-unpriv-spec]).
 
 include::store_tag_perms.adoc[]
 
 include::malformed_no_check.adoc[]
 
-//include::store_exceptions.adoc[]
+:store_cond:
+:has_cap_data:
+include::store_exceptions.adoc[]
 
 Prerequisites::
 {cheri_base_ext_name}, and A or Zalrsc

--- a/src/cheri/insns/store_exceptions.adoc
+++ b/src/cheri/insns/store_exceptions.adoc
@@ -1,13 +1,15 @@
 Exceptions::
-//ifdef::store_cond[]
-//All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a store/AMO access fault exception.
-//+
-//endif::[]
 ifdef::has_cap_data[]
 #ARC feedback: needs to be an access fault as it can't be emulated#
 +
 Misaligned address fault exception when the effective address is not aligned to CLEN/8 if Zam is supported, otherwise store access fault exception.
 +
+endif::[]
+ifndef::has_cap_data[]
+ ifdef::store_cond[]
+All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a store/AMO access fault exception.
++
+ endif::[]
 endif::[]
 #ARC suggestion: consider software check fault#
 +

--- a/src/cheri/insns/store_exceptions.adoc
+++ b/src/cheri/insns/store_exceptions.adoc
@@ -1,13 +1,16 @@
 Exceptions::
-ifdef::store_cond[]
-All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a store/AMO access fault exception.
-+
-endif::[]
+//ifdef::store_cond[]
+//All misaligned store conditionals cause a store/AMO address misaligned exception to allow software emulation (if the Zam extension is supported, see cite:[riscv-unpriv-spec]), otherwise they take a store/AMO access fault exception.
+//+
+//endif::[]
 ifdef::has_cap_data[]
-Misaligned address fault exception when the effective address is not aligned
-to CLEN/8.
+#ARC feedback: needs to be an access fault as it can't be emulated#
++
+Misaligned address fault exception when the effective address is not aligned to CLEN/8 if Zam is supported, otherwise store access fault exception.
 +
 endif::[]
+#ARC suggestion: consider software check fault#
++
 _CHERI data fault_ exceptions occur when the authorizing capability fails one of the checks
 listed below (see <<sec_cheri_exception_handling,_CHERI Exception handling_ in the privileged specification>> for further details):
 +

--- a/src/cheri/insns/store_tag_perms.adoc
+++ b/src/cheri/insns/store_tag_perms.adoc
@@ -1,5 +1,7 @@
-Tag of the written capability value::
+Valid tag of the stored capability value::
 
-The capability written to memory has the valid tag set to 0 if the valid tag of `cs2` is 0 or if the authorizing capability (`cs1`) does not grant <<c_perm>>.
+The stored valid tag is 0 if:
 +
-The stored tag is also set to zero if the authorizing capability does not have <<sl_perm>> set but the stored data has a <<section_cap_level>> of 0 (_local_).
+. `cs2.tag=0`, or
+. `cs1` does not grant <<c_perm>>, or
+. `cs1` does not grant <<sl_perm>> and `cs2` has a <<section_cap_level>> of 0 (_local_).

--- a/src/cheri/scripts/generate_tables.py
+++ b/src/cheri/scripts/generate_tables.py
@@ -213,7 +213,7 @@ class both_mode_insns(table):
             outStr = ""
             for i in self.indices:
                 if i==0:
-                    outStr += '|' + insn_xref(row[i]) + '>>'
+                    outStr += '|' + insn_xref(row[i])
                 else:
                     outStr += '|'+row[i]
             self.file.write(outStr+'\n')


### PR DESCRIPTION
List the operations in a logical order
Don't allow non-normative notes
Require final value of cd to be in the trace interface
