### PR TITLE
restrict YBNDSWI to 8-bits (anticipating a smaller immediate following ARC review)

### DIFF
--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -45,22 +45,9 @@ Set `{cd}.tag=0` if the requested bounds cannot be encoded exactly.
 +
 include::malformed_cs1_clear_tag.adoc[]
 +
-<<SCBNDSI>> uses the following formula to determine the requested length:
+<<SCBNDSI>> uses the following formula to determine the requested length, so that the value of zero is mapped to a useful value:
 
-* `((imm[7:0] + 257) << imm[9:8]) - 256`
-
-[NOTE]
-====
-This formula does not actually require two additions in decode as it expands to the following:
-[%autowidth]
-|===
-|`imm[9:8]`|Resulting immediate   | Immediate range
-|0         |`(imm[7:0]<<0) + 1`   | 1, 2, ..., 255, 256
-|1         |`(imm[7:0]<<1) + 258` | 258, 260, ..., 766, 768
-|2         |`(imm[7:0]<<2) + 772` | 772, 776, ..., 1788, 1792
-|3         |`(imm[7:0]<<3) + 1800`| 1800, 1808, ..., 3832, 3840
-|===
-====
+* `if (imm[7:0]==0) 256 : imm[7:0]`
 
 Included in::
 <<rvy_insn_table>>

--- a/src/cheri/insns/wavedrom/scbnds_32bit.adoc
+++ b/src/cheri/insns/wavedrom/scbnds_32bit.adoc
@@ -18,7 +18,7 @@
   {bits: 5,  name: '{cd}={cs1}', attr: ['5', 'dest'], type: 2},
   {bits: 3,  name: 'funct3',     attr: ['3', '{SCBNDSI}=011'], type: 8},
   {bits: 5,  name: '{cs1}={cd}', attr: ['5', 'src'], type:4},
-  {bits: 10, name: 'uimm',       attr: ['10','uimm'], type: 4},
-  {bits: 2,  name: 'funct2',     attr: ['3', '00'], type: 8},
+  {bits: 8,  name: 'imm',        attr: ['8','imm'], type: 4},
+  {bits: 4,  name: 'funct4',     attr: ['4', '{SCBNDSI}=0000'], type: 8},
 ]}
 ....


### PR DESCRIPTION
We don't have any compelling data for the top 2 bits of the 10-bit immediate, so instead of waiting for it to be rejected by ARC we may as well trim it up-front.
The 8-bit immediate covers all the CHERIoT use cases, and almost all of the FreeBSD use cases too.

