### PR TITLE
Define Zicond instructions to copy the full capability

### DIFF
--- a/src/cheri/app-standalone-unpriv-refs.adoc
+++ b/src/cheri/app-standalone-unpriv-refs.adoc
@@ -18,5 +18,7 @@ See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
 See Chapter _"A" Extension for Atomic Instructions_ in cite:[riscv-unpriv-spec].
 [[zba]]Zba::
 See Chapter _"B" Extension for Bit Manipulation_ in cite:[riscv-unpriv-spec].
+[[Zicond]]Zicond::
+See Chapter _"Zicond" Extension for Integer Conditional Operations_ in cite:[riscv-unpriv-spec].
 
 endif::[]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -809,6 +809,7 @@ include::insns/store_32bit_cap.adoc[]
 These rules affect the following <<rv32,base ISA>> instructions listed in the following subsections, and also apply to instructions added by other extensions, e.g.:
 
 * Shift-and-add instructions from <<zba_cheri>>, such as <<SH3ADD_CHERI>>.
+* Conditional zero instructions from <<Zicond>>, such as <<insns-czero-eqz,czero.eqz>>.
 * RVC encodings C.ADDI16SPN, C.ADDI4SP and C.MV change behavior, and encodings such as C.FSD, C.FLD are remapped to load/store capabilities.
 
 ==== Changes to load/stores

--- a/src/zicond.adoc
+++ b/src/zicond.adoc
@@ -90,6 +90,8 @@ Encoding::
 
 Description::
 If _rs2_ contains the value zero, this instruction writes the value zero to _rd_.  Otherwise, this instruction copies the contents of _rs1_ to _rd_.
+When {cheri_base_ext_name} is supported, this instruction copies all bits of _rs1_ to _rd_ including capability metadata and valid tag.
+If _rs2_ is zero, this instructions writes a <<null-cap>> (with zero metadata and valid tag).
 
 This instruction carries a syntactic dependency from both _rs1_ and _rs2_ to _rd_.
 Furthermore, if the Zkt extension is implemented, this instruction's timing is independent of the data values in _rs1_ and _rs2_.
@@ -129,6 +131,8 @@ Encoding::
 
 Description::
 If _rs2_ contains a nonzero value, this instruction writes the value zero to _rd_.  Otherwise, this instruction copies the contents of _rs1_ to _rd_.
+When {cheri_base_ext_name} is supported, this instruction copies all bits of _rs1_ to _rd_ including capability metadata and valid tag.
+If _rs2_ is nonzero, this instructions writes a <<null-cap>> (with zero metadata and valid tag).
 
 This instruction carries a syntactic dependency from both _rs1_ and _rs2_ to _rd_.
 Furthermore, if the Zkt extension is implemented, this instruction's timing is independent of the data values in _rs1_ and _rs2_.


### PR DESCRIPTION
This allows for a branchless conditional move of capabilities. If we only copy the integer part and zero the metadata+tag, we would need to rely on macro-op fusion for conditional capability moves.