### PR TITLE
Fix headline for dscratch0

### DIFF
--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -98,8 +98,8 @@ Debug Program Counter (dpc)::
 .Debug program counter
 include::img/dpcreg.edn[]
 
-[#dscratch0,reftext="dscratch1"]
-Debug Scratch Register 1 (dscratch1)::
+[#dscratch0,reftext="dscratch0"]
+Debug Scratch Register 0 (dscratch0)::
 <<dscratch0>> is an optional DXLEN-bit scratch register that can be used by implementations which need it.
 +
 .Debug scratch 0 register


### PR DESCRIPTION
The headline for dscratch0 was referring to dscratch1. Fix that.