### PR TITLE
YPERMC permissions readability improvements

### DIFF
--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -152,7 +152,7 @@ non-zero value.
 NOTE: Mode is encoded with permissions for {cheri_base32_ext_name}, but is not a permission. It is
 orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 
-When {cheri_base32_ext_name}, this encoding's compressed permission format
+This encoding's compressed permission format
 specifies a _particular procedure_ for encoding architectural permissions,
 which is used _instead of_ <<CLRPERM>>'s default fixed-pointing procedure.
 If <<section_zylevels1>> is absent, the following rules are run once _in order_:
@@ -217,7 +217,7 @@ If <<section_zylevels1>> is absent, the following rules are run once _in order_:
 ^1^ _Mode (<<m_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
 is supported, otherwise such encodings are reserved. Despite being encoded here it is *not* an architectural permission._
 
-If <<section_zylevels1>> is present, the following rules are run once _in order_:
+The following rules are run once _in order_:
 
 [#clrperm-rules-zylevels1]
 .{cheri_base32_ext_name} <<CLRPERM>> rules if <<section_zylevels1>> is present.

--- a/src/cheri/app-cap-description.adoc
+++ b/src/cheri/app-cap-description.adoc
@@ -97,14 +97,16 @@ Quadrant 0 does the opposite - the encodings are allocated _not_ to implicitly a
 Quadrant 1 encodes permissions for executable capabilities and the <<m_bit>>.
 
 <<<
+[#default-cap-AP-no-zylevels1]
+==== AP encoding and rules without <<section_zylevels1>> for {cheri_base32_ext_name}
 
 .Encoding of architectural permissions for {cheri_base32_ext_name} without <<section_zylevels1>>
 [#cap_perms_encoding_nolevels32,width="100%",options=header,cols="^2,^1,^1,^1,^1,^1,^1,^1,4",align="center"]
 |==============================================================================
-| Field[2:0] | R | W | C | LM | X | ASR | Mode^1^ | Notes
 9+| *Quadrant 0: Non-capability data read/write*
 9+| bit[2] - write, bit[1] - reserved (0), bit[0] - read
 9+| _Reserved bits for future extensions are 0 so new permissions are not implicitly granted_
+| Field[2:0] | R | W | C | LM | X | ASR | Mode^1^ | Notes
 | 0   |   |   |   |   |     |   | N/A | No permissions
 | 1   | ✔ |   |   |   |     |   | N/A | Data RO
 | 2-3   8+| reserved
@@ -113,6 +115,7 @@ Quadrant 1 encodes permissions for executable capabilities and the <<m_bit>>.
 | 6-7   8+| reserved
 9+| *Quadrant 1: Executable capabilities*
 9+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
+| Field[2:0] | R | W | C | LM | X | ASR | Mode^1^ | Notes
 | 0-1   | ✔ | ✔ | ✔ | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
 | 2-3   | ✔ |   | ✔ | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RO
 | 4-5   | ✔ | ✔ | ✔ | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RW
@@ -121,12 +124,14 @@ Quadrant 1 encodes permissions for executable capabilities and the <<m_bit>>.
 9+| R and C implicitly granted, LM dependent on W permission.
 9+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
 9+| _bit[2] is reserved to mean write for future encodings_
+| Field[2:0] | R | W | C | LM | X | ASR | Mode^1^ | Notes
 | 0-2   8+| reserved
 | 3       | ✔ |   | ✔ |   |   |     | N/A | Data & Cap RO (no LM)
 | 4-7   8+| reserved
 9+| *Quadrant 3: Capability data read/write*
 9+| bit[2] - write, R and C implicitly granted.
 9+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
+| Field[2:0] | R | W | C | LM | X | ASR | Mode^1^ | Notes
 | 0-2   8+| reserved
 | 3       | ✔ |   | ✔ | ✔ |   |     | N/A | Data & Cap RO
 | 4-6   8+| reserved
@@ -147,50 +152,13 @@ non-zero value.
 NOTE: Mode is encoded with permissions for {cheri_base32_ext_name}, but is not a permission. It is
 orthogonal to permissions as it can vary arbitrarily using <<SCMODE>>.
 
-.Encoding of architectural permissions for {cheri_base32_ext_name} with <<section_zylevels1>>
-[#cap_perms_encoding32,width="100%",options=header,cols="^2,^1,^1,^1,^1,^1,^1,^1,^1,^1,4",align="center"]
-|==============================================================================
-|Field[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
-11+| *Quadrant 0: Non-capability data read/write*
-11+| bit[2] - write, bit[1] - reserved (0), bit[0] - read
-11+| _Reserved bits for future extensions are 0 so new permissions are not implicitly granted_
-| 0   |   |   |   |   |   |   |   |   | N/A | No permissions
-| 1   | ✔ |   |   |   |   |   |   |   | N/A | Data RO
-| 2-3   10+| reserved
-| 4   |   | ✔ |   |   |   |   |   |   | N/A | Data WO
-| 5   | ✔ | ✔ |   |   |   |   |   |   | N/A | Data RW
-| 6-7   10+| reserved
-11+| *Quadrant 1: Executable capabilities*
-11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
-| 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
-| 2-3   | ✔ |   | ✔ | ✔  | ✔  |   | ✔ |     | Mode^1^  | Execute + Data & Cap RO
-| 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RW
-| 6-7   | ✔ | ✔ |   |    |    |   | ✔ |     | Mode^1^  | Execute + Data RW
-11+| *Quadrant 2: Restricted capability data read/write*
-11+| bit[2] = write, bit[1] reserved, bit[0] = !SL. R and C implicitly granted, LM dependent on W permission.
-| 0-2   10+| reserved
-| 3       | ✔ |   | ✔ |    |    |   |   |     | N/A | Data & Cap R0 (without <<lm_perm>>)
-| 4-5  10+| reserved
-| 6       | ✔ | ✔ | ✔ | ✔  |    | ✔ |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
-| 7       | ✔ | ✔ | ✔ | ✔  |    |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
-11+| *Quadrant 3: Capability data read/write*
-11+| bit[2] = write, bit[1] reserved, bit[0] = !SL. R and C implicitly granted.
-11+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
-| 0-2   10+| reserved
-| 3       | ✔ |   | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap R0
-| 4-6   10+| reserved
-| 6       | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>)
-| 7       | ✔ | ✔ | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>)
-|==============================================================================
-
-^1^ _Mode (<<m_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
-is supported, otherwise such encodings are reserved. Despite being encoded here it is *not* an architectural permission._
-
 When {cheri_base32_ext_name}, this encoding's compressed permission format
 specifies a _particular procedure_ for encoding architectural permissions,
 which is used _instead of_ <<CLRPERM>>'s default fixed-pointing procedure.
-If <<section_zylevels1>> is absent, the following rules are run _in order_:
+If <<section_zylevels1>> is absent, the following rules are run once _in order_:
 
+[#clrperm-rules-no-zylevels1]
+.{cheri_base32_ext_name} <<CLRPERM>> rules if <<section_zylevels1>> is absent.
 [float="center",align="center",cols="2,2,4",options="header"]
 |===
 | <<CLRPERM>> Rule | Permission   | Valid only if
@@ -204,8 +172,55 @@ If <<section_zylevels1>> is absent, the following rules are run _in order_:
 | RV32-base-8      | <<m_bit>>    | <<x_perm>> and {cheri_default_ext_name} is implemented
 |===
 
-If <<section_zylevels1>> is present, the following rules are run _in order_:
+[#default-cap-AP-zylevels1]
+==== AP encoding and rules with <<section_zylevels1>> for {cheri_base32_ext_name}
 
+.Encoding of architectural permissions for {cheri_base32_ext_name} with <<section_zylevels1>>
+[#cap_perms_encoding32,width="100%",options=header,cols="^2,^1,^1,^1,^1,^1,^1,^1,^1,^1,4",align="center"]
+|==============================================================================
+11+| *Quadrant 0: Non-capability data read/write*
+11+| bit[2] - write, bit[1] - reserved (0), bit[0] - read
+11+| _Reserved bits for future extensions are 0 so new permissions are not implicitly granted_
+|Field[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
+| 0   |   |   |   |   |   |   |   |   | N/A | No permissions
+| 1   | ✔ |   |   |   |   |   |   |   | N/A | Data RO
+| 2-3   10+| reserved
+| 4   |   | ✔ |   |   |   |   |   |   | N/A | Data WO
+| 5   | ✔ | ✔ |   |   |   |   |   |   | N/A | Data RW
+| 6-7   10+| reserved
+11+| *Quadrant 1: Executable capabilities*
+11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
+|Field[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
+| 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
+| 2-3   | ✔ |   | ✔ | ✔  | ✔  |   | ✔ |     | Mode^1^  | Execute + Data & Cap RO
+| 4-5   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RW
+| 6-7   | ✔ | ✔ |   |    |    |   | ✔ |     | Mode^1^  | Execute + Data RW
+11+| *Quadrant 2: Restricted capability data read/write*
+11+| bit[2] = write, bit[1] reserved, bit[0] = !SL. R and C implicitly granted, LM dependent on W permission.
+|Field[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
+| 0-2   10+| reserved
+| 3       | ✔ |   | ✔ |    |    |   |   |     | N/A | Data & Cap R0 (without <<lm_perm>>)
+| 4-5  10+| reserved
+| 6       | ✔ | ✔ | ✔ | ✔  |    | ✔ |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
+| 7       | ✔ | ✔ | ✔ | ✔  |    |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>, no <<zylevels1_lg_perm>>)
+11+| *Quadrant 3: Capability data read/write*
+11+| bit[2] = write, bit[1] reserved, bit[0] = !SL. R and C implicitly granted.
+11+| _Reserved bits for future extensions must be 1 so they are implicitly granted_
+|Field[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
+| 0-2   10+| reserved
+| 3       | ✔ |   | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap R0
+| 4-6   10+| reserved
+| 6       | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ |   |     | N/A | Data & Cap RW (with <<zylevels1_sl_perm>>)
+| 7       | ✔ | ✔ | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>)
+|==============================================================================
+
+^1^ _Mode (<<m_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
+is supported, otherwise such encodings are reserved. Despite being encoded here it is *not* an architectural permission._
+
+If <<section_zylevels1>> is present, the following rules are run once _in order_:
+
+[#clrperm-rules-zylevels1]
+.{cheri_base32_ext_name} <<CLRPERM>> rules if <<section_zylevels1>> is present.
 [float="center",align="center",cols="2,2,4",options="header"]
 |===
 | <<CLRPERM>> Rule | Permission            | Valid only if

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -100,8 +100,11 @@ The <<m_bit>> of a <<x_perm>>-granting capability can be read and written by the
 
 NOTE: In addition to the mode switching instructions, the current mode can also be updated by setting the <<m_bit>> of a target capability using <<SCMODE>> followed by a <<JALR_CHERI>>.
 
+[#sec_m_bit_hybrid_rule]
+==== Representation of the <<m_bit>> in the capability encoding
+
 For capabilities that do not grant <<x_perm>>,
-<<m_bit>> must always be interpreted and reported as {cap_mode_value}.
+<<m_bit>> must always be interpreted and reported as {cap_mode_value} representing {cheri_cap_mode_name}.
 
 NOTE: While this is not phrased as an additional rule for <<CLRPERM>> to follow,
 beyond those of <<sec_permission_transitions>>,

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -389,6 +389,7 @@ Currently defined examples are:
 
 . <<section_cheri_hybrid_ext,{cheri_default_ext_name}>>, see <<sec_m_bit_hybrid_rule>>
 . <<section_zylevels1>>, see <<zylevels1-clrperm-rules>>
+. <<section_zyseal>>, see <<zyseal_ap_field>>
 
 Capability _encodings_ may impose additional constraints.
 to reduce the number of bits necessary to represent permissions.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -384,9 +384,12 @@ such that a permission bit being set in the result of <<GCPERM>>
 implies that all bits for permissions upon which it depends will also be set.
 
 For the base set of permissions just defined, the following rules apply.
-Extensions that define new permission bits (such as
-<<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and <<section_zylevels1>>)
-may also introduce new dependency constraints.
+Extensions that define new permission bits may also introduce new dependency constraints.
+Currently defined examples are:
+
+. <<section_cheri_hybrid_ext,{cheri_default_ext_name}>>, see <<sec_m_bit_hybrid_rule>>
+. <<section_zylevels1>>, see <<zylevels1-clrperm-rules>>
+
 Capability _encodings_ may impose additional constraints.
 to reduce the number of bits necessary to represent permissions.
 
@@ -398,6 +401,8 @@ to reduce the number of bits necessary to represent permissions.
 | [[perm_req:base:lm:c-and-r,base-2]]base-2 | <<lm_perm>>  | <<c_perm>> and <<r_perm>>
 | [[perm_req:base:asr:x,base-3]]base-3      | <<asr_perm>> | <<x_perm>>
 |===
+
+When using <<app_cap_description,{rvy_default_encoding_name}>> and {cheri_base32_ext_name} the complete set of rules with and without <<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and <<section_zylevels1>> are shown in <<clrperm-rules-no-zylevels1>> and <<clrperm-rules-zylevels1>>.
 
 [#sec_cap_sdp]
 ==== Software-Defined Permissions (SDP)

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -389,7 +389,9 @@ Currently defined examples are:
 
 . <<section_cheri_hybrid_ext,{cheri_default_ext_name}>>, see <<sec_m_bit_hybrid_rule>>
 . <<section_zylevels1>>, see <<zylevels1-clrperm-rules>>
+ifdef::cheri_standalone_spec[]
 . <<section_zyseal>>, see <<zyseal_ap_field>>
+endif::[]
 
 Capability _encodings_ may impose additional constraints.
 to reduce the number of bits necessary to represent permissions.

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -92,6 +92,7 @@ as shown in <<zylevels1_acperm_bit_field>>.
 This is unlike architectural and software permissions.
 This applies to both "implicit <<CLRPERM>>s" in loads from memory and explicit <<CLRPERM>> instructions.
 
+[#zylevels1-clrperm-rules]
 ==== Additional <<CLRPERM>> rules
 
 As mentioned, the <<zylevels1_sl_perm>> and <<zylevels1_lg_perm>> permissions

--- a/src/cheri/zyseal.adoc
+++ b/src/cheri/zyseal.adoc
@@ -60,6 +60,7 @@ not intrinsically.
 
 === Added Architectural Permissions (AP) Bits
 
+.{cheri_seal_ext_name} <<CLRPERM>> rules.
 [#zyseal_ap_field,width="100%",options=header,halign=center,cols="2,2,5"]
 |==============================================================================
 | Permission         | Type                        | Comment


### PR DESCRIPTION
I'm navigating the document to understand he full set of permissions rules.
This is an attempt to make it easier to navigate (mainly) for RV32.

Note that I've reorganised a bit - the rules table and permissions tables for RV32 are paired up now to make them easier to interpret.