### PR TITLE
Made use of TID vs TIDC consistent

### DIFF
--- a/src/smstateen.adoc
+++ b/src/smstateen.adoc
@@ -181,7 +181,7 @@ read-only).
 {bits: 1, name: 'C'},
 {bits: 1, name: 'FCSR'},
 {bits: 1, name: 'JVT'},
-{bits: 1, name: 'TIDC'},
+{bits: 1, name: 'TID'},
 {bits: 50, name: 'WPRI'},
 {bits: 1, name: 'CTR'},
 {bits: 1, name: 'SRMCFG'},
@@ -203,7 +203,7 @@ read-only).
 {bits: 1, name: 'C'},
 {bits: 1, name: 'FCSR'},
 {bits: 1, name: 'JVT'},
-{bits: 1, name: 'TIDC'},
+{bits: 1, name: 'TID'},
 {bits: 50, name: 'WPRI'},
 {bits: 1, name: 'CTR'},
 {bits: 2, name: 'WPRI'},
@@ -224,7 +224,7 @@ read-only).
 {bits: 1, name: 'C'},
 {bits: 1, name: 'FCSR'},
 {bits: 1, name: 'JVT'},
-{bits: 1, name: 'TIDC'},
+{bits: 1, name: 'TID'},
 {bits: 28, name: 'WPRI'}
 ], config:{bits: 32, lanes: 2, hspace:1024}}
 ....


### PR DESCRIPTION
This is a minor spelling fix and does not impact functionality.