### PR TITLE
use ctag variable

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -280,7 +280,7 @@ NOTE: Future extensions may allow more combinations of permissions, especially f
 NOTE: Future extensions may define new dependent permissions and, if so, must augment the above table.
 
 If any of these transitions (or those added by extensions or the encoding) alter a sealed capability,
-the resulting capability's tag is cleared.
+the resulting capability's {ctag} is cleared.
 
 [#SDP-field, reftext="SDP-field"]
 ==== Software-Defined Permissions (SDP) Encoding
@@ -333,7 +333,7 @@ The bounds encode the base and top addresses that constrain memory accesses.
 The capability can be used to access any memory location A in the range base
 &#8804; A < top. The bounds are encoded in compressed format, so it is not
 possible to encode any arbitrary combination of base and top addresses. An
-invalid capability with tag cleared is produced when attempting to construct a
+invalid capability with {ctag} cleared is produced when attempting to construct a
 capability that is not _representable_ because its bounds cannot be correctly
 encoded. The bounds are decoded as described in
 xref:section_cap_encoding[xrefstyle=short].
@@ -681,9 +681,9 @@ Permissions added by extensions (such as those of <<section_zylevels1>>) are pre
 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
 space of 2^XLEN^ bytes for all memory accesses. Each memory region capable of
-holding a capability also stores a tag bit for each naturally aligned YLEN bits
-(e.g., 16 bytes in RV64), so that capabilities with their tag set can only be
-stored in naturally aligned addresses. Tags must be atomically bound to the
+holding a capability also stores a {ctag} bit for each naturally aligned YLEN bits
+(e.g., 16 bytes in RV64), so that capabilities with their {ctag} set can only be
+stored in naturally aligned addresses. {ctag_cap} must be atomically bound to the
 data they protect.
 
 The memory address space is circular, so the byte at address

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -87,6 +87,7 @@ endif::support_varxlen[]
 :cheri_levels1_ext_name:             Zylevels1
 
 :ctag: capability tag
+:ctag_cap:   Capability tag
 :ctag_title: Capability Tag
 
 :cheri_int_mode_name: pass:quotes[_(Non-CHERI) Address Mode_]

--- a/src/cheri/insns/acperm_32bit.adoc
+++ b/src/cheri/insns/acperm_32bit.adoc
@@ -37,7 +37,7 @@ In these cases, <<CLRPERM>> will return a minimal sets of permissions, which may
 Therefore, it is possible that requesting to clear a permission also clears others, but <<CLRPERM>> will never _add_ new permissions.
 . Copy `{cs1}` to `{cd}`, and update the <<AP-field>>, <<SDP-field>>, and any others therein with the newly calculated versions.
 . Set `{cd}.tag=0` if `{cs1}` is sealed and any bits in the <<AP-field>> or <<SDP-field>> were affected by <<CLRPERM>>;
-  extensions must describe whether such changes to their bits also necessitate tag clearing.
+  extensions must describe whether such changes to their bits also necessitate {ctag} clearing.
 . Set `{cd}.tag=0` if any <<section_cap_integrity,integrity>> checks fail.
 
 .Capability permissions bit field

--- a/src/cheri/insns/atomic_exceptions.adoc
+++ b/src/cheri/insns/atomic_exceptions.adoc
@@ -4,11 +4,11 @@ Requires the authorizing capability have its {ctag} set and not be sealed.
 +
 Requires <<r_perm>> and <<w_perm>> in the authorizing capability.
 +
-If <<c_perm>> is not granted then store the memory tag as zero, and load `{cd}.tag` as zero.
+If <<c_perm>> is not granted then store the memory {ctag} as zero, and load `{cd}.tag` as zero.
 +
 If the authorizing capability does not grant <<lm_perm>>, and the {ctag} of `{cd}` is 1 and `{cd}` is not sealed, then an implicit <<CLRPERM>> clearing <<w_perm>> and <<lm_perm>> is performed to obtain the intermediate permissions on `{cd}` (see <<LOAD_CAP>>).
 +
-Extensions may further (monotonically) modify loaded or stored capabilities via "implicit <<CLRPERM>>-s" and/or outright tag clearing;
+Extensions may further (monotonically) modify loaded or stored capabilities via "implicit <<CLRPERM>>-s" and/or outright {ctag} clearing;
 see <<LOAD_CAP>> and <<STORE_CAP>>.
 +
 endif::[]

--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -39,7 +39,7 @@ capabilities from integer values.
 
 NOTE: When `{cs1}` is `{creg}0` <<CBLD>> will copy `{cs2}` to `{cd}` and clear `{cd}.tag`.
 However future extensions may add additional behavior to update currently reserved fields,
-and so software should not assume `{cs1}==0` to be a pseudo-instruction for tag clearing.
+and so software should not assume `{cs1}==0` to be a pseudo-instruction for {ctag} clearing.
 
 Included in::
 {rvyi_xref}

--- a/src/cheri/insns/store_16bit_cap_sprel.adoc
+++ b/src/cheri/insns/store_16bit_cap_sprel.adoc
@@ -34,7 +34,7 @@ obtained by adding the address of `{abi_creg}sp` to the zero-extended offset.
 
 The capability written to memory has the {ctag} set to 0 if the {ctag} of `{cs2}'` is 0 or if the authorizing capability (`{abi_creg}sp`) does not grant <<c_perm>>.
 +
-Extensions may define further circumstances under which stored capabilities may have their valid tags cleared.
+Extensions may define further circumstances under which stored capabilities may have their {ctag}s cleared.
 
 include::malformed_no_check.adoc[]
 

--- a/src/cheri/insns/store_tag_perms.adoc
+++ b/src/cheri/insns/store_tag_perms.adoc
@@ -6,4 +6,4 @@ The stored {ctag} is set to zero if:
 . `{cs1}` does not grant <<c_perm>>, or
 . The PMA is _CHERI {ctag_title} Strip_
 +
-Extensions may define further circumstances under which stored capabilities may have their valid tags cleared.
+Extensions may define further circumstances under which stored capabilities may have their {ctag}s cleared.

--- a/src/cheri/insns/zcmt_cmjalt.adoc
+++ b/src/cheri/insns/zcmt_cmjalt.adoc
@@ -31,7 +31,7 @@ Redirect instruction fetch via the jump table defined by the indexing via `jvt.a
 +
 The target <<pcc>> is calculated by replacing the current <<pcc>> address with the value read from the jump table, and is updated using the semantics of the <<SCADDR>> instruction.
 +
-If the <<jvt_y>> check fails, then clear the tag of the target <<pcc>>.
+If the <<jvt_y>> check fails, then clear the {ctag} of the target <<pcc>>.
 
 include::zcm_common.adoc[]
 

--- a/src/cheri/insns/zcmt_cmjt.adoc
+++ b/src/cheri/insns/zcmt_cmjt.adoc
@@ -31,7 +31,7 @@ Redirect instruction fetch via the jump table defined by the indexing via `jvt.a
 +
 The target <<pcc>> is calculated by replacing the current <<pcc>> address with the value read from the jump table, and is updated using the semantics of the <<SCADDR>> instruction.
 +
-If the <<jvt_y>> check fails, then clear the tag of the target <<pcc>>.
+If the <<jvt_y>> check fails, then clear the {ctag} of the target <<pcc>>.
 
 include::zcm_common.adoc[]
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -614,7 +614,7 @@ The {ctag} bit of the stored capability is checked _after_ it is potentially cle
 Therefore, the behavior in this section isn't relevant if:
 
 * The authorizing capability doesn't have <<c_perm>>.
-* Any extension-specific mediation has already cleared the valid tag of the to-be-stored capability.
+* Any extension-specific mediation has already cleared the {ctag} of the to-be-stored capability.
 ====
 
 [#section_invalid_addr_conv,reftext="Invalid address conversion"]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -126,15 +126,15 @@ All capabilities derived from invalid capabilities are themselves invalid, i.e.,
 
 NOTE: When the {ctag} is zero, the register or memory location may be used to store non-capability data.
 
-==== Capability tags in registers
+==== {ctag_cap}s in registers
 
 Every YLEN-bit register has a one-bit {ctag}, indicating whether the capability in the register is valid to be dereferenced.
 This {ctag} is cleared whenever an invalid capability operation is performed.
 Examples of such invalid operations include writing only the integer portion (the address field) of the register or attempting to increase bounds or permissions.
 
-==== Capability tags in memory
+==== {ctag_cap}s in memory
 
-Capability tags are tracked through the memory subsystem: every aligned YLEN-bit wide region has a non-addressable one-bit {ctag}, which the hardware manages atomically with the data.
+{ctag_cap}s are tracked through the memory subsystem: every aligned YLEN-bit wide region has a non-addressable one-bit {ctag}, which the hardware manages atomically with the data.
 The {ctag} is set to zero if any byte in the YLEN/8 aligned memory region is ever written using an operation other than a store of a capability operand which is permitted to set the {ctag} to one (see <<c_perm>>), and that the stored capability data has its {ctag} set.
 
 NOTE: All system memory and caches that store capabilities must preserve this abstraction, handling the {ctag}s atomically with the data.
@@ -630,7 +630,7 @@ Special instructions are provided to copy capabilities or derive a new capabilit
 |<<SCBNDS>>   |Set register bounds on capability with rounding, clear {ctag} if rounding is required
 |<<SCBNDSR>>  |Set bounds on capability with rounding up as required
 |<<SENTRY>>   |Seal capability
-|<<CBLD>>     |Set {cd} to {cs2} with its tag set after checking that {cs2} is a subset of {cs1}
+|<<CBLD>>     |Set {cd} to {cs2} with its {ctag} set after checking that {cs2} is a subset of {cs1}
 |=======================
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>
@@ -695,7 +695,7 @@ include::insns/gchi_32bit.adoc[]
 |=======================
 |Mnemonic   |Description
 |<<SCEQ>>   |Full capability bitwise compare, set result true if all bits (including the {ctag}) are equal
-|<<SCSS>>   |Set result true if {cs1} and {cs1} tags match and {cs2} bounds and permissions are a subset of {cs1}
+|<<SCSS>>   |Set result true if {cs1} and {cs1} {ctag}s match and {cs2} bounds and permissions are a subset of {cs1}
 |<<CRAM>>   |Representable Alignment Mask: Return mask to apply to address to get the requested bounds
 |=======================
 
@@ -814,7 +814,7 @@ endif::[]
 
 All load instructions, except for the {cheri_base_ext_name} <<LOAD_CAP>>, always zero the {ctag} and metadata of the result register.
 
-All store instructions, except for the {cheri_base_ext_name} <<STORE_CAP>>, always write zero to the {ctag} or tags associated with the memory locations that are written to.
+All store instructions, except for the {cheri_base_ext_name} <<STORE_CAP>>, always write zero to the {ctag} or {ctag}s associated with the memory locations that are written to.
 
 Therefore, misaligned stores may clear up to two associated {ctag} bits.
 

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -12,9 +12,9 @@ There are, or will soon be, a wide range of CHERI systems in existence from tiny
 There are two types of bus connections used in SoCs which contain CHERI CPUs:
 
 . Tag-aware busses, where the bus protocol is extended to carry the {ctag} along with the data.  This is typically done using user defined bits in the protocol.
-.. These busses will read tags from memory (if tags are present in the target memory) and return them to the requestor.
+.. These busses will read {ctag}s from memory (if {ctag}s are present in the target memory) and return them to the requestor.
 .. These busses will write the {ctag} to memory as an extension of the data write.
-. Non-tag aware busses, i.e., current non-CHERI aware busses.
+. Non-{ctag} aware busses, i.e., current non-CHERI aware busses.
 .. Reads of tagged memory will not read the {ctag}.
 .. Writes to tagged memory will set the {ctag} to zero of any YLEN-aligned YLEN-wide memory location where any byte matches the memory write.
 
@@ -25,7 +25,7 @@ The fundamental rule for any CHERI system is that the {ctag} and data are always
 . Read a {ctag} value with mismatched (stale or newer) data
 . Set the {ctag} without also writing the data.
 
-NOTE: Clearing tags in memory does not necessarily require updating the associated data.
+NOTE: Clearing {ctag}s in memory does not necessarily require updating the associated data.
 
 === Small CHERI system example
 
@@ -35,30 +35,30 @@ image::../cheri/img/small_cheri_system.drawio.png[width=80%,align=center]
 
 This example shows a minimum sized system where only the local memory is extended to support {ctag}s.
 The {ctag}-aware region is highlighted.
-All tags are created by the CHERI CPU, and only stored locally. The memory is shared with the system, probably via a secure DMA, which is not tag aware.
+All {ctag}s are created by the CHERI CPU, and only stored locally. The memory is shared with the system, probably via a secure DMA, which is not {ctag} aware.
 
-Therefore the connection between CPU and memory is tag-aware, and the connection to the system is not tag aware.
+Therefore the connection between CPU and memory is tag-aware, and the connection to the system is not {ctag} aware.
 
-All writes from the system port to the memory must clear any memory tags to follow the rules from above.
+All writes from the system port to the memory must clear any memory {ctag}s to follow the rules from above.
 
 === Large CHERI system example
 
 [#large_cheri_system]
-.Example large CHERI system with tag cache
+.Example large CHERI system with {ctag} cache
 image::../cheri/img/large_cheri_system.drawio.png[width=80%,align=center]
 
-In the case of a large CHERI SoC with caches, all the cached memory visible to the CHERI CPUs must support tags.
-All memory is backed up by DRAM, and standard DRAM does not offer the extra bit required for CHERI {ctag} storage and so a typical system will have a tag cache IP.
+In the case of a large CHERI SoC with caches, all the cached memory visible to the CHERI CPUs must support {ctag}s.
+All memory is backed up by DRAM, and standard DRAM does not offer the extra bit required for CHERI {ctag} storage and so a typical system will have a {ctag} cache IP.
 
 A region of DRAM is typically reserved for CHERI {ctag} storage.
 
 The {ctag} cache sits on the boundary of the {ctag}-aware and non-tag-aware memory domains, and it provides the bridge between the two.
-It stores tags locally in its cache, and if there is a miss, it will create an extra bus request to access the region of DRAM reserved for tag storage.
+It stores {ctag}s locally in its cache, and if there is a miss, it will create an extra bus request to access the region of DRAM reserved for {ctag} storage.
 Therefore in the case of a miss a single access is split into two - one to access the data and one to access the {ctag}.
 
-The key property of the {ctag} cache is to preserve the atomic access of data and tags in the memory system so that all CPUs have a consistent view of tags and data.
+The key property of the {ctag} cache is to preserve the atomic access of data and {ctag}s in the memory system so that all CPUs have a consistent view of {ctag}s and data.
 
-The region of DRAM reserved for tag storage must be only accessible by the {ctag} cache, therefore no bus initiators should be able to write to the DRAM without the transactions passing through the {ctag} cache.
+The region of DRAM reserved for {ctag} storage must be only accessible by the {ctag} cache, therefore no bus initiators should be able to write to the DRAM without the transactions passing through the {ctag} cache.
 
 Therefore the GPUs and peripherals cannot write to the {ctag} storage in the DRAM, or the {ctag}ged memory data storage region.
 These constraints will be part of the design of the network-on-chip.
@@ -82,4 +82,4 @@ In this example every DRAM access passes through the {ctag} cache, and so _all_ 
 The system topology is simpler than in xref:large_cheri_system[xrefstyle=short].
 
 There is likely to be a performance difference between the two systems.
-The main motivation for xref:large_cheri_system[xrefstyle=short] is to avoid the GPU DRAM traffic needing to look-up every tag in the {ctag} cache, potentially adding overhead to every transaction.
+The main motivation for xref:large_cheri_system[xrefstyle=short] is to avoid the GPU DRAM traffic needing to look-up every {ctag} in the {ctag} cache, potentially adding overhead to every transaction.

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -12,7 +12,7 @@ The distinction refines the behavior of capability store and load instructions:
 
 * Capability-write-permissive capabilities are refined to authorize stores of _any_ capability or _global_ capabilities only.
   The former may attenuate into the latter.
-  Attempting to store a local capability through an insufficiently permissive authority clears the tag of the value written to memory, if any.
+  Attempting to store a local capability through an insufficiently permissive authority clears the {ctag} of the value written to memory, if any.
 
 * Capability-load-permissive capabilities are refined to authorize loads of _any_ capabilities or _local_ capabilities only.
   Again, the former may attenuate to the latter.
@@ -94,7 +94,7 @@ This applies to both "implicit <<CLRPERM>>s" in loads from memory and explicit <
 
 Implementations _are permitted but not mandated_ to require that an explicit <<CLRPERM>> instruction wishing to clear <<zylevels1_gl_perm>>
 has an input mask that is _entirely 1s_ except for <<zylevels1_gl_perm>>
-(or else clear the tag of the resulting capability).
+(or else clear the {ctag} of the resulting capability).
 
 .Additional <<CLRPERM>> rules (see <<acperm_rules>>)
 
@@ -136,13 +136,13 @@ will necessarily also clear <<zylevels1_sl_perm>>.
 As outlined above, {cheri_levels1_ext_name} introduces a new constraint on capabilities stored to memory,
 as part of a <<STORE_CAP>> instruction `{store_cap_name_lc} {cs2}, offset({cs1})`
 or <<STORE_COND_CAP>> instruction `sc{ld_st_dot_cap_lc} {cs2}, offset({cs1})`:
-the written valid tag may be set _only if_ either
+the written valid {ctag} may be set _only if_ either
 
 * `{cs2}` 's <<zylevels1_gl_perm>> is set or
 * `{cs1}` 's <<zylevels1_sl_perm>> is set.
 
 NOTE: While <<zylevels1_lg_perm>> attenuates by reducing <<zylevels1_gl_perm>> and <<zylevels1_lg_perm>>,
-<<zylevels1_sl_perm>> attenuates by clearing valid tags.
+<<zylevels1_sl_perm>> attenuates by clearing {ctag}s.
 
 === Interaction with <<SCSS>>
 
@@ -172,7 +172,7 @@ The existing permission subset logic applies to the new <<zylevels1_sl_perm>> an
     h|*W*    h|*C* h|*SL* h|*GL*           h| Notes
 .3+.^|1  .3+.^| 1   | 1    | X              | Store data capability unmodified
                .2+.^| 0    | 0              | Store data capability unmodified
-                           | 1              | Store data capability with valid tag cleared
+                           | 1              | Store data capability with valid {ctag} cleared
 |==============================================================================
 
 NOTE: <<zylevels1_sl_perm>> is relevant only to capabilities bearing both <<w_perm>> and <<c_perm>>.

--- a/src/cheri/zylevelsN.adoc
+++ b/src/cheri/zylevelsN.adoc
@@ -33,7 +33,7 @@ Capabilities with a <<zylevelsN_cl_field>> (see below) less than the inverse of 
 In the base ISA this is a single bit comparison, behaving as follows:
 
 * If this field (as well as <<c_perm>> and <<w_perm>>) is set to one then capabilities may be stored via this capability regardless of their associated <<zylevelsN_cl_field>>.
-* If this field is zero, then any capability with a <<zylevelsN_cl_field>> of zero (i.e., _local_), will be stored with the valid tag cleared.
+* If this field is zero, then any capability with a <<zylevelsN_cl_field>> of zero (i.e., _local_), will be stored with the {ctag} cleared.
 
 NOTE: Future extensions may make this field wider to enable more use cases.
 
@@ -42,7 +42,7 @@ NOTE: For `LVLBITS=1` this permission is equivalent to _StoreLocal_ in CHERI v9,
 endif::[]
 
 [#zylevelsN_el_perm,reftext="EL-permission"]
-Elevate Level Permission (EL):: Any unsealed capability with its valid tag set to one that is loaded from memory has its <<zylevelsN_el_perm>> cleared and its <<zylevelsN_cl_field>> restricted to the authorizing capability's <<zylevelsN_cl_field>> if the authorizing capability does not grant <<zylevelsN_el_perm>>.
+Elevate Level Permission (EL):: Any unsealed capability with its {ctag} set to one that is loaded from memory has its <<zylevelsN_el_perm>> cleared and its <<zylevelsN_cl_field>> restricted to the authorizing capability's <<zylevelsN_cl_field>> if the authorizing capability does not grant <<zylevelsN_el_perm>>.
 +
 If sealed, then only <<zylevelsN_cl_field,CL>> is modified, <<zylevelsN_el_perm>> is unchanged.
 +
@@ -99,7 +99,7 @@ TODO
     h|*W*    h|*C* h|*SL* h|*CL* h| Notes
 .3+.^|1  .3+.^| 1   | 1    | X    | Store data capability unmodified
                .2+.^| 0    | 1    | Store data capability unmodified (`CL ≥ ~SL`)
-                           | 0    | Store data capability with valid tag cleared (`CL < ~SL`)
+                           | 0    | Store data capability with {ctag} cleared (`CL < ~SL`)
 |==============================================================================
 
 NOTE: if W=0 or C=0 then SL is irrelevant
@@ -133,9 +133,9 @@ Considering for an example `<<cheri_lvlbits>>=2`:
 |===
 |<<sl_perm>> | Permitted for levels| Resulting semantics
 |3 | As low as `~0b11=0` | Authorizes stores of capabilities with any level
-|2 | As low as `~0b10=1` | Strip tag for level 0 (most _local_), keep for 1,2,3
-|1 | As low as `~0b01=2` | Strip tag for level 0&1, keep for 2&3
-|0 | As low as `~0b00=3` | Strip tag for level 0,1,2, i.e., only the most _global_ can be stored
+|2 | As low as `~0b10=1` | Strip {ctag} for level 0 (most _local_), keep for 1,2,3
+|1 | As low as `~0b01=2` | Strip {ctag} for level 0&1, keep for 2&3
+|0 | As low as `~0b00=3` | Strip {ctag} for level 0,1,2, i.e., only the most _global_ can be stored
 |===
 
 NOTE: While this extra negation is non-intuitive, it is required such that <<CLRPERM>> can use a monotonically decreasing operation for both <<section_cap_level,CL>> <<sl_perm>>.


### PR DESCRIPTION
@qwattash https://github.com/riscv/riscv-cheri/pull/737 needs similar substitution but I didn't want to cause conflicts