### PR TITLE
Drop note that branches can raise exceptions

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -628,8 +628,6 @@ E.g., `lw t0, 16(csp)` loads a word from memory, getting the address, bounds, an
 
  No other exception paths are added by {cheri_base_ext_name}: in particular, capability manipulations do not raise an exception, but may set {ctag} of the resulting capability to zero if the operation is not permitted.
 
-NOTE: Branches and jumps may raise exceptions, reusing the Instruction Address Misaligned exception path.
-
 === Added Instructions
 {cheri_base_ext_name} adds new instructions to operate on capabilities.
 To clarify whether an instruction accesses XLEN or CLEN bits of the register, the instruction listing uses `cd/cs1/cs2` for capability operands and `rd/rs1/rs2` for integer operands.


### PR DESCRIPTION
This is no longer true since https://github.com/riscv/riscv-cheri/pull/651.
