### PR TITLE
Clarify what the various Xstateen0.TID bits control access to.

### DIFF
--- a/src/cheri/contributors.adoc
+++ b/src/cheri/contributors.adoc
@@ -39,5 +39,6 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Robert N. M. Watson <robert.watson@cl.cam.ac.uk>
 * Toby Wenman <toby.wenman@codasip.com>
 * Jay Williams <jay.williams@codasip.com>
+* Adrian Wise <adrian.wise@codasip.com>
 * Jonathan Woodruff <jonathan.woodruff@cl.cam.ac.uk>
 * Jason Zhijingcheng Yu <yu.zhi@comp.nus.edu.sg>

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -149,7 +149,7 @@ include::img/ycfgreg.edn[]
 endif::[]
 
 === "Smstateen/Ssstateen" Integration
-The new TID bit controls access to the <<vstidc>> CSR.
+The new TID bit controls access to the <<stidc>> (really <<vstidc>>) CSR.
 
 .Hypervisor State Enable 0 Register (`hstateen0`)
 [wavedrom, ,svg,subs=attributes+]

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -235,7 +235,7 @@ For all CHERI faults, <<mtval>> is written with the MXLEN-bit effective address 
 include::img/mtvalreg.edn[]
 
 ==== "Smstateen/Ssstateen" Integration
-The TID bit in `mstateen0` controls access to the <<stidc>> CSR.
+The TID bit in `mstateen0` controls access to the <<stidc>>, <<vstidc>>, and <<utidc>> CSRs.
 
 .Machine State Enable 0 Register (`mstateen0`)
 [wavedrom, ,svg,subs=attributes+]

--- a/src/smstateen.adoc
+++ b/src/smstateen.adoc
@@ -256,7 +256,9 @@ whether they really do.
 The JVT bit controls access to the `jvt` CSR provided by the Zcmt extension.
 
 If the base architecture is {cheri_base_ext_name} then
-the TID bit controls access to the <<stidc>> and <<utidc>> CSRs.
+the TID bit in `mstateen0` controls access to the <<stidc>>, <<vstidc>>, and <<utidc>> CSRs.
+The TID bit in `hstateen0` controls access to the <<stidc>> (really <<vstidc>>) CSR.
+The TID bit in `sstateen0` controls access to the <<utidc>> CSR.
 
 The SE0 bit in `mstateen0` controls access to the `hstateen0`, `hstateen0h`,
 and the `sstateen0` CSRs. The SE0 bit in `hstateen0` controls access to the


### PR DESCRIPTION
Fix #928.

In particular, that mstateen0.TID affects access to all of stidc, vstidc, and utidc.