### PR TITLE
tidy up atomic pages - no spec changes

### DIFF
--- a/src/cheri/insns/amoswap_32bit_cap.adoc
+++ b/src/cheri/insns/amoswap_32bit_cap.adoc
@@ -14,9 +14,6 @@ include::wavedrom/amoswap_cap.adoc[]
 
 include::load_store_creg0.adoc[]
 
-:has_cap_data:
-include::atomic_exceptions.adoc[]
-
 Description::
 Atomic swap of capability type, authorized by the capability in `{cs1}`.
 +
@@ -27,6 +24,9 @@ The operation is equivalent to an atomically executed sequence of:
 `{store_cap_name_lc} {cs2}, 0({cs1})`
 +
 With the proviso that `{cd}` is only updated if no exceptions are raised.
+
+:has_cap_data:
+include::atomic_exceptions.adoc[]
 
 Prerequisites::
 {cheri_base_ext_name}, and A or Zaamo

--- a/src/cheri/insns/load_res_cap_32bit.adoc
+++ b/src/cheri/insns/load_res_cap_32bit.adoc
@@ -25,11 +25,9 @@ If the PMA is _CHERI {ctag_title}_ then load the associated {ctag}, otherwise se
 +
 Set the reservation as for LR.W/D.
 +
-Use the YLEN-bit data and the {ctag} to determine the value of `{cd}` as specified below.
+Use the YLEN-bit data and the {ctag} to determine the value of `{cd}` as specified by the <<LOAD_CAP>> instruction.
 +
 include::malformed_no_check.adoc[]
-+
-include::load_tag_perms.adoc[]
 +
 :cap_load:
 :load_res:

--- a/src/cheri/insns/store_cond_cap_32bit.adoc
+++ b/src/cheri/insns/store_cond_cap_32bit.adoc
@@ -23,7 +23,7 @@ Conditionally store, following the same rules as SC.W, a naturally aligned YLEN-
 +
 Set rd to 1 for success or 0 for failure.
 +
-include::store_tag_perms.adoc[]
+The written capability {ctag} may be cleared following the same modification rules as <<STORE_CAP>>.
 +
 include::malformed_no_check.adoc[]
 +


### PR DESCRIPTION
small restructuring, and making them all refer to the semantics of LY, SY to avoid replicating text