### PR TITLE
riscv-unpriv: Fix up the description of Valid Tag

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -119,7 +119,7 @@ Capability load/store require the _provenance_ check:
 * Any store that wrote the capability to memory was correctly authorized
 * Any load that read the capability from memory was correctly authorized
 
-When an operation fails a check, either due to software error or malicious intent, then the operation raises an exception or sets the resulting valid tag.
+When an operation fails a check, either due to software error or malicious intent, then the operation raises an exception or sets the resulting invalid tag.
 
 Using an invalid capability to dereference memory or authorize any operation raises an exception.
 All capabilities derived from invalid capabilities are themselves invalid, i.e., their valid tags are zero.


### PR DESCRIPTION
When an operation fails a check, either due to software error or malicious intent, then the operation raises an exception or "sets the resulting valid tag".

This should be "sets the resulting invalid tag" when the operation fails a check.