### PR TITLE
Fix tag clearing for YBNDRW

### DIFF
--- a/src/cheri/contributors.adoc
+++ b/src/cheri/contributors.adoc
@@ -38,5 +38,6 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Ricki Tura <ricki.tura@codasip.com>
 * Robert N. M. Watson <robert.watson@cl.cam.ac.uk>
 * Toby Wenman <toby.wenman@codasip.com>
+* Jay Williams <jay.williams@codasip.com>
 * Jonathan Woodruff <jonathan.woodruff@cl.cam.ac.uk>
 * Jason Zhijingcheng Yu <yu.zhi@comp.nus.edu.sg>

--- a/src/cheri/insns/scbndsr_32bit.adoc
+++ b/src/cheri/insns/scbndsr_32bit.adoc
@@ -29,8 +29,6 @@ capability covering the requested base and top.
 +
 Set `{cd}.tag=0` if `{cs1}.tag=0`, `{cs1}` is sealed or if `{cd}` 's bounds exceed `{cs1}` 's bounds.
 +
-Set `{cd}.tag=0` if the requested bounds cannot be encoded exactly.
-+
 include::malformed_cs1_clear_tag.adoc[]
 
 Included in::


### PR DESCRIPTION
With this line included, there is no difference between YBNDRW and YBNDSW. This looks like a copy-and-paste bug.