### PR TITLE
cheri-pte-ext: fix note

### DIFF
--- a/src/cheri/cheri-pte-ext.adoc
+++ b/src/cheri/cheri-pte-ext.adoc
@@ -71,10 +71,13 @@ include::img/sv48pte_crg.edn[]
 [#sv57pte_crg]
 include::img/sv57pte_crg.edn[]
 
-NOTE: The behavior in this section isn't relevant if:
+[NOTE]
+====
+The behavior in this section isn't relevant if:
 
 . The authorizing capability doesn't have <<c_perm>>, for loads, stores and AMO.
 . Any extension-specific mediation has already cleared the stored tag, for stores and AMOs.
+====
 
 The CRW bit (defined by {cheri_priv_vmem_ext}) indicates whether reading or writing capabilities with the {ctag} set to
 the virtual page is permitted. When the CRW bit is set, capabilities are written


### PR DESCRIPTION
The note would only span the first sentence while it should also include the two point listing afterwards, so expand the formatting to wrap the following list.