### PR TITLE
jumps not authorised by PCC in hybrid mode

### DIFF
--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -35,7 +35,7 @@ All <<rvy_insn_table>> instructions, and associated CSRs, are available in addit
 +
 The authorizing capability for memory access is <<ddc>> (as opposed to `rs1`).
 That is, all memory accesses, including <<PREFETCH_W_CHERI>> and <<PREFETCH_R_CHERI>>, are implicitly authorized by <<ddc>> and only the memory address is sourced from `rs1`.
-Jumps and <<PREFETCH_I_CHERI>> are exceptions to this rule, as <<pcc>> authorizes them.
+<<PREFETCH_I_CHERI>> is the exception to this rule, as <<pcc>> authorizes it.
 +
 NOTE: <<ddc>> is also used to authorize {cheri_base_ext_name} specific memory instructions such as <<LOAD_CAP>> and <<STORE_CAP>>.
 +


### PR DESCRIPTION
There is still a statement about jumps being authorised by PCC in integer mode.
This is no longer the case, as jumps no longer fault.
There is an associated query about using PCC to authorise `PREFETCH.I` which is addressed in https://github.com/riscv/riscv-cheri/pull/900