### PR TITLE
remove cheriot as a future encoding, and comment out dedicated chapter

### DIFF
--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -125,7 +125,7 @@ WARNING: {YSEAL} and {YUNSEAL} are not included in the v1.0 ratification package
 [NOTE]
 ====
 
-The following changes are for forwards compatibility with {cheriot_ext_name}:
+The following changes are for forwards compatibility with CHERIoT:
 
 . Capability encodings are now the naming authorities for capability types (only 0/unsealed exists in the base architecture).
 . Capability encoding formats are now in separate base parameterizations.

--- a/src/cheri/cheri-unpriv-appendix.adoc
+++ b/src/cheri/cheri-unpriv-appendix.adoc
@@ -1,7 +1,7 @@
 [appendix]
 == CHERI ({cheri_base64_ext_name}) Unprivileged Appendix
 
-include::xycheriot.adoc[leveloffset=+1]
+//include::xycheriot.adoc[leveloffset=+1]
 
 include::app-cheri-instructions.adoc[leveloffset=+1]
 

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -142,7 +142,6 @@ The extensions in this section have not been fully prototyped and so are not con
 |<<section_cheri_vector_integration>>                       | Vector
 |<<ZCMT_CHERI>>                                             | Table Jump for {cheri_base32_ext_name}
 |<<ZCMP_CHERI>>                                             | Push/pop and double move for {cheri_base32_ext_name}
-|<<section_xycheriot>>                                      | CHERIoT capability encoding
 |<<section_zyseal>>                                         | Capability-mediated capability (un)sealing instructions
 |=============================================================================================================================================================
 


### PR DESCRIPTION
I don't think we need the dedicated CHERIoT chapter now - or if we do - it needs updating to be in-line with the rest of the spec