### PR TITLE
riscv-unpriv: fix Zyseal cross-refs

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -309,6 +309,7 @@ Additionally, <<JALR_CHERI>> both
 <<JALR_CHERI>> places no constraints on the triple of input <<sec_cap_type>> value, `{cd}` selector, and `{cs1}` selector.
 That is, <<JALR_CHERI>> will, as directed, attempt to jump to any unsealed or sealed capability in any register regardless of which register comes to hold the sealed return pointer.
 
+ifdef::cheri_standalone_spec[]
 [NOTE]
 =====
 The permission encodings of <<AP-field-encoding>> do not provide mappings for
@@ -316,6 +317,7 @@ the <<section_zyseal>> extension's <<zyseal_se_perm>> or <<zyseal_us_perm>>.
 Thus, without further revision, the encodings of this chapter
 are incompatible with the <<section_zyseal>> extension.
 =====
+endif::[]
 
 #End changed since last ARC review#
 


### PR DESCRIPTION
Omitted in error from #780; this fixes missing cross-references while building the unprivileged document.  (Perhaps it would be better to make the cross-references conditional?)