### PR TITLE
Fixes in zylevels1

### DIFF
--- a/src/cheri/img/zylevels1-acperm_bit_field.edn
+++ b/src/cheri/img/zylevels1-acperm_bit_field.edn
@@ -7,7 +7,7 @@
 (def right-margin 100)
 (def boxes-per-row 32)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse
-  ["0" "" "2" "3" "4" "5" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1"]
+  ["0" "" "1" "2" "3" "4" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1"]
 )})
 
 (draw-box "As is"     {:span 27})

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -23,7 +23,7 @@ The distinction refines the behavior of capability store and load instructions:
 [#zylevels1_ap_field_summary,width="100%",options=header,halign=center,cols="2,2,5"]
 |==============================================================================
 | Permission   | Type | Comment
-| <<zylevels1_sl_perm>>  | Data memory permission         | Used to filter the permissions of loaded capabilities.
+| <<zylevels1_sl_perm>>  | Data memory permission         | Used to filter the validity of stored capabilities.
 | <<zylevels1_lg_perm>>  | Data memory permission         | Used to filter the permissions of loaded capabilities.
 |==============================================================================
 


### PR DESCRIPTION
I applied two fixes to the `zylevels1` spec:

- The SL bit touches on stores and not on loads
- The "As is" bitfield on is only 2 bits long, but the figure claimed it was 3 bits long