### PR TITLE
xycheriot: drop YBNDSWBigI

### DIFF
--- a/src/cheri/xycheriot.adoc
+++ b/src/cheri/xycheriot.adoc
@@ -503,6 +503,7 @@ the use of a CSR is presently experimental.
 The impact of lowering register pressure is yet to be measured.
 =====
 
+////
 ==== {cheriot_setbounds_big_imm_name}
 
 [NOTE]
@@ -526,6 +527,7 @@ Should the I-type instruction's immediate be a length and a shift,
 since our encoding's mantissas are smaller than 12 bits wide?
 
 =====
+////
 
 ==== {cheriot_setbounds_round_down_name}
 


### PR DESCRIPTION
Now that YBNDSWI in the base spec has its 8+2 immediate encoding form, there's no need for us to separately propose a large-immediate set-bounds instruction.