### PR TITLE
Temporary: change SRLIY encoding to avoid clash with old SCBNDSI

### DIFF
--- a/src/cheri/insns/wavedrom/gchi.adoc
+++ b/src/cheri/insns/wavedrom/gchi.adoc
@@ -5,8 +5,8 @@
   {bits: 7,  name: 'opcode',  attr: ['7', 'OP-IMM=0010011'], type: 8},
   {bits: 5,  name: 'rd',      attr: ['5', 'dest'], type: 2},
   {bits: 3,  name: 'funct3',  attr: ['3', '{GCHI_BASE}=101'], type: 8},
-  {bits: 5,  name: '{cs1}',     attr: ['5', 'src'], type: 4},
-  {bits: 7,  name: 'funct7',  attr: ['7', 'rv64: 1000000', 'rv32: 0100000'], type: 3},
-  {bits: 5,  name: 'funct5',  attr: ['5', '00000'], type: 3},
+  {bits: 5,  name: '{cs1}',   attr: ['5', 'src'], type: 4},
+  {bits: 7,  name: 'shamt',   attr: ['7', 'rv64: 1000000', 'rv32: 0100000'], type: 3},
+  {bits: 5,  name: 'funct5',  attr: ['5', '10000'], type: 3},
 ]}
 ....


### PR DESCRIPTION
This one is a bit strange - the 0.9.5 ISA and the 0.9.6 ISA have no conflicting encodings except for this one.
With this one change then a single simulator can support both version of the ISA.
The encodings will be replaced once ARC assigns correct encodings anyway - this one bit change helps with the migration from 0.9.5 to 0.9.6 - before everything standardises on the final approved version.

<img width="638" height="270" alt="image" src="https://github.com/user-attachments/assets/654d0d1d-1db5-4a54-80d0-0897748c9fb7" />
