### PR TITLE
Remove redundant Xtval RVY text

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -397,11 +397,9 @@ is not performed but no exception is generated.
 [#CHERI_SPEC,reftext="CHERI Exceptions and speculative execution"]
 === CHERI Exceptions and speculative execution
 
-#should be non-normative - and needs more details - move to appendix?#
-
-CHERI adds architectural guarantees that can prove to be microarchitecturally useful.
-Speculative-execution attacks can -- among other factors -- rely on instructions that fail CHERI permission checks not to take effect.
-When implementing any of the extensions proposed here, microarchitects need to carefully consider the interaction of late-exception raising and side-channel attacks.
+NOTE: CHERI adds architectural guarantees that can prove to be microarchitecturally useful.
+ Speculative-execution attacks can -- among other factors -- rely on instructions that fail CHERI permission checks not to take effect.
+ When implementing any of the extensions proposed here, microarchitects need to carefully consider the interaction of late-exception raising and side-channel attacks.
 
 [#section_pma]
 === Physical Memory Attributes (PMA)


### PR DESCRIPTION
mtval_y and stval_y sections need deleting
Also changed the speculative execution section to be non-normative
