### PR TITLE
Rename YBNDSIW to YBNDSWI

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -107,8 +107,8 @@
 :SCBNDS_LC:    ybndsw
 :SCBNDS_DESC:  Write capability bounds
 
-:SCBNDSI:      YBNDSIW
-:SCBNDSI_LC:   ybndsiw
+:SCBNDSI:      YBNDSWI
+:SCBNDSI_LC:   ybndswi
 :SCBNDSI_DESC: Write capability bounds by immediate
 
 :SCBNDSR:      YBNDSRW


### PR DESCRIPTION
This matches CSRW/CSRWI/CSRCI and all other instructions with immediates that follow the `<mnemonic>I<size>` pattern (e.g. ADDIW).