### PR TITLE
make redundant branch encodings reserved

### DIFF
--- a/src/cheri/insns/condbr_32bit.adoc
+++ b/src/cheri/insns/condbr_32bit.adoc
@@ -17,6 +17,10 @@ Mnemonics::
 Encoding::
 include::wavedrom/ct-conditional.adoc[]
 
+IMPORTANT: For `beq` and `bne` only, if `rs1≥rs2` then the encoding is RESERVED. These encodings are redundant and may be used by future extensions.
+
+NOTE: Future branch behavior may include branching on valid tag values only, or CLEN-bit compares.
+
 Description::
 Execute as defined in the base ISA.
 If taken, the <<pcc>> is incremented by the offset using <<SCADDR>> semantics.

--- a/src/cheri/insns/load_store_c0.adoc
+++ b/src/cheri/insns/load_store_c0.adoc
@@ -1,2 +1,2 @@
-NOTE: Any instance of this instruction with a `cs1`=`c0` will raise an exception, as `c0` is defined to always hold a <<null-cap>> capability.
+IMPORTANT: Any instance of this instruction with a `cs1`=`c0` will raise an exception, as `c0` is defined to always hold a <<null-cap>> capability.
 As such, the encodings with a `cs1`=`c0` are RESERVED for use by future extensions.


### PR DESCRIPTION
Fix https://github.com/riscv/riscv-cheri/issues/664
Not to define new branches, but to reserve encoding space