### PR TITLE
Zyhybrid tweaks

### DIFF
--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -66,7 +66,7 @@ The _<<cheri_execution_mode>>_ is determined by a bit in the metadata of the <<p
 This field _need_ be present only in capabilities granting <<X-permission>>,
 as it is only ever architecturally interpreted on the capability resident in <<pcc>>.
 Capabilities not granting <<X-permission>> may or may not have a defined M field,
-and attempting to update this field may or may not clear their {ctag}s.
+and attempting to update this field may be a no-op.
 The exact location of the M-bit in the capability format for XLEN=32 and XLEN=64 is described in <<app_cap_description>>.
 
 * Mode (M)={CAP_MODE_VALUE} indicates {cheri_cap_mode_name}.


### PR DESCRIPTION
- The example code for observing the execution mode was, AFAICT, backwards.
- The M field is logically not a permission but is X-permission-dependent (see the "default" RV32 encoding), so reflect that in the text.