### PR TITLE
16-bit shift encodings are not HINTs for RVY

### DIFF
--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -774,15 +774,15 @@ the value in register _rd′_ then writes the result to
 _rd′_. The shift amount is encoded in the _shamt_ field.
 C.SRLI expands into `srli rd′, rd′, shamt`.
 
-The C.SRLI code points with _shamt_=0 are HINTs if the
-base architecture is _not_ {cheri_base_ext_name}.
-
 For RV32C, _shamt[5]_ must be zero; the code points with _shamt[5]_=1
 are designated for custom extensions.
 
 C.SRAI is defined analogously to C.SRLI, but instead performs an
 arithmetic right shift. C.SRAI expands to
 `srai rd′, rd′, shamt`.
+
+The C.SRLI and C.SRAI code points with _shamt_=0 are HINTs if the
+base architecture is _not_ {cheri_base_ext_name}.
 
 [NOTE]
 ====

--- a/src/c-st-ext.adoc
+++ b/src/c-st-ext.adoc
@@ -757,7 +757,8 @@ the value in register _rd_ then writes the result to _rd_. The shift
 amount is encoded in the _shamt_ field.
 C.SLLI expands into `slli rd, rd, shamt[5:0]`.
 
-The C.SLLI code points with _shamt_=0 or with _rd_=`x0` are HINTs.
+The C.SLLI code points with _shamt_=0 or with _rd_=`x0` are HINTs if the
+base architecture is _not_ {cheri_base_ext_name}.
 
 For RV32C, _shamt[5]_ must be zero; the code points with _shamt[5]_=1
 are designated for custom extensions.
@@ -773,7 +774,8 @@ the value in register _rd′_ then writes the result to
 _rd′_. The shift amount is encoded in the _shamt_ field.
 C.SRLI expands into `srli rd′, rd′, shamt`.
 
-The C.SRLI code points with _shamt_=0 are HINTs.
+The C.SRLI code points with _shamt_=0 are HINTs if the
+base architecture is _not_ {cheri_base_ext_name}.
 
 For RV32C, _shamt[5]_ must be zero; the code points with _shamt[5]_=1
 are designated for custom extensions.


### PR DESCRIPTION
fixes https://github.com/riscv/riscv-cheri/issues/629