### PR TITLE
tidy up priv extensions and abbreviate main name to RVY

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -9,7 +9,7 @@
 // Base CHERI extension (without the mode bit in capability format)
 :cheri_base64_ext_name:    RV64Y
 :cheri_base32_ext_name:    RV32Y
-:cheri_base_ext_name:      {cheri_base32_ext_name}/{cheri_base64_ext_name}
+:cheri_base_ext_name:      RVY
 // CHERI extension adding support for integer pointer mode (and mode bit)
 :cheri_default_ext_name:   Zyhybrid
 :cheri_priv_m_ext: Smy
@@ -18,7 +18,8 @@
 :cheri_priv_s_ext: Ssy
 :cheri_priv_h_ext: Shy
 :cheri_priv_vmem_ext: Svy
-:cheri_priv_debug_ext: Sdy
+:cheri_priv_debug_ext: Sdyext
+:cheri_priv_debug_trig: Sdytrig
 // Extension for CHERI CRG bits
 :cheri_priv_crg_ext:          Svucrg
 :cheri_priv_crg_load_tag_ext: Svucrglvt

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -1,4 +1,4 @@
-[#section_debug_integration]
+[#section_debug_integration_ext]
 === "{cheri_priv_debug_ext}", Integrating {cheri_base_ext_name} with Sdext
 
 ifdef::cheri_standalone_spec[]

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -48,17 +48,23 @@ The following two extensions are useful independent of CHERI:
 <<abhlrsc_ext,{lr_sc_bh_ext_name}>>:: Addition of <<LR_B>>, <<LR_H>>, <<SC_B>>, <<SC_H>> for more accurate atomic locking as the memory ranges are restricted by using bounds, therefore precise locking is needed.
 
 ==== Extensions to the privileged specification
-The following extensions are added to the privleged specification
 
-<<section_priv_cheri,{cheri_priv_m_ext}>>:: Machine-Level Privileged extension to support CHERI.
-<<section_priv_cheri,{cheri_priv_s_ext}>>:: Supervisor-Level Privileged extension to support CHERI.
-<<section_priv_cheri_vmem,{cheri_priv_vmem_ext}>>:: Privileged extension for integrating CHERI with virtual memory.
-<<section_debug_integration,{cheri_priv_debug_ext}>>:: Privileged extension for integrating CHERI with debug mode.
+#ARC-QUESTION: do we need to declare extensions for RVY+<ext> or is just having RVY+<ext> enough?#
+
+The following extensions are added to the privileged specification for {cheri_base_ext_name}:
+
+<<section_priv_cheri,{cheri_priv_m_ext}>>:: Machine-Level Privileged extension to support CHERI (implies Machine ISA).
+<<section_priv_cheri,{cheri_priv_s_ext}>>:: Supervisor-Level Privileged extension to support CHERI (implies Supervisor ISA).
+<<section_priv_cheri_vmem,{cheri_priv_vmem_ext}>>:: Privileged extension for integrating CHERI with virtual memory (implies Sv39).
+<<section_cheri_priv_crg_ext,{cheri_priv_crg_ext}>>:: CHERI extension for capability revocation on RISC-V harts supporting page-based virtual-memory (implies {cheri_priv_vmem_ext}).
+<<section_debug_integration_ext,{cheri_priv_debug_ext}>>:: Privileged extension for integrating CHERI with external debug mode (implies Sdext).
+<<section_debug_integration_trig,{cheri_priv_debug_trig}>>:: Privileged extension for integrating CHERI with debug triggers (implies Sdtrig).
+<<section_priv_cheri,{cheri_priv_h_ext}>>:: Privileged extension to integrate CHERI with the Hypervisor extensions (implies H).
+
+If {cheri_default_ext_name} is implemented, then these extensions are available. All imply {cheri_default_ext_name}.
+
 <<section_cheri_disable,{cheri_priv_m_reg_enable_ext}>>:: Privileged extension to disable explicit access to CHERI registers and instructions.
 <<section_cheri_dyn_xlen,{cheri_priv_m_dyn_xlen_ext}>>:: Privileged extension to allow dynamic XLEN and endianness changes.
-<<section_cheri_priv_crg_ext,{cheri_priv_crg_ext}>>:: CHERI extension for capability revocation on RISC-V harts supporting page-based
-virtual-memory.
-<<section_priv_cheri,{cheri_priv_h_ext}>>:: Privileged extension to integrate CHERI with the Hypervisor extensions.
 
 CAUTION: The extension names are provisional and subject to change.
 
@@ -76,7 +82,8 @@ CAUTION: The extension names are provisional and subject to change.
 |<<section_cheri_disable,{cheri_priv_m_reg_enable_ext}>> | Stable        | This extension is a candidate for freezing
 |<<section_cheri_dyn_xlen,{cheri_priv_m_dyn_xlen_ext}>> | Stable        | This extension is a candidate for freezing
 |<<section_priv_cheri_vmem,{cheri_priv_vmem_ext}>> | Stable        | This extension is a candidate for freezing
-|<<section_debug_integration,{cheri_priv_debug_ext}>> | Stable        | This extension is a candidate for freezing
+|<<section_debug_integration_ext,{cheri_priv_debug_ext}>> | Stable        | This extension is a candidate for freezing
+|<<section_debug_integration_trig,{cheri_priv_debug_trig}>> | Stable        | This extension is a candidate for freezing
 |<<section_priv_cheri,{cheri_priv_h_ext}>>          | Stabilizing   | This extension is a candidate for freeze, software evaluation currently ongoing
 |<<section_cheri_priv_crg_ext,    {cheri_priv_crg_ext}>>         | Stabilizing   | This extension is a candidate for freeze, software evaluation currently ongoing
 |==============================================================================

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -61,7 +61,7 @@ The following extensions are added to the privileged specification for {cheri_ba
 <<section_debug_integration_trig,{cheri_priv_debug_trig}>>:: Privileged extension for integrating CHERI with debug triggers (implies Sdtrig).
 <<section_priv_cheri,{cheri_priv_h_ext}>>:: Privileged extension to integrate CHERI with the Hypervisor extensions (implies H).
 
-If {cheri_default_ext_name} is implemented, then these extensions are available. All imply {cheri_default_ext_name}.
+If {cheri_default_ext_name} is implemented, then these extensions are available. All imply {cheri_base_ext_name}.
 
 <<section_cheri_disable,{cheri_priv_m_reg_enable_ext}>>:: Privileged extension to disable explicit access to CHERI registers and instructions.
 <<section_cheri_dyn_xlen,{cheri_priv_m_dyn_xlen_ext}>>:: Privileged extension to allow dynamic XLEN and endianness changes.

--- a/src/cheri/trigger-integration.adoc
+++ b/src/cheri/trigger-integration.adoc
@@ -1,13 +1,15 @@
 [#section_trigger_integration]
-=== Integrating {cheri_base_ext_name} with Sdtrig
+=== "{cheri_priv_debug_trig}", Integrating {cheri_base_ext_name} with Sdtrig
 
 ifdef::cheri_standalone_spec[]
 WARNING: This chapter will appear in the priv spec. Exact location TBD.
 endif::[]
 
-The Sdtrig extension is generally orthogonal to {cheri_base_ext_name}. However,
+The Sdtrig extension is orthogonal to {cheri_base_ext_name}. However,
 the priority of synchronous exceptions and where triggers fit is adjusted as
 shown in xref:trigger-exception-priority[xrefstyle=short].
+
+Debug triggers are higher priority than CHERI exceptions to allow debug.
 
 [[trigger-exception-priority]]
 .Synchronous exception priority (including triggers) in decreasing priority order. Entries added in {cheri_base_ext_name} are in *bold*


### PR DESCRIPTION
add in implication rules between extensions