### PR TITLE
ymodew: remove unnecessary requirement of rs1's failing integrity check

### DIFF
--- a/src/cheri/insns/scmode_32bit.adoc
+++ b/src/cheri/insns/scmode_32bit.adoc
@@ -30,8 +30,6 @@ Otherwise, if `{cs1}` grants <<x_perm>> then update the <<m_bit>> of `{cd}` to:
 +
 2. {cheri_int_mode_name} if the least significant bit of `rs2` is {INT_MODE_VALUE}.
 +
-Otherwise do not update the <<m_bit>>.
-+
 include::no_tag_affect.adoc[]
 
 Included in::


### PR DESCRIPTION
If rs1 fails its integrity check, then its tag is set to zero by construction (assuming the absence of faulty IP cores or memory corruption). Furthermore, we will later only adjust the M-bit if rs1 passes the integrity checks, so the previous check for them failing is unnecessary.