### PR TITLE
Refactor CLRPERM rules

### DIFF
--- a/misc/rv32y_perms.hs
+++ b/misc/rv32y_perms.hs
@@ -1,0 +1,190 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Check that the RV32 encodings, with and without Zylevels1, are sensible and
+--   that the procedure we give for computing permissions has the intended
+--   effect.
+--
+--   1. Each defined compressed permission set holds only defined permissions
+--
+--   2. For each defined compressed permission set, it had better be stable
+--      under the transformation rules (that is, a fixed point thereof).
+--
+--   3. For each subset of all defined permissions, the result of evaluating
+--      the rules is a defined compressed permission set.
+--
+--   4. Removing permissions from a defined compressed permission set and
+--      evaluating the rules selects the best result, in that all other defined
+--      compressed permission sets that could have been chosen are subsets of
+--      the one picked.
+module Main where
+
+import           Control.Monad
+import qualified Data.Set  as S
+import qualified Data.Text as T
+
+data P = PR | PW | PC | PLM | PLG | PSL | PX | PASR | PM
+ deriving (Bounded, Enum, Eq, Ord, Show)
+
+type SP = S.Set P
+
+allPermsL1, allPermsL0 :: SP
+allPermsL1 = S.fromList [minBound .. maxBound]
+allPermsL0 = S.difference allPermsL1 [PLG, PSL] -- remove Zylevel perms
+
+validsL1, validsL0 :: S.Set SP
+validsL0 = S.fromList $
+  [ -- Quadrant 0
+    {- No permissions             -}     [                         ]
+  , {- Data RO                    -}     [PR                       ]
+  , {- Data WO                    -}     [    PW                   ]
+  , {- Data RW                    -}     [PR, PW                   ]
+
+  , -- Quadrant 2
+    {- Data & Cap RO              -}     [PR,     PC               ]
+
+  , -- Quadrant 3
+    {- Data & Cap RO              -}     [PR,     PC, PLM          ]
+  , {- Data & Cap RW              -}     [PR, PW, PC, PLM          ]
+  ]
+  -- Quadrant 1
+  ++ {- Exec, Data & Cap RW & ASR -} wPM [PR, PW, PC, PLM, PX, PASR]
+  ++ {- Exec, Data & Cap RO       -} wPM [PR,     PC, PLM, PX      ]
+  ++ {- Exec, Data & Cap RW       -} wPM [PR, PW, PC, PLM, PX      ]
+  ++ {- Exec, Data RW             -} wPM [PR, PW,          PX      ]
+ where
+  wPM s = [s, S.insert PM s]
+
+validsL1 = S.fromList $
+  [ -- Quadrant 0
+    {- No permissions             -}     [                                   ]
+  , {- Data RO                    -}     [PR                                 ]
+  , {- Data WO                    -}     [    PW                             ]
+  , {- Data RW                    -}     [PR, PW                             ]
+
+  , -- Quadrant 2
+    {- Data & Cap RO, !SL, !LG    -}     [PR,     PC                         ]
+  , {- Data & Cap RW, SL, !LG     -}     [PR, PW, PC, PLM,      PSL          ]
+  , {- Data & Cap RW, !SL, !LG    -}     [PR, PW, PC, PLM                    ]
+
+  , -- Quadrant 3
+    {- Data & Cap RO, !SL, LG     -}     [PR,     PC, PLM, PLG               ]
+  , {- Data & Cap RW, SL, LG      -}     [PR, PW, PC, PLM, PLG, PSL          ]
+  , {- Data & Cap RW, !SL, LG     -}     [PR, PW, PC, PLM, PLG               ]
+  ]
+  -- Quadrant 1
+  ++ {- Exec, Data & Cap RW & ASR -} wPM [PR, PW, PC, PLM, PLG, PSL, PX, PASR]
+  ++ {- Exec, Data & Cap RO       -} wPM [PR,     PC, PLM, PLG,      PX      ]
+  ++ {- Exec, Data & Cap RW       -} wPM [PR, PW, PC, PLM, PLG, PSL, PX      ]
+  ++ {- Exec, Data RW             -} wPM [PR, PW,                    PX      ]
+ where
+  wPM s = [s, S.insert PM s]
+
+(||^), (&&^) :: Applicative f => f Bool -> f Bool -> f Bool
+(||^) = liftA2 (||)
+(&&^) = liftA2 (&&)
+
+sAny, sAll :: SP -> SP -> Bool
+sAny s = not . S.null . S.intersection s
+sAll   = S.isSubsetOf
+
+sImplies :: P -> P -> SP -> Bool
+sImplies p q = (not <$> S.member p) ||^ S.member q
+
+data Rule = Rule T.Text P (SP -> Bool)
+
+rulesL0, rulesL1 :: [Rule]
+rulesL0 =
+  [ Rule "C on R"         PC   $ S.member PR
+  , Rule "X on R"         PX   $ S.member PR
+  , Rule "W on LM | !C"   PW   $ S.member PLM ||^ (not <$> S.member PC)
+  , Rule "X on W | C"     PX   $ sAny [PC, PW]
+  , Rule "LM on C"        PLM  $ S.member PC
+  , Rule "X dependence"   PX   $ sAll [PC, PLM] ||^ (not <$> sAny [PC, PLM])
+  , Rule "ASR on W C X"   PASR $ sAll [PW, PC, PX]
+  , Rule "M on X"         PM   $ S.member PX
+  ]
+
+rulesL1 =
+  [ Rule "C on R"         PC   $ S.member PR
+  , Rule "X on R"         PX   $ S.member PR
+  , Rule "W on LM | !C"   PW   $ S.member PLM ||^ (not <$> S.member PC)
+  , Rule "X on W | C"     PX   $ sAny [PC, PW]
+  , Rule "LM on C"        PLM  $ S.member PC
+  , Rule "LM on W | LG"   PLM  $ sAny [PW, PLG]
+  , Rule "LG on LM"       PLG  $ S.member PLM
+  , Rule "SL on W LM"     PSL  $ sAll [PW, PLM]
+  , Rule "X dependence"   PX   $ (sAll [PC, PLM, PLG] &&^ sImplies PW PSL)
+                                 ||^ (not <$> sAny [PC, PLM, PLG, PSL])
+  , Rule "ASR on W C X"   PASR $ sAll [PW, PC, PX]
+  , Rule "M on X"         PM   $ S.member PX
+  ]
+
+data RuleResult = RRFire   -- Rule fired and removed target permission
+                | RRAbsent -- Rule fired, but permission not present
+                | RRNoFire -- Rule did not fire
+ deriving (Eq, Ord, Show)
+
+type LogEntry = (T.Text, RuleResult)
+
+interpRule :: Rule -> SP -> (LogEntry, SP)
+interpRule (Rule n p f) s = case () of
+  _ | f s                -> ((n, RRNoFire), s)
+  _ | not (S.member p s) -> ((n, RRAbsent), s)
+  _ | otherwise          -> ((n, RRFire  ), S.delete p s)
+
+interpRules :: [Rule] -> SP -> ([LogEntry], SP)
+interpRules = \rs s0 -> let (l, s') = foldl interp (id, s0) rs in (l [], s')
+ where
+  interp :: ([LogEntry] -> [LogEntry], SP)
+         -> Rule
+         -> ([LogEntry] -> [LogEntry], SP)
+  interp (l, s) r = let (le,s') = interpRule r s in (l . (le:), s')
+
+stepsUnder :: [Rule] -> SP -> Maybe ([LogEntry], SP)
+stepsUnder rs s = let e@(_, s') = interpRules rs s in
+                  if s == s' then Nothing else Just e
+
+conditions :: [(T.Text, SP, [Rule], S.Set SP)]
+conditions = [("no levels", allPermsL0, rulesL0, validsL0)
+             ,("zylevels1", allPermsL1, rulesL1, validsL1)
+             ]
+
+main :: IO ()
+main = forM_ conditions $ \(cn, cperms, crules, cdefines) -> do
+  putStrLn $ "[*] Checking condition " ++ (show cn)
+
+  putStrLn "[*] Checking that all defined encodings are subsets of all perms..."
+  forM_ cdefines $ \s ->
+    unless (S.isSubsetOf s cperms) $ putStrLn $
+      "[-] Defined permission set " ++ (show s)
+      ++ " exceeds permissions " ++ (show cperms)
+
+  putStrLn "[*] Checking that all defined encodings are fixed points..."
+  forM_ cdefines $ \s ->
+   forM_ (stepsUnder crules s) $ \(l, s') ->
+    putStrLn $ "[-] Defined set " ++ (show s) ++ " stepped to " ++ (show s')
+               ++ " thus: " ++ (show l)
+
+  putStrLn "[*] Checking that all permission sets eval to defined encodings..."
+  forM_ (S.powerSet cperms) $ \s ->
+    let (l, s') = interpRules crules s in
+    unless (S.member s' cdefines) $
+    putStrLn $ "[-] Permission set " ++ (show s)
+               ++ " steps to invalid " ++ (show s') ++ " thus: " ++ (show l)
+
+  putStrLn "[*] Checking that removal picks the best..."
+  forM_ cdefines $ \sStart ->
+    forM_ (S.powerSet sStart) $ \sShedding ->
+      let
+        sShed = S.difference sStart sShedding
+        (_, sComputed) = interpRules crules sShed
+      in
+      forM_ cdefines $ \sDefined ->
+        when (S.isSubsetOf sDefined sShed
+              && S.isProperSubsetOf sComputed sDefined) $
+        putStrLn $ "[-] Removing set " ++ (show sShedding)
+                   ++ " from " ++ (show sStart)
+                   ++ " resulted in " ++ (show sComputed)
+                   ++ " but could have used " ++ (show sDefined)

--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -169,53 +169,72 @@ orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 | 6-7   10+| reserved
 11+| *Quadrant 1: Executable capabilities*
 11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
-| 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
-| 2-3   | ✔ |   | ✔ | ✔  | ✔  | 1^2^| ✔ |     | Mode^1^  | Execute + Data & Cap RO
-| 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | 1   | ✔ |     | Mode^1^  | Execute + Data & Cap RW
-| 6-7   | ✔ | ✔ |   |    |    | 0^2^| ✔ |     | Mode^1^  | Execute + Data RW
+| 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
+| 2-3   | ✔ |   | ✔ | ✔  | ✔  |   | ✔ |     | Mode^1^  | Execute + Data & Cap RO
+| 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RW
+| 6-7   | ✔ | ✔ |   |    |    |   | ✔ |     | Mode^1^  | Execute + Data RW
 11+| *Quadrant 2: Restricted capability data read/write*
 11+| bit[2] = write, bit[1] reserved, bit[0] = !SL. R and C implicitly granted, LM dependent on W permission.
 | 0-2   10+| reserved
-| 3       | ✔ |   | ✔ |    |    | 0^2^  |   |     | N/A | Data & Cap R0 (without <<lm_perm>>)
+| 3       | ✔ |   | ✔ |    |    |   |   |     | N/A | Data & Cap R0 (without <<lm_perm>>)
 | 4-5  10+| reserved
-| 6       | ✔ | ✔ | ✔ | ✔  |    | 1     |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
-| 7       | ✔ | ✔ | ✔ | ✔  |    | 0     |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
+| 6       | ✔ | ✔ | ✔ | ✔  |    | ✔ |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
+| 7       | ✔ | ✔ | ✔ | ✔  |    |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
 11+| *Quadrant 3: Capability data read/write*
 11+| bit[2] = write, bit[1] reserved, bit[0] = !SL. R and C implicitly granted.
 11+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
 | 0-2   10+| reserved
-| 3       | ✔ |   | ✔ | ✔  | ✔  | 0^2^  |   |     | N/A | Data & Cap R0
+| 3       | ✔ |   | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap R0
 | 4-6   10+| reserved
-| 6       | ✔ | ✔ | ✔ | ✔  | ✔  | 1     |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>)
-| 7       | ✔ | ✔ | ✔ | ✔  | ✔  | 0     |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>)
+| 6       | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>)
+| 7       | ✔ | ✔ | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>)
 |==============================================================================
 
 ^1^ _Mode (<<m_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
-is supported, otherwise such encodings are reserved. Despite being encoded here it is *not* an architectural permission._ +
-^2^ SL isn't applicable in these cases, but this value is reported by <<GCPERM>> to simplify the rules followed by <<CLRPERM>> +
+is supported, otherwise such encodings are reserved. Despite being encoded here it is *not* an architectural permission._
 
-When MXLEN=32, this compressed permission format introduces
-new dependencies between permisison bits.
-When <<section_zylevels1>> _is not_ present, the following new rows are added to <<acperm_rules>>:
-
-[float="center",align="center",cols="2,2,4",options="header"]
-|===
-| Rule            | Permission   | Valid only if
-| RV32-base-1     | <<lm_perm>>  | <<w_perm>>
-| RV32-base-2     | <<x_perm>>   | (<<c_perm>> and <<lm_perm>>) or (not(<<c_perm>> and not(<<lm_perm>>)))
-|===
-
-
-When <<section_zylevels1>> _is_ present, the following new rows are added to <<acperm_rules>>:
+When MXLEN=32, this encoding's compressed permission format
+specifies a _particular procedure_ for encoding architectural permissions,
+which is used _instead of_ <<CLRPERM>>'s default fixed-pointing procedure.
+If <<section_zylevels1>> is absent, the following rules are run _in order_:
 
 [float="center",align="center",cols="2,2,4",options="header"]
 |===
-| Rule                            | Permission            | Valid only if
-| RV32-{cheri_levels1_ext_name}-1 | <<zylevels1_sl_perm>> | (<<lm_perm>> and (<<x_perm>> or <<w_perm>>))
-| RV32-{cheri_levels1_ext_name}-2 | <<lm_perm>>           | (<<w_perm>> or <<zylevels1_lg_perm>>)
-| RV32-{cheri_levels1_ext_name}-3 | <<x_perm>>            | (<<c_perm>> and <<lm_perm>> and <<zylevels1_lg_perm>> and <<zylevels1_sl_perm>>) or +
-not(<<c_perm>> or <<lm_perm>> or <<zylevels1_lg_perm>> or <<zylevels1_sl_perm>>)
+| <<CLRPERM>> Rule | Permission   | Valid only if
+| RV32-base-1      | <<c_perm>>   | <<r_perm>> (supersedes <<perm_req:base:c:r-or-w>>)
+| RV32-base-2      | <<x_perm>>   | <<r_perm>>
+| RV32-base-3      | <<w_perm>>   | not(<<c_perm>>) or <<lm_perm>>
+| RV32-base-4      | <<x_perm>>   | <<w_perm>> or <<c_perm>>
+| RV32-base-5      | <<lm_perm>>  | <<c_perm>> (supersedes <<perm_req:base:lm:c-and-r>>)
+| RV32-base-6      | <<x_perm>>   | (<<c_perm>> and <<lm_perm>>) or not (<<c_perm>> or <<lm_perm>>)
+| RV32-base-7      | <<asr_perm>> | <<w_perm>> and <<c_perm>> and <<x_perm>> (supersedes <<perm_req:base:asr:x>>)
+| RV32-base-8      | <<m_bit>>    | <<x_perm>> and {cheri_default_ext_name} is implemented
 |===
+
+If <<section_zylevels1>> is present, the following rules are run _in order_:
+
+[float="center",align="center",cols="2,2,4",options="header"]
+|===
+| <<CLRPERM>> Rule | Permission            | Valid only if
+| RV32-l1-1        | <<c_perm>>            | <<r_perm>> (supersedes <<perm_req:base:c:r-or-w>>)
+| RV32-l1-2        | <<x_perm>>            | <<r_perm>>
+| RV32-l1-3        | <<w_perm>>            | not(<<c_perm>>) or <<lm_perm>>
+| RV32-l1-4        | <<x_perm>>            | <<w_perm>> or <<c_perm>>
+| RV32-l1-5        | <<lm_perm>>           | <<c_perm>> (supersedes <<perm_req:base:lm:c-and-r>>)
+| RV32-l1-6        | <<lm_perm>>           | <<w_perm>> or <<zylevels1_lg_perm>>
+| RV32-l1-7        | <<zylevels1_lg_perm>> | <<lm_perm>> (supersedes <<perm_req:zylevels1:lg:c-and-r>>)
+| RV32-l1-8        | <<zylevels1_sl_perm>> | <<lm_perm>> and <<w_perm>> (supersedes <<perm_req:zylevels1:sl:c-and-w>>)
+| RV32-l1-9        | <<x_perm>>            |
+  (<<c_perm>> and <<lm_perm>> and <<zylevels1_lg_perm>> and <<zylevels1_sl_perm>>) or +
+  (<<c_perm>> and <<lm_perm>> and <<zylevels1_lg_perm>> and not <<w_perm>>) or +
+  not (<<c_perm>> or <<lm_perm>> or <<zylevels1_lg_perm>> or <<zylevels1_sl_perm>>)
+| RV32-l1-10       | <<asr_perm>>          | <<w_perm>> and <<c_perm>> and <<x_perm>> (supersedes <<perm_req:base:asr:x>>)
+| RV32-l1-11       | <<m_bit>>             | <<x_perm>> and {cheri_default_ext_name} is implemented
+|===
+
+For RV32, the encodings which have the <<m_bit>> set to {int_mode_value} for {cheri_int_mode_name}
+are only valid if {cheri_default_ext_name} is implemented.
+Otherwise those encodings represent invalid permissions.
 
 When MXLEN=64, there is a bit per permission as shown in xref:cap_perms_encoding64[xrefstyle=short].
 A permission is granted if its corresponding bit, and those of any dependent permissions, are set;
@@ -243,44 +262,9 @@ implementation supports {cheri_default_ext_name} _and_ <<x_perm>> is set.
 . For MXLEN=64, the bit assigned to the <<m_bit>> must be zero if <<x_perm>> isn't set.
 . For MXLEN=32, the <<m_bit>> is only encoded in quadrant 1 and does _not_ exist in the other quadrants.
 
-[#sec_permission_transitions]
-===== Permission Transitions
-
-Executing <<CLRPERM>> can result in sets of permissions which cannot be represented when MXLEN=32
-(see <<cap_perms_encoding32>>) or permission combinations which are not useful for MXLEN=64, such as
-<<asr_perm>> set without <<x_perm>>.
-These cases are defined to return useful minimal sets of permissions.
-
-When removing permissions with <<CLRPERM>> the following rules,
-along with any added by extensions,
-are iterated to fixed-point:
-
-[#acperm_rules]
-.<<CLRPERM>> common rules
-[float="center",align="center",cols="2,2,4",options="header"]
-|===
-| Rule            | Permission   | Valid only if
-|  1  (RV32 only) | <<asr_perm>> | All other permissions are set.
-|  2              | <<c_perm>>   | <<r_perm>> or <<w_perm>>
-|  3  (RV32 only) | <<c_perm>>   | <<r_perm>>
-|  4  (RV32 only) | <<x_perm>>   | <<r_perm>>
-|  5  (RV32 only) | <<w_perm>>   | not(<<c_perm>>) or <<lm_perm>>
-|  6  (RV32 only) | <<x_perm>>   | <<w_perm>> or <<c_perm>>
-|  7              | <<lm_perm>>  | <<c_perm>> and <<r_perm>>
-|  8  (RV32 only) | <<lm_perm>>  | (<<w_perm>> or <<zylevels1_lg_perm>>)
-|  9              | <<asr_perm>> | <<x_perm>>
-| 10^1^           | <<m_bit>>    | <<x_perm>> and {cheri_default_ext_name} is implemented
-|===
-
-^1^ For RV32, the encodings which have the <<m_bit>> set to {int_mode_value} for {cheri_int_mode_name}
-are only valid if {cheri_default_ext_name} is implemented. Otherwise those encodings represent invalid permissions.
-
 NOTE: Future extensions may allow more combinations of permissions, especially for MXLEN=64.
 
 NOTE: Future extensions may define new dependent permissions and, if so, must augment the above table.
-
-If any of these transitions (or those added by extensions or the encoding) are applied to a sealed capability,
-the {ctag} of the resulting capability is cleared.
 
 [#SDP-field, reftext="SDP-field"]
 ==== Software-Defined Permissions (SDP) Encoding

--- a/src/cheri/insns/acperm_32bit.adoc
+++ b/src/cheri/insns/acperm_32bit.adoc
@@ -30,7 +30,11 @@ format shown in xref:acperm_bit_field[xrefstyle=short].
 . The initial value in register `rs2[XLEN-1:0]` is treated as a bit mask that specifies bit positions to be cleared in the bit field. Any bit that is high in `rs2` will cause the corresponding bit to be cleared in the bit field.
 +
 NOTE: Future extensions may include hardwired permission bits, in which case they are not cleared by set bits in `rs2`.
-. Encode the resulting architectural permissions following the rules in <<sec_permission_transitions>>.
+. Encode the resulting architectural permissions as specified by the encoding in use.
+  This may involve iterating over the rules in <<sec_permission_transitions>>,
+  as well as any rules added by extensions or the capability encoding,
+  to a fixed point (that is, a set of permissions not further reduced by any rule);
+  encodings may, however, specify other encoding procedures.
 +
 IMPORTANT: Depending on the base ISA and supported extensions, some combinations of permissions cannot be encoded or are not useful.
 In these cases, <<CLRPERM>> will return a minimal sets of permissions, which may be no permissions.

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -77,7 +77,7 @@ The <<m_bit>> of <<pcc>> can be updated by the instructions listed in <<tab_cher
 | <<MODESW_CAP>> |{cheri_int_mode_name}| {MODESW_CAP_DESC}
 |=======================
 
-The <<m_bit>> of a capability can be read and written by the instructions listed in <<tab_hybrid_summary>>:
+The <<m_bit>> of a <<x_perm>>-granting capability can be read and written by the instructions listed in <<tab_hybrid_summary>>:
 
 .{cheri_default_ext_name} instructions to observe and update the mode in a capability
 [#tab_hybrid_summary,%autowidth,options=header,align="center",cols="1,4"]
@@ -88,6 +88,14 @@ The <<m_bit>> of a capability can be read and written by the instructions listed
 |=======================
 
 NOTE: The mode can also be updated by setting the <<m_bit>> of a target capability using <<SCMODE>> followed by a <<JALR_CHERI>>.
+
+For capabilities that do not grant <<x_perm>>,
+<<m_bit>> must always be interpreted and reported as {cap_mode_value}.
+
+NOTE: While this is not phrased as an additional rule for <<CLRPERM>> to follow,
+beyond those of <<sec_permission_transitions>>,
+capability encodings may nevertheless take advantage of this implication
+in their representation of architectural CHERI capabilities.
 
 [#m_bit_observe,reftext="Observing the CHERI Execution Mode"]
 ==== Observing the CHERI Execution Mode

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -339,6 +339,32 @@ NOTE: This permission is important in privileged execution environments.
 
 NOTE: Extensions may add additional non-privileged CSRs that require <<asr_perm>>.
 
+[#sec_permission_transitions]
+===== Permission Transitions
+
+Not all capability permissions are _orthogonal_
+(that is, some permissions inherently _depend_ on others).
+As such, using <<CLRPERM>> to clear some permissions
+may have the effect of clearing others as well,
+such that a permission bit being set in the result of <<GCPERM>>
+implies that all bits for permissions upon which it depends will also be set.
+
+For the base set of permissions just defined, the following rules apply.
+Extensions that define new permission bits (such as
+<<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and <<section_zylevels1>>)
+may also introduce new dependency constraints.
+Capability _encodings_ may impose additional constraints.
+to reduce the number of bits necessary to represent permissions.
+
+.<<CLRPERM>> base rules
+[float="center",align="center",cols="2,2,4",options="header"]
+|===
+| <<CLRPERM>> Rule                          | Permission   | Valid only if
+| [[perm_req:base:c:r-or-w,base-1]]base-1   | <<c_perm>>   | <<r_perm>> or <<w_perm>>
+| [[perm_req:base:lm:c-and-r,base-2]]base-2 | <<lm_perm>>  | <<c_perm>> and <<r_perm>>
+| [[perm_req:base:asr:x,base-3]]base-3      | <<asr_perm>> | <<x_perm>>
+|===
+
 [#sec_cap_sdp]
 ==== Software-Defined Permissions (SDP)
 The metadata also contains an encoding-dependent number of software-defined permission (SDP) bits.

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -102,13 +102,15 @@ As mentioned, the <<zylevels1_sl_perm>> and <<zylevels1_lg_perm>> permissions
 are dependent on (refinements of) base permissions.
 <<CLRPERM>> (including "implicit <<CLRPERM>>" operations) and/or the capability encoding
 therefore clear these permissions when their dependencies clear.
-Specifically, we add the following rules to <<acperm_rules>>:
+Specifically, we add the following rules to those of <<sec_permission_transitions>>:
 
 [float="center",align="center",cols="2,2,4",options="header"]
 |===
-| Rule                       | Permission            | Valid only if
-| {cheri_levels1_ext_name}-1 | <<zylevels1_lg_perm>> | <<c_perm>> and <<r_perm>>
-| {cheri_levels1_ext_name}-2 | <<zylevels1_sl_perm>> | <<c_perm>> and <<w_perm>>
+| <<CLRPERM>> Rule | Permission | Valid only if
+| [[perm_req:zylevels1:lg:c-and-r,{cheri_levels1_ext_name}-1]]{cheri_levels1_ext_name}-1 +
+                   | <<zylevels1_lg_perm>> | <<c_perm>> and <<r_perm>>
+| [[perm_req:zylevels1:sl:c-and-w,{cheri_levels1_ext_name}-2]]{cheri_levels1_ext_name}-2 +
+                   | <<zylevels1_sl_perm>> | <<c_perm>> and <<w_perm>>
 |===
 
 === Interaction with <<LOAD_CAP>>


### PR DESCRIPTION
Move common rules out into the architectural specification, not the encoding, and clarify that extensions and encodings may each add new rules.  Adjust cross-references to follow along.