### PR TITLE
Drop virtual memory notes from unpriv atomics description

### DIFF
--- a/src/cheri/insns/atomic_exceptions.adoc
+++ b/src/cheri/insns/atomic_exceptions.adoc
@@ -34,10 +34,4 @@ listed below (see <<sec_cheri_exception_handling,_CHERI Exception handling_ in t
 | {cheri_excep_name_st}       | {cheri_excep_desc_bounds}
 |==============================================================================
 +
-If virtual memory is enabled on an RV64 hart, then the state of <<section_priv_cheri_vmem,PTE>>.CW,
-and, if {cheri_priv_crg_ext} is implemented, <<section_cheri_priv_crg_ext,PTE.CRG>> from the current virtual memory page may
-cause a <<section_priv_cheri_vmem,CHERI PTE store/AMO page fault>> exception in addition to a normal RISC-V page fault
-when operating in user mode.
-See <<mtval2-page-fault>> for the exception reporting in this case.
-+
 :!cap_atomic:


### PR DESCRIPTION
This is handled in the Svucrg/Svy chapters. This was missed in #654.
