### PR TITLE
zyhybrid: clarify role of rs1 in (Non-CHERI) Address Mode

### DIFF
--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -32,8 +32,9 @@ NOTE: Instructions which are _modified_ on an {cheri_base_ext_name} architecture
 +
 All <<rvy_insn_table>> instructions, and associated CSRs, are available in addition to RVI/RVE and all supported non-CHERI extensions.
 +
-All memory accesses are implicitly authorized by <<ddc>>, including <<PREFETCH_W_CHERI>> and <<PREFETCH_R_CHERI>>.
-<<PREFETCH_I_CHERI>> is authorized by <<pcc>> instead.
+The authorizing capability for memory access is <<ddc>> (as opposed to `rs1`).
+That is, all memory accesses, including <<PREFETCH_W_CHERI>> and <<PREFETCH_R_CHERI>>, are implicitly authorized by <<ddc>> and only the memory address is sourced from `rs1`.
+Jumps and <<PREFETCH_I_CHERI>> are exceptions to this rule, as <<pcc>> authorizes them.
 +
 NOTE: <<ddc>> is also used to authorize {cheri_base_ext_name} specific memory instructions such as <<LOAD_CAP>> and <<STORE_CAP>>.
 +


### PR DESCRIPTION
As soon as DDC is used as the authorizing capability, the metadata, incl. the tag bit, of rs1 becomes irrelevant. Only the address is sourced from rs1.

While this behavior seems natural, and the specification certainly gives that impression, I had to convince myself by looking at [CHERI's SAIL model](https://github.com/CTSRD-CHERI/sail-cheri-riscv/blob/bb07488dac8322fc4a653a01d049e16fa05c9065/src/cheri_addr_checks.sail#L182-L189) that my interpretation of the specification is correct. Therefore, it seems sensible to spell it out once in prose.

The following is my attempt to address this, and I hope you find it useful. However, feel free to reject this entirely.