### PR TITLE
fix permission check wording to be unambiguous

### DIFF
--- a/src/cheri/insns/cbo_exceptions.adoc
+++ b/src/cheri/insns/cbo_exceptions.adoc
@@ -11,11 +11,11 @@ listed below (see <<sec_cheri_exception_handling,_CHERI Exception handling_ in t
 | Seal violation        | Authorizing capability is sealed
 
 ifdef::cbo_clean_flush[]
-| Permission violation  | Authorizing capability does not grant <<w_perm>> and <<r_perm>>, or the <<AP-field>> could not have been produced by <<ACPERM>>
+| Permission violation  | Authorizing capability does not grant <<w_perm>>, or does not grant <<r_perm>>, or the <<AP-field>> could not have been produced by <<ACPERM>>
 endif::cbo_clean_flush[]
 
 ifdef::cbo_inval[]
-| Permission violation  | Authorizing capability does not grant <<w_perm>>, <<r_perm>> or <<asr_perm>>, or the <<AP-field>> could not have been produced by <<ACPERM>>
+| Permission violation  | Authorizing capability does not grant <<w_perm>>, or does not grant <<r_perm>> or does not grant <<asr_perm>>, or the <<AP-field>> could not have been produced by <<ACPERM>>
 endif::[]
 ifdef::invalid_address_viol[]
 | Invalid address violation  | The effective address is invalid according to xref:section_invalid_addr_conv[xrefstyle=short]


### PR DESCRIPTION
fix https://github.com/riscv/riscv-cheri/issues/633

maybe a bit wordy but I think it's clear
