### PR TITLE
Fix YBNDSIW encoding conflict

### DIFF
--- a/src/cheri/insns/wavedrom/scbnds_32bit.adoc
+++ b/src/cheri/insns/wavedrom/scbnds_32bit.adoc
@@ -20,6 +20,6 @@
   {bits: 5,  name: 'cs1',     attr: ['5', 'src'], type: 4},
   {bits: 5,  name: 'uimm',    attr: ['5', 'uimm', '(> 1 if s=1)'], type: 3},
   {bits: 1,  name: 's',       attr: ['1', 'scaled'], type: 3},
-  {bits: 6,  name: 'funct6',  attr: ['6', '{SCBNDSI}','=000001'], type: 3},
+  {bits: 6,  name: 'funct6',  attr: ['6', '{SCBNDSI}','=000100'], type: 3},
 ]}
 ....


### PR DESCRIPTION
YBNDSIW to avoid conflict with 64 place right shift
Brings encodings into line with https://github.com/riscv/riscv-opcodes/pull/365