### PR TITLE
riscv-unpriv-integration: (trivial) fix the wording

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -561,7 +561,7 @@ protection units, e.g., two or more libraries. Code can be separated by sentries
 which allow for giving out code capabilities to untrusted code where the untrusted
 code can only call the code capability, but not modify it. The <<utidc>> register supports
 a model where untrusted code is separated by trusted code and each call from one piece of untrusted
-code to another piece of untrusted piece of code goes through trusted code. Often, the trusted
+code to another piece of untrusted code goes through trusted code. Often, the trusted
 code is referred to as a *trampoline*. Sentries can
 be called from different software threads and thus there needs to be a way of
 identifying the current software thread. While identifying the current software thread


### PR DESCRIPTION
Fix a sentence that introduces a trampoline.