### PR TITLE
Zylevels1: remove optional imposition on YPERMC

### DIFF
--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -88,13 +88,9 @@ used by <<CLRPERM>> and <<GCPERM>>,
 as shown in <<zylevels1_acperm_bit_field>>.
 
 ==== <<CLRPERM>> and the Capability Global (GL) Flag
-<<CLRPERM>> can produce a new capability value with the _Capability Global_ flag cleared, even if the source capability is sealed.
+<<CLRPERM>> can produce a new capability value with its <<zylevels1_gl_perm>> cleared, even if the source capability is sealed.
 This is unlike architectural and software permissions.
 This applies to both "implicit <<CLRPERM>>s" in loads from memory and explicit <<CLRPERM>> instructions.
-
-Implementations _are permitted but not mandated_ to require that an explicit <<CLRPERM>> instruction wishing to clear <<zylevels1_gl_perm>>
-has an input mask that is _entirely 0s_ except for <<zylevels1_gl_perm>>
-(or else clear the {ctag} of the resulting capability).
 
 ==== Additional <<CLRPERM>> rules
 


### PR DESCRIPTION
YPERMC is presently phrased as requiring a check that the AP and SDP fields are not changed under seal, but Zylevels1 introduces a GLobal flag that is permission-like in its monotonicity but is not "under seal".

We had considered the possibility of having YPERMC require that, if its input capability operand is sealed, then its scalar operand may at most request clearing GLobal (if Zylevels1 is implemented) or must be zero (if not).  But this is somewhat non-compositional and perhaps confusing, so just remove the text in question.