### PR TITLE
Fix remaining misa xrefs text

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -435,7 +435,7 @@ registers and instructions (hereafter referred to _disabling CHERI_).
 
 NOTE: When _CHERI is disabled_ for a specific privilege level, <<pcc>> and <<ddc>> bounds are _still_ enforced.
 
-The {cheri_priv_m_reg_enable_ext} extension makes the {CRE} bit of <<misa,misa>>, <<menvcfg>>, and <<senvcfg>> writable to allow CHERI to be disabled.
+The {cheri_priv_m_reg_enable_ext} extension makes the {CRE} bit of <<misa>>, <<menvcfg>>, and <<senvcfg>> writable to allow CHERI to be disabled.
 
 {cheri_priv_m_reg_enable_ext} implies {cheri_default_ext_name}.
 
@@ -448,14 +448,14 @@ The {cheri_priv_m_reg_enable_ext} extension makes the {CRE} bit of <<misa,misa>>
 
 The effective CHERI-enable for the current privilege is:
 
-* Machine: `<<misa,misa>>.{CRE}`
-* Supervisor: `<<misa,misa>>.{CRE} & <<menvcfg>>.{CRE}`
-* User: `<<misa,misa>>.{CRE} & <<menvcfg>>.{CRE} & <<senvcfg>>.{CRE}`
+* Machine: `<<misa>>.{CRE}`
+* Supervisor: `<<misa>>.{CRE} & <<menvcfg>>.{CRE}`
+* User: `<<misa>>.{CRE} & <<menvcfg>>.{CRE} & <<senvcfg>>.{CRE}`
 
 #move this to debug spec#
 NOTE: The effective CHERI-enable is always 1 in debug mode.
 
-NOTE: On reset CHERI is always disabled for backwards compatibility (<<misa,misa>>.{CRE} resets to zero, <<ddc>> and <<pcc>> bounds are nominally root capabilities (see <<root-cap>>).
+NOTE: On reset CHERI is always disabled for backwards compatibility (<<misa>>.{CRE} resets to zero, <<ddc>> and <<pcc>> bounds are nominally root capabilities (see <<root-cap>>).
 
 The following occurs when executing code in a privilege mode that has CHERI disabled:
 

--- a/src/machine.adoc
+++ b/src/machine.adoc
@@ -15,7 +15,7 @@ other details of the hardware implementation.
 In addition to the machine-level CSRs described in this section, M-mode
 code can access all CSRs at lower privilege levels.
 
-[[misa]]
+[#misa, reftext="misa"]
 ==== Machine ISA (`misa`) Register
 
 The `misa` CSR is a *WARL* read-write register reporting the ISA supported by the hart. This register must be readable in any implementation, but a value of zero can be returned to indicate the `misa` register has not been implemented, requiring that CPU capabilities be determined through a separate non-standard mechanism.


### PR DESCRIPTION
Add a reftext attribute to simplify this instead of requiring `<<misa,misa>>` which we were using for almost all references previously.