### PR TITLE
Fix suggested assembly syntax for ADDIY aka CADDI aka CIncOffsetImm

### DIFF
--- a/src/cheri/insns/cadd_32bit.adoc
+++ b/src/cheri/insns/cadd_32bit.adoc
@@ -26,9 +26,9 @@ Mnemonic::
 
 Suggested assembly syntax::
 `add cd, cs1, rs2` +
-`add cd, cs1, imm`
+`addi cd, cs1, imm`
 
-NOTE: The suggested assembly syntax distinguishes from integer `add` by operand type.
+NOTE: The suggested assembly syntax distinguishes from integer `add`/`addi` by operand type.
 
 Encoding::
 include::wavedrom/cadd.adoc[]


### PR DESCRIPTION
Although GNU as accepts ADD with an immediate, and LLVM followed this
for compatibility, it is not the canonical form, and therefore we should
not be suggesting using ADD as the canonical form for ADDIY.
