### PR TITLE
integrity checks: clarify that this is about valid capabilities

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -586,8 +586,8 @@ CHERI enforces the following rules for all valid capabilities:
 
 Since a capability with the {ctag} set that fails integrity checks could not have been legally created, such a failure indicates either
 
-* state corruption due to memory or logic faults, or
-* the presence of incompatible or faulty CHERI IP within the system.
+* State corruption due to memory or logic faults, or
+* The presence of incompatible or faulty CHERI IP within the system.
 
 NOTE: These checks are much less rigorous than parity or ECC protection, and are only
 used to detect simple problems with the capability metadata.


### PR DESCRIPTION
Eventually, integrity checks apply to valid and invalid capabilities. While they are more dominant for valid capabilities, they have their use for invalid ones as well:
1. ybld uses integrity checks on invalid capabilities (as noted in the text below).
2. ymoder and ymodew use integrity checks on invalid capabilities.

So make it clear that only a *valid* capability that fails integrity checks is something abnormal.

Also refine the wording a bit.