### PR TITLE
Fix column heading for Table 21. Encoding of architectural permissions for MXLEN=32

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -157,7 +157,7 @@ orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 .Encoding of architectural permissions for MXLEN=32 with <<section_zylevels1>>
 [#cap_perms_encoding32,width="100%",options=header,cols="^2,^1,^1,^1,^1,^1,^1,^1,^1,^2,4",align="center"]
 |==============================================================================
-|Bits[4:3]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
+|Encoding[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
 11+| *Quadrant 0: Non-capability data read/write*
 11+| bit[2] - write, bit[1] - reserved (0), bit[0] - read
 11+| _Reserved bits for future extensions are 0 so new permissions are not implicitly granted_
@@ -169,14 +169,14 @@ orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 | 6-7   10+| reserved
 11+| *Quadrant 1: Executable capabilities*
 11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
-|Bits[4:3]| R | W | C | LM | LG | SL  | X | ASR | Mode^1^ |
+|Encoding[2:0]| R | W | C | LM | LG | SL  | X | ASR | Mode^1^ |
 | 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |  ✔  | Mode^1^  | Execute + ASR (see <<infinite-cap>>)
 | 2-3   | ✔ |   | ✔ | ✔  | ✔  | 1^2^| ✔ |     | Mode^1^  | Execute + Data & Cap RO
 | 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |     | Mode^1^  | Execute + Data & Cap RW
 | 6-7   | ✔ | ✔ |   |    |    | 0^2^| ✔ |     | Mode^1^  | Execute + Data RW
 11+| *Quadrant 2: Restricted capability data read/write*
 11+| bit[2] = write, bit[1:0] = store level. R and C implicitly granted, LM dependent on W permission.
-|Bits[4:3]| R | W | C | LM | LG | SL    | X | ASR | Mode^1^ |
+|Encoding[2:0]| R | W | C | LM | LG | SL    | X | ASR | Mode^1^ |
 | 0-2   10+| reserved
 | 3       | ✔ |   | ✔ |    |    | 0^1^  |   |     | N/A | Data & Cap R0 (without <<lm_perm>>)
 | 4       | ✔ | ✔ | ✔ | ✔  |    | _(3)_ |   |     | N/A | _Reserved_^3^
@@ -186,7 +186,7 @@ orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 11+| *Quadrant 3: Capability data read/write*
 11+| bit[2] = write, bit[1:0] = store level. R and C implicitly granted.
 11+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
-|Bits[4:3]| R | W | C | LM | LG | SL    | X | ASR | Mode^1^ |
+|Encoding[2:0]| R | W | C | LM | LG | SL    | X | ASR | Mode^1^ |
 | 0-2   10+| reserved
 | 3       | ✔ |   | ✔ | ✔  | ✔  | 0^2^  |   |     | N/A | Data & Cap R0
 | 4       | ✔ | ✔ | ✔ | ✔  | ✔  | _(3)_ |   |     | N/A | _Reserved_^3^


### PR DESCRIPTION
This column lists the values for bits[2:0] within each quadrant, the heading was incorrect. Using "Encoding[2:0]" is consistent with the version of the table provided when cheri_nolevels is set.