### PR TITLE
Fix incorrect description for JALR

### DIFF
--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -4,7 +4,7 @@
 ==== JALR ({cheri_base_ext_name})
 
 Synopsis::
-{JAL_CHERI_DESC}
+{JALR_CHERI_DESC}
 
 Mnemonic::
 `jalr {cd}, {cs1}, offset`


### PR DESCRIPTION
It was using the wrong macro name