### PR TITLE
Primordial, not Infinite, capabilities

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -120,7 +120,7 @@ Quadrant 1 encodes permissions for executable capabilities and the <<m_bit>>.
 | 6-7   8+| reserved
 9+| *Quadrant 1: Executable capabilities*
 9+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
-| 0-1   | ✔ | ✔ | ✔ | ✔ | ✔ |  ✔  | Mode^1^  | Execute + ASR (see <<infinite-cap>>)
+| 0-1   | ✔ | ✔ | ✔ | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
 | 2-3   | ✔ |   | ✔ | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RO
 | 4-5   | ✔ | ✔ | ✔ | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RW
 | 6-7   | ✔ | ✔ |   |   | ✔ |     | Mode^1^  | Execute + Data RW
@@ -170,7 +170,7 @@ orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 11+| *Quadrant 1: Executable capabilities*
 11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
 |Encoding[2:0]| R | W | C | LM | LG | SL  | X | ASR | Mode^1^ |
-| 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |  ✔  | Mode^1^  | Execute + ASR (see <<infinite-cap>>)
+| 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
 | 2-3   | ✔ |   | ✔ | ✔  | ✔  | 1^2^| ✔ |     | Mode^1^  | Execute + Data & Cap RO
 | 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |     | Mode^1^  | Execute + Data & Cap RW
 | 6-7   | ✔ | ✔ |   |    |    | 0^2^| ✔ |     | Mode^1^  | Execute + Data RW
@@ -642,8 +642,10 @@ Permissions added by extensions (such as those of <<section_zylevels1>>) are pre
 [#section_infinite_cap_encoding]
 ==== Infinite Capability Encoding
 
-The <<infinite-cap>> capability grants all permissions while its bounds also cover the whole address space.
+The encoding herein admits an _Infinite_ capability value, which
+grants all permissions while its bounds also cover the whole address space.
 It includes <<x_perm>> and so includes the <<m_bit>> if {cheri_default_ext_name} is supported.
+This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capability.
 
 // Added note here for CHERIoT which enforces W xor X.
 NOTE: Future extension to the capability format may use a "multi-root" format where the infinite capability does not exist and instead have multiple roots with different permissions (e.g., one for code and one for data).
@@ -670,14 +672,14 @@ NOTE: Future extension to the capability format may use a "multi-root" format wh
 | Reserved      | zeros | All reserved fields
 |==============================================================================
 
-^1^If {cheri_default_ext_name} is supported, then the <<infinite-cap>> capability must represent
+^1^If {cheri_default_ext_name} is supported, then the infinite capability must represent
 {cheri_int_mode_name} for compatibility with standard RISC-V code. Therefore:
 
 * For MXLEN=32, the <<m_bit>> is set to {INT_MODE_VALUE} in the <<AP-field>>, giving the value 0x9
 * For MXLEN=64, the <<m_bit>> is set to {INT_MODE_VALUE} in a separate M field which is _not shown_ in the table above.
 
-^2^If an <<infinite-cap>> capability is used as a constant in either hardware or software, then the address field will typically be set to zero.
- If the address field is non-zero then it is still referred to as an <<infinite-cap>> capability, and it still has the authority to authorize all memory accesses.
+^2^If an infinite capability is used as a constant in either hardware or software, then the address field will typically be set to zero.
+ If the address field is non-zero then it is still referred to as an infinite capability, and it still has the authority to authorize all memory accesses.
 
 Permissions added by extensions (such as those of <<section_zylevels1>>) are presumed present in Infinite capabilities.
 
@@ -697,7 +699,7 @@ also circular, so address 0 is within the <<section_cap_representable_check>> of
 where address 2^MXLEN^ - 1 is within the bounds.
 However, the decoded top field of a capability is MXLEN + 1 bits wide and does *not* wrap, so
 a capability with base 2^MXLEN^ - 1 and top 2^MXLEN^ + 1 is not a subset of the
-<<infinite-cap>> capability and does not authorize access to the byte at address 0.
+infinite capability and does not authorize access to the byte at address 0.
 Like malformed bounds (see xref:section_cap_malformed[xrefstyle=short]), it is impossible for
 a CHERI core to generate a valid capability with top > 2^MXLEN^.
 If such a capability exists then it must have been caused by a logic or memory fault.

--- a/src/cheri/csv/CHERI_CSR.csv
+++ b/src/cheri/csv/CHERI_CSR.csv
@@ -4,31 +4,31 @@ Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply
 direct write if address didn't change","✔","","✔","Sdext","Debug Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
 "dscratch0_y","0x7b2","dscratch0","D","DRW","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","Sdext","Debug Scratch Capability 0","","","","","","","","","","","","","","","","","","","","",""
 "dscratch1_y","0x7b3","dscratch1","D","DRW","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","Sdext","Debug Scratch Capability 1","","","","","","","","","","","","","","","","","","","","",""
-"mtvec_y","0x305","mtvec","M","MRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"mtvec_y","0x305","mtvec","M","MRW, <<asr_perm>>","<<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","✔","","","M-mode","Machine Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
 "mscratch_y","0x340","mscratch","M","MRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","M-mode","Machine Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
-"mepc_y","0x341","mepc","M","MRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"mepc_y","0x341","mepc","M","MRW, <<asr_perm>>","<<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","✔","M-mode","Machine Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
-"stvec_y","0x105","stvec","S","SRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"stvec_y","0x105","stvec","S","SRW, <<asr_perm>>","<<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","✔","","","S-mode","Supervisor Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
 "sscratch_y","0x140","sscratch","S","SRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","S-mode","Supervisor Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
-"sepc_y","0x141","sepc","S","SRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"sepc_y","0x141","sepc","S","SRW, <<asr_perm>>","<<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","✔","S-mode","Supervisor Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
-"vstvec_y","0x205","vstvec","VS","HRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"vstvec_y","0x205","vstvec","VS","HRW, <<asr_perm>>","<<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","✔","","","H","Virtual Supervisor Trap-Vector Base-Address Capability","","","","","","","","","","","","","","","","","","","","",""
 "vsscratch_y","0x240","vsscratch","VS","HRW, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","H","Virtual Supervisor Scratch Capability","","","","","","","","","","","","","","","","","","","","",""
-"vsepc_y","0x241","vsepc","VS","HRW, <<asr_perm>>","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"vsepc_y","0x241","vsepc","VS","HRW, <<asr_perm>>","<<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","✔","H","Virtual Supervisor Exception Program Counter Capability","","","","","","","","","","","","","","","","","","","","",""
 "jvt_y","0x017","jvt","U","URW","tag=0, otherwise undefined","Apply <<section_invalid_addr_conv>>.
@@ -37,10 +37,11 @@ direct write if address didn't change","✔","","","Zcmt","Jump Vector Table Cap
 "dddc","0x7bc","","D","DRW","tag=0, otherwise undefined","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","","✔","","{cheri_default_ext_name}, Sdext","Debug Default Data Capability (saved/restored on debug mode entry/exit)","","","","","","","","","","","","","","","","","","","","",""
-"ddc","0x416","","U","URW","<<infinite-cap>>","Apply <<section_invalid_addr_conv>>.
+"ddc","0x416","","U","URW","<<root-rw-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","","✔","","{cheri_default_ext_name}","User Default Data Capability","","","","","","","","","","","","","","","","","","","","",""
-"dinfc","0x7bd","","D","DRW","<<infinite-cap>>","Ignore","Ignore","","","","Sdext","Source of <<infinite-cap>> capability in debug mode, writes are ignored","","","","","","","","","","","","","","","","","","","","",""
+"drootcsel","0x7ba","","D","DRW","0","Ignore","Ignore","","","","Sdext","Multiplexing selector for <<drootc>>","","","","","","","","","","","","","","","","","","","","",""
+"drootc","0x7bd","","D","DRW","<<root-rx-cap>>","Ignore","Ignore","","","","Sdext","Source of authority in debug mode, writes are ignored","","","","","","","","","","","","","","","","","","","","",""
 "utidc","0x480","","U","Read: U, Write: U, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","User thread ID","","","","","","","","","","","","","","","","","","","","",""
 "stidc","0x580","","S","Read: S, Write: S, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Supervisor thread ID","","","","","","","","","","","","","","","","","","","","",""
 "vstidc","0xA80","","H","Read: VS, Write: VS, <<asr_perm>>","tag=0, otherwise undefined","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Virtual supervisor thread ID","","","","","","","","","","","","","","","","","","","","",""

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -57,7 +57,7 @@ ebreak
 
 # Write the {ctag} (if nonzero)
 csrrw   {creg}2, dscratch0, {creg}2
-csrr    {creg}2, dinfc
+csrr    {creg}2, drootc
 {cbld_lc}    {creg}1, {creg}2, {creg}1
 csrrw   {creg}2, dscratch0, {creg}2
 ebreak
@@ -126,7 +126,7 @@ Upon entry to debug mode, the _RISC-V Debug Specification_, does not specify how
 update the PC, and says PC relative instructions may be illegal. This concept
 is extended to include any instruction which reads or updates <<pcc>>, which refers to
 all jumps, conditional branches and <<AUIPC_CHERI>>. The exceptions are <<MODESW_CAP>> and <<MODESW_INT>>
-which _are_ supported if {cheri_default_ext_name} is implemented, see <<dinfc>>
+which _are_ supported if {cheri_default_ext_name} is implemented, see <<drootc>>
 for details.
 
 As a result, the value of <<pcc>> is UNSPECIFIED in debug mode according
@@ -164,30 +164,44 @@ The <<dscratch1>> register is extended to hold a capability.
 .Debug scratch 1 capability register
 include::img/dscratch1creg.edn[]
 
-[#dinfc,reftext="dinfc"]
-==== Debug Infinite Capability Register (dinfc)
+[#drootcsel,reftext="drootcsel"]
+==== Debug Root Capability Selector (drootcsel)
 
-<<dinfc>> is a debug mode accessible capability CSR. The address and access details are shown in
+<<drootcsel>> is a debug mode accessible integer CSR.  The address and access details are shown in
 xref:default-csrnames-added[xrefstyle=short].
 
-The reset value is the <<infinite-cap>> capability.
+It selects which <<root-cap>> capability is exposed through <<drootc>>.
+The reset value is `0`, which must cause <<drootcsel>> to expose a
+<<root-rx-cap>> capability.
 
-If {cheri_default_ext_name} is implemented:
+Other capability values may be defined for exposure through <<drootc>>
+by the capability encoding,
+and may be selected by having the debugger write to this register.
+Writes are WARL, so the debugger may confirm that its selection has been applied.
+
+.Debug root capability register
+include::img/drootcselreg.edn[]
+
+[#drootc,reftext="drootc"]
+==== Debug Root Capability Register (drootc)
+
+<<drootc>> is a debug mode accessible capability CSR. The address and access details are shown in
+xref:default-csrnames-added[xrefstyle=short].
+It exposes the capability selected by <<drootcsel>>.
+
+If {cheri_default_ext_name} is implemented,
+the <<root-rx-cap>> exposed when <<drootcsel>> is `0` is further specified thus:
 
 * The <<m_bit>> is reset to {cheri_int_mode_name} ({INT_MODE_VALUE}).
 * The debugger can set the <<m_bit>> to {cheri_cap_mode_name} ({CAP_MODE_VALUE}) by executing <<MODESW_CAP>> from the program buffer.
 ** Executing <<MODESW_CAP>> causes subsequent instructions execution from the program buffer, starting from the next instruction, to be executed in {cheri_cap_mode_name}. It also sets the CHERI execution mode to {cheri_cap_mode_name} on future entry into debug mode.
 ** Therefore to enable use of a CHERI debugger, a single <<MODESW_CAP>> only needs to be executed once from the program buffer after resetting the core.
-** The debugger can also execute <<MODESW_INT>> to change the mode back to {cheri_int_mode_name}, which also affects the execution of the next instruction in the program buffer, updates the <<m_bit>> of <<dinfc>> and controls which CHERI execution mode to enter on the next entry into debug mode.
+** The debugger can also execute <<MODESW_INT>> to change the mode back to {cheri_int_mode_name}, which also affects the execution of the next instruction in the program buffer, updates the <<m_bit>> of this capability and controls which CHERI execution mode to enter on the next entry into debug mode.
 
-The <<m_bit>> of <<dinfc>> is _only_ updated by executing <<MODESW_CAP>> or <<MODESW_INT>> from the program buffer.
+The <<m_bit>> of this capability is _only_ updated by executing <<MODESW_CAP>> or <<MODESW_INT>> from the program buffer.
 
-NOTE: A future version of this specification may add writeable fields to allow creation
- of other capabilities, if, for example, a future extension requires multiple formats for
- the <<infinite-cap>> capability.
-
-.Debug infinite capability register
-include::img/dinfcreg.edn[]
+.Debug root capability register
+include::img/drootcreg.edn[]
 
 [#section_hybrid_debug_integration]
 === Integrating {cheri_default_ext_name} with Sdext
@@ -198,15 +212,15 @@ shown in xref:default-csrnames-added[xrefstyle=short].
 {cheri_default_ext_name} allows <<MODESW_CAP>> and <<MODESW_INT>> to execute in debug mode.
 
 When entering debug mode, whether the core enters {cheri_int_mode_name} or
-{cheri_cap_mode_name} is controlled by the <<m_bit>> in <<dinfc>>.
+{cheri_cap_mode_name} is controlled by the <<m_bit>> in the <<drootc>> capability selected by <<drootcsel>> value 0.
 
-The current mode can be read from <<dinfc>>.
+The current mode can be read by setting <<drootcsel>> to `0` and then reading <<drootc>>.
 
 The following sequence executed from the program buffer will write {CAP_MODE_VALUE} for {cheri_cap_mode_name} and {INT_MODE_VALUE} for {cheri_int_mode_name} to `x1`:
 
 [source,subs=attributes+]
 ----
-csrr   {creg}1, dinfc
+csrr   {creg}1, drootc
 {gcmode_lc} x1, {creg}1
 ----
 
@@ -228,9 +242,8 @@ xref:default-csrnames-added[xrefstyle=short].
 .Debug default data capability
 include::img/dddcreg.edn[]
 
-Upon entry to debug mode, <<ddc>> is saved in <<dddc>>. <<ddc>>'s metadata is
-set to the <<infinite-cap>> capability's metadata (with tag set) and <<ddc>>'s
-address remains unchanged.
+Upon entry to debug mode, <<ddc>> is saved in <<dddc>>. <<ddc>> is set to a
+<<root-rw-cap>> capability such that <<ddc>>'s address remains unchanged.
 
 When debug mode is exited by executing <<DRET_CHERI>>, the hart's <<ddc>> is updated to
 the capability stored in <<dddc>>. A debugger may write <<dddc>> to change the

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -80,7 +80,7 @@ xref:mstatus_cheri[xrefstyle=short] for mstatus.UXL.
 === Virtual Supervisor Trap Vector Base Address Capability Register (vstvec)
 
 The <<vstvec>> register is extended to hold a capability.
-Its reset value is the <<infinite-cap>> capability.
+Its reset value is a <<root-rx-cap>> capability.
 
 .Virtual supervisor trap vector base address capability register
 include::img/vstveccreg.edn[]
@@ -104,7 +104,7 @@ include::img/vsscratchcreg.edn[]
 === Virtual Supervisor Exception Program Counter Capability (vsepc)
 
 The <<vsepc>> register is extended to hold a capability.
-Its reset value is the <<infinite-cap>> capability.
+Its reset value is a <<root-rx-cap>> capability.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<vsepc_y>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
 Additionally, the capability in <<vsepc_y>> is unsealed when it is written to <<pcc>> on execution of an <<SRET_CHERI>> instruction when V=1.

--- a/src/cheri/img/drootcreg.edn
+++ b/src/cheri/img/drootcreg.edn
@@ -6,17 +6,17 @@
 (def left-margin 100)
 (def right-margin 100)
 (def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
 
 (draw-box "V" {:span 1})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "dinfc (Metadata)" {:span 32})
+(draw-box "drootc (Metadata)" {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
 
-(draw-box "dinfc (Address)"  {:span 32})
+(draw-box "drootc (Address)"  {:span 32})
 
 (draw-box "" {:span 2 :borders {}})
-(draw-box "MXLEN" {:span 32 :borders {}})
+(draw-box "DXLEN" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/drootcselreg.edn
+++ b/src/cheri/img/drootcselreg.edn
@@ -1,0 +1,14 @@
+[bytefield]
+----
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 21}])
+(def row-height 40)
+(def row-header-fn nil)
+(def left-margin 100)
+(def right-margin 100)
+(def boxes-per-row 32)
+(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1"])})
+
+(draw-box "drootcsel"  {:span 32})
+
+(draw-box "DXLEN" {:span 32 :borders {}})
+----

--- a/src/cheri/insns/modesw_32bit.adoc
+++ b/src/cheri/insns/modesw_32bit.adoc
@@ -23,11 +23,6 @@ Set the current CHERI execution mode in <<pcc>>.
 * {MODESW_CAP}: If the current mode in <<pcc>> is {cheri_int_mode_name} ({INT_MODE_VALUE}), then the <<m_bit>> in <<pcc>> is set to {cheri_cap_mode_name} ({CAP_MODE_VALUE}). Otherwise no effect.
 * {MODESW_INT}: If the current mode in <<pcc>> is {cheri_cap_mode_name} ({CAP_MODE_VALUE}), then the <<m_bit>> in <<pcc>> is set to {cheri_int_mode_name} ({INT_MODE_VALUE}). Otherwise no effect.
 
-//TODO: move to debug spec
-//NOTE: Executing <<MODESW_CAP>> or <<MODESW_INT>> from the program buffer in debug mode updates the <<m_bit>> of <<dinfc>>.
-// The <<m_bit>> of <<dinfc>> sets the CHERI execution mode for the execution of the next instruction from the program buffer, and is used to control which CHERI execution mode to enter next time debug mode is entered.
-// The CHERI execution mode is *only* controlled by the <<m_bit>> of <<dinfc>> in debug mode.
-
 Operation::
 +
 sail::execute[clause="MODESW()",part=body,unindent]

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -130,7 +130,9 @@ xref:default-csrnames-added[xrefstyle=short].
 <<ddc>> is a read-write, user mode accessible capability CSR.
 It does not require <<asr_perm>> in <<pcc>> for writes or reads.
 Similarly to <<pcc>> authorizing all control flow and instruction fetches, this capability register is implicitly checked to authorize all data memory accesses  when the current CHERI mode is {cheri_int_mode_name}.
-On startup <<ddc>> bounds and permissions must be set such that the program can run successfully (e.g., by setting it to <<infinite-cap>> to ensure _all_ data references are in bounds).
+On startup <<ddc>> bounds and permissions must be set such that the program can run successfully
+(e.g., by setting it to have sufficiently broad bounds and permissions,
+possibly a <<root-rw-cap>> capability).
 
 .Unprivileged default data capability register
 include::img/ddcreg.edn[]

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -17,9 +17,9 @@ to the CSRs.
 ==== Machine Trap Vector Base Address Capability Register (mtvec)
 
 The <<mtvec>> register is extended to hold a code capability.
-Its reset value is nominally the <<infinite-cap>> capability.
+Its reset value is nominally a <<root-rx-cap>> capability.
 
-NOTE: <<mtvec_y>> exists in all CHERI implementations, and so may be used as a source of the <<infinite-cap>> capability after reset.
+NOTE: <<mtvec_y>> exists in all CHERI implementations, and so may be used as a source of a <<root-rx-cap>> capability after reset.
 
 .Machine-mode trap-vector base-capability register
 include::img/mtveccreg.edn[]
@@ -29,7 +29,7 @@ The fields in the metadata are WARL as many fields can be implemented as constan
 NOTE: Examples of WARL behavior include always setting <<x_perm>> to 1 and setting the reserved fields to zero, otherwise the capability is unusable.
  Another example is to partially or fully restrict the bounds to constant values.
 
-NOTE: Care must be taken however that an <<infinite-cap>> capability is available to software after reset if this CSR does not represent one.
+NOTE: Care must be taken however that suitable root capabilities are available to software after reset if this CSR does not represent one.
 
 When traps are taken into machine mode, the pc is updated following the standard `mtvec` behavior.
 The {ctag} and metadata from <<mtvec_y>> are also written to the <<pcc>>.
@@ -73,7 +73,7 @@ include::img/mscratchcreg.edn[]
 ==== Machine Exception Program Counter Capability (mepc)
 
 The <<mepc>> is extended to hold a capability.
-Its reset value is nominally the <<infinite-cap>> capability.
+Its reset value is nominally a <<root-rx-cap>> capability.
 
 .Machine exception program counter capability register
 include::img/mepccreg.edn[]
@@ -258,7 +258,7 @@ hold capabilities or with other new functions. <<asr_perm>> in the <<pcc>> is ty
 ==== Supervisor Trap Vector Base Address Capability Register (stvec)
 
 The <<stvec>> register is extended to hold a capability.
-When the S-mode execution environment starts, the value is nominally the <<infinite-cap>> capability.
+When the S-mode execution environment starts, the value is nominally a <<root-rx-cap>> capability.
 
 .Supervisor trap-vector base-capability register
 include::img/stveccreg.edn[]
@@ -281,7 +281,7 @@ include::img/sscratchcreg.edn[]
 ==== Supervisor Exception Program Counter Capability (sepc)
 
 The <<sepc>> register is extended to hold a capability.
-Its reset value is the <<infinite-cap>> capability.
+When the S-mode execution environment starts, the value is nominally a <<root-rx-cap>> capability.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<sepc_y>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
 Additionally, the capability in <<sepc_y>> is unsealed when it is written to <<pcc>> on execution of an <<SRET_CHERI>> instruction.
@@ -294,7 +294,8 @@ include::img/sepccreg.edn[]
 ==== Supervisor Thread Identifier Capability (stidc)
 
 The <<stidc>> register is used to identify the current software thread in supervisor mode, using the method defined in the section for the unprivileged utidc CSR.
-On reset the {ctag} of <<stidc>> will be set to zero and the remainder of the data is UNSPECIFIED.
+When the S-mode execution environment starts,
+the {ctag} of <<stidc>> will be set to zero and the remainder of the data is UNSPECIFIED.
 
 .Supervisor thread identifier capability register
 include::img/stidcreg.edn[]
@@ -506,7 +507,7 @@ in connection with the <<section_cheri_disable,{CRE}>> and the <<cheri_execution
 ^1^ M-bit is irrelevant when {CRE}=0. +
 ^2^ See xref:legacy_mnemonics[xrefstyle=short] for a list of remapped
 instructions. +
-^3^ The hart is fully compatible with standard RISC-V when {CRE}=0 provided that <<pcc>>, <<mtvec_y>>, <<mepc_y>>, <<stvec_y>>, <<sepc_y>>, <<vstvec_y>>, <<vsepc_y>> and <<ddc>> have not been changed from the default reset state (i.e., hold the <<infinite-cap>> capability).
+^3^ The hart is fully compatible with standard RISC-V when {CRE}=0 provided that <<pcc>>, <<mtvec_y>>, <<mepc_y>>, <<stvec_y>>, <<sepc_y>>, <<vstvec_y>>, <<vsepc_y>> and <<ddc>> have not been changed from the default reset state (i.e., hold <<root-rx-cap>> and <<root-rw-cap>> capabilities).
 
 
 [#section_cheri_dyn_xlen]
@@ -637,13 +638,13 @@ memory addresses must match for the address to be valid.
 The CSRs shown in xref:CSR_exevectors[xrefstyle=short], as well as the pc, need not hold all possible invalid addresses.
 Implementations may convert an invalid address into some other invalid address that the register is capable of holding.
 
-However, the bounds encoding of capabilities depends on the address value if the bounds are not of the <<infinite-cap>> capability.
+However, the bounds encoding of capabilities depends on the address value if the bounds are not infinite.
 
-Therefore implementations must not convert invalid addresses to other arbitrary invalid addresses in an unrestricted manner if the bounds are not <<infinite-cap>>.
+Therefore implementations must not convert invalid addresses to other arbitrary invalid addresses in an unrestricted manner if the bounds are not infinite.
 
-If the bounds could not be decoded due to the address being invalid, and the bounds not being <<infinite-cap>>, then a _{cheri_excep_name_pc}_, _{cheri_excep_name_ld}_ or _{cheri_excep_name_st}_ exception is raised as appropriate.
+If the bounds could not be decoded due to the address being invalid, then a _{cheri_excep_name_pc}_, _{cheri_excep_name_ld}_ or _{cheri_excep_name_st}_ exception is raised as appropriate.
 
-NOTE: In all cases, if the authorizing capability has <<infinite-cap>> bounds, then the behavior is identical to the normal RISC-V behavior without CHERI.
+NOTE: In all cases, if the authorizing capability has bounds that cover all addresses, then the behavior is identical to the normal RISC-V behavior without CHERI.
 
 NOTE: Not requiring to the implementation to decode the bounds for invalid addresses reduces the size of bounds comparators from 64-bits to the supported virtual address width.
 
@@ -656,23 +657,23 @@ A CSR may be updated to hold a capability with an invalid address, due to:
 
 To ensure that the bounds of a valid capability cannot be corrupted:
 
-* If the new address is invalid and the capability does not have <<infinite-cap>> bounds, then set the {ctag} to zero before writing to the CSR.
+* If the new address is invalid and the capability bounds do not cover all addresses, then set the {ctag} to zero before writing to the CSR.
 
 NOTE: When the capability's address is invalid and happens to match an invalid address which the CSR
 can hold, then it is implementation defined whether to set the {ctag} to zero.
 
 ==== Branches and Jumps
 
-If the effective target address of the jump or branch is invalid, and the authorizing capability does not have <<infinite-cap>> bounds, then set the {ctag} of the target <<pcc>> to zero.
+If the effective target address of the jump or branch is invalid, and the authorizing capability's bounds do not cover all addresses, then set the {ctag} of the target <<pcc>> to zero.
 This will cause a {cheri_excep_name_pc} exception when executing the target instruction.
 
 NOTE: RISC-V harts that do not support {cheri_base_ext_name} normally raise an
 instruction access fault or page fault after jumping or branching to an invalid address.
 Therefore, {cheri_base_ext_name} aims to preserve that behavior to ensure that
 harts supporting {cheri_base_ext_name} and {cheri_default_ext_name} are fully
-compatible with RISC-V harts provided that <<pcc>> and <<ddc>> are set to the
-<<infinite-cap>> capability.
+compatible with RISC-V harts provided that <<pcc>> and <<ddc>> are set to
+<<root-rx-cap>> and <<root-rw-cap>> capabilities, respectively.
 
 ==== Memory Accesses
 
-If the effective address of the memory access is invalid, and the authorizing capability does not have <<infinite-cap>> bounds, then raise a {cheri_excep_name_ld} or {cheri_excep_name_st} exception because the bounds cannot be reliably decoded.
+If the effective address of the memory access is invalid, and the authorizing capability's bounds do not cover all addresses, then raise a {cheri_excep_name_ld} or {cheri_excep_name_st} exception because the bounds cannot be reliably decoded.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -181,8 +181,9 @@ NOTE: A future extension may add an instruction to directly read the _top_ if ne
 
 ==== Updating the Bounds
 
-On system initialization the <<infinite-cap>> capability is available which has bounds which cover all of memory, and maximum permissions set.
-All smaller capabilities are derived from this.
+On system initialization, one or more <<root-cap>> capabilities are available;
+typically, these have bounds which cover all of memory and the maximum permissions set.
+All smaller capabilities are derived from these.
 
 The ISA does not allow the bounds (and permissions) of a capability with its {ctag} set to be increased (_monotonicity_).
 
@@ -353,17 +354,39 @@ NOTE: This property is required to ensure restricted programs cannot forge capab
 [#section_special_caps]
 ==== Special Capabilities
 
-[#infinite-cap,reftext="Infinite"]
-===== Infinite Capability
+[#root-cap,reftext="Root"]
+===== Root Capabilities
 
-The _Infinite_ capability grants all permissions and its bounds cover the whole 2^MXLEN^ address space.
-Extensions that introduce new capability metadata must describe their metadata's state in Infinite capabilities.
-The address field can hold any value.
+_Root_ (sometimes also _primordial_, _initial_) capabilities are those provided by the system at reset.
+In some systems (and capability encodings), there is a single "Infinite" capability value,
+which grants all permissions and has bounds covering the whole 2^MXLEN^ address space;
+in such systems, root capabilities are often Infinite.
+More generally, the _set_ of root capabilities often collectively grant all permissions to all addresses.
+By way of example, an encoding may prohibit one capability from authorizing both write and execute;
+a system using such an encoding would typically make available maximally permissive
+read-write and read-execute capabilities as part of their root set.
 
-All capability checks pass when performed against a valid <<infinite-cap>> capability.
-The encoding of the _Infinite_ capability is described in <<section_infinite_cap_encoding>>.
+[NOTE]
+=====
+How unprivileged software receives its root capabilities is largely an ABI question;
+the privileged specification will detail requirements of capability registers' reset state
+(and so on the root capabilities held therein).
+=====
 
-NOTE: The _Infinite_ capability is also known as 'default', 'almighty', or 'root' capability in other CHERI documentation.
+Because particular sets of requirements recur throughout the specification,
+we define some useful short-hand terminology.
+
+[#root-rx-cap,reftext="Root Executable"]
+Root Executable Capability::
+A capability that has bounds covering all addresses
+and bears at least all of <<x_perm>>, <<r_perm>>, <<c_perm>>, <<lm_perm>>, and <<asr_perm>>.
+Extensions introducing new permissions may require these to be provided by root executable capabilities.
+
+[#root-rw-cap,reftext="Root Data"]
+Root Data Capability::
+A capability that has bounds covering all addresses
+and bears at least all of <<r_perm>>, <<w_perm>>, <<c_perm>>, and <<lm_perm>>.
+Extensions introducing new permissions may require these to be provided by root data capabilities.
 
 [#null-cap,reftext="NULL"]
 ===== NULL Capability
@@ -420,7 +443,7 @@ A failing check raises a CHERI exception.
 * All bytes of the instruction must be in bounds
 * All <<section_cap_integrity,integrity>> checks passed.
 
-On system initialization the `pc` bounds and permissions must be set such that the program can run successfully (e.g., by setting it to <<infinite-cap>> to ensure _all_ instructions are in bounds).
+On system initialization the `pc` bounds and permissions must be set such that the program can run successfully (e.g., by setting it to a <<root-rx-cap>> capability to ensure _all_ instructions are in bounds).
 
 NOTE: Future ISA extensions should respect these rules so that the checked bits do not need storing in all copies of the <<pcc>> in the implementation.
 

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -65,10 +65,16 @@ The _Capability Global_ flag holds one of two values:
 
 As with permissions, the _Capability Global_ flag of a valid capability can be cleared but never set (without reconstruction from a global superset capability).
 
-=== Interaction with <<infinite-cap,Infinite Capabilities>>
+=== Interaction with <<root-cap>> Capabilities
 
-As expected, <<infinite-cap,Infinite capabilities>> have both new permissions, <<zylevels1_lg_perm>> and <<zylevels1_sl_perm>> set.
-Further, Infinite caps have <<zylevels1_gl_perm>> set to _global_.
+The <<root-cap>> capabilities used in the system are extended thus:
+
+* The definitions of <<root-rx-cap>> and <<root-rw-cap>> capabilities are
+  both augmented to require <<zylevels1_gl_perm>> be set to _global_.
+
+* A <<root-rx-cap>> capability is required to bear <<zylevels1_lg_perm>>.
+
+* A <<root-rw-cap>> capability is required to bear both <<zylevels1_lg_perm>>, and <<zylevels1_sl_perm>>.
 
 === Interaction with <<CLRPERM>> and <<GCPERM>>
 

--- a/src/priv-csrs.adoc
+++ b/src/priv-csrs.adoc
@@ -1072,11 +1072,17 @@ Debug program counter. +
 Debug scratch register 0. +
 Debug scratch register 1. +
 
+4+^|#{cheri_priv_debug_ext} Debug Mode added XLEN CSRs#
+|`0x7BA`
+|DRW
+|`drootcsel`
+|#Debug Root Capability Multiplexing Selector.# +
+
 4+^|#{cheri_priv_debug_ext} Debug Mode added YLEN CSRs#
 |`0x7BD`
 |DRW
-|`dinfc`
-|#Debug Infinite Capability.# +
+|`drootc`
+|#Debug Root Capability.# +
 
 4+^|#{cheri_priv_debug_ext} Debug Mode YLEN CSRs added for {cheri_default_ext_name}#
 |`0x7BC`


### PR DESCRIPTION
Rampage through the spec and attempt to expunge the notion of a singular infinite capability in favor of explicit requirements.

Partially addresses https://github.com/riscv/riscv-cheri/issues/391