### PR TITLE
Fix permission compression with Zylevels1

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -196,7 +196,7 @@ is supported, otherwise such encodings are reserved. Despite being encoded here 
 
 When MXLEN=32, this compressed permission format introduces
 new dependencies between permisison bits.
-When <<section_zylevels1>> _is not_ present, the following new rows are added to <<acperm_rules>> table:
+When <<section_zylevels1>> _is not_ present, the following new rows are added to <<acperm_rules>>:
 
 [float="center",align="center",cols="2,2,4",options="header"]
 |===
@@ -206,7 +206,7 @@ When <<section_zylevels1>> _is not_ present, the following new rows are added to
 |===
 
 
-When <<section_zylevels1>> _is_ present, the following new rows are added to <<acperm_rules>> table:
+When <<section_zylevels1>> _is_ present, the following new rows are added to <<acperm_rules>>:
 
 [float="center",align="center",cols="2,2,4",options="header"]
 |===


### PR DESCRIPTION
Some of the rows in the encoding table still had multi-bit SLs.