### PR TITLE
[ARC Feedback] Rename ADD(I)Y to YADD(I)

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -215,12 +215,12 @@ endif::support_varxlen[]
 :pcc: pc
 
 //ISA naming
-:CADD:         ADDY
-:CADD_LC:      addy
+:CADD:         YADD
+:CADD_LC:      yadd
 :CADD_DESC:    Capability pointer increment
 
-:CADDI:        ADDIY
-:CADDI_LC:     addiy
+:CADDI:        YADDI
+:CADDI_LC:     yaddi
 :CADDI_DESC:   Capability pointer increment by immediate
 
 :SCADDR:       YADDRW
@@ -333,40 +333,40 @@ endif::support_varxlen[]
 :MODESW_INT_LC:   ymodeswi
 :MODESW_INT_DESC: Switch execution to {cheri_int_mode_name}
 
-:SH1ADD_CHERI:    SH1ADDY
-:SH1ADD_CHERI_LC: sh1addy
-:SH2ADD_CHERI:    SH2ADDY
-:SH2ADD_CHERI_LC: sh2addy
-:SH3ADD_CHERI:    SH3ADDY
-:SH3ADD_CHERI_LC: sh3addy
-:SH4ADD_CHERI:    SH4ADDY
-:SH4ADD_CHERI_LC: sh4addy
+:SH1ADD_CHERI:    YSH1ADD
+:SH1ADD_CHERI_LC: ysh1add
+:SH2ADD_CHERI:    YSH2ADD
+:SH2ADD_CHERI_LC: ysh2add
+:SH3ADD_CHERI:    YSH3ADD
+:SH3ADD_CHERI_LC: ysh3add
+:SH4ADD_CHERI:    YSH4ADD
+:SH4ADD_CHERI_LC: ysh4add
 
 :SENTRY:                  YSENTRY
 :SENTRY_LC:               ysentry
 :SENTRY_DESC:             Seal capability as a sentry
 
-:SH1ADD_UW_CHERI:    SH1ADDY.UW
-:SH1ADD_UW_CHERI_LC: sh1addy.uw
-:SH2ADD_UW_CHERI:    SH2ADDY.UW
-:SH2ADD_UW_CHERI_LC: sh2addy.uw
-:SH3ADD_UW_CHERI:    SH3ADDY.UW
-:SH3ADD_UW_CHERI_LC: sh3addy.uw
-:SH4ADD_UW_CHERI:    SH4ADDY.UW
-:SH4ADD_UW_CHERI_LC: sh4addy.uw
-:ADD_UW_CHERI:       ADDY.UW
-:ADD_UW_CHERI_LC:    addy.uw
+:SH1ADD_UW_CHERI:    YSH1ADD.UW
+:SH1ADD_UW_CHERI_LC: ysh1add.uw
+:SH2ADD_UW_CHERI:    YSH2ADD.UW
+:SH2ADD_UW_CHERI_LC: ysh2add.uw
+:SH3ADD_UW_CHERI:    YSH3ADD.UW
+:SH3ADD_UW_CHERI_LC: ysh3add.uw
+:SH4ADD_UW_CHERI:    YSH4ADD.UW
+:SH4ADD_UW_CHERI_LC: ysh4add.uw
+:ADD_UW_CHERI:       YADD.UW
+:ADD_UW_CHERI_LC:    yadd.uw
 
-:SH1ADD_UW_CHERI:    SH1ADDY.UW
-:SH1ADD_UW_CHERI_LC: sh1addy.uw
-:SH2ADD_UW_CHERI:    SH2ADDY.UW
-:SH2ADD_UW_CHERI_LC: sh2addy.uw
-:SH3ADD_UW_CHERI:    SH3ADDY.UW
-:SH3ADD_UW_CHERI_LC: sh3addy.uw
-:SH4ADD_UW_CHERI:    SH4ADDY.UW
-:SH4ADD_UW_CHERI_LC: sh4addy.uw
-:ADD_UW_CHERI:       ADDY.UW
-:ADD_UW_CHERI_LC:    addy.uw
+:SH1ADD_UW_CHERI:    YSH1ADD.UW
+:SH1ADD_UW_CHERI_LC: ysh1add.uw
+:SH2ADD_UW_CHERI:    YSH2ADD.UW
+:SH2ADD_UW_CHERI_LC: ysh2add.uw
+:SH3ADD_UW_CHERI:    YSH3ADD.UW
+:SH3ADD_UW_CHERI_LC: ysh3add.uw
+:SH4ADD_UW_CHERI:    YSH4ADD.UW
+:SH4ADD_UW_CHERI_LC: ysh4add.uw
+:ADD_UW_CHERI:       YADD.UW
+:ADD_UW_CHERI_LC:    yadd.uw
 
 :LD_ST_DOT_CAP:           .Y
 :ld_st_dot_cap_lc:        .y

--- a/src/cheri/insns/auipc_32bit.adoc
+++ b/src/cheri/insns/auipc_32bit.adoc
@@ -73,20 +73,20 @@ NOTE: Future extensions that add instructions with similar semantics
 
 NOTE: It is possible for the compiler to generate code that is compatible with any AUIPC shift by emitting a AUIPC with a zero offset followed by a sequence of LUI and <<CADD>>/<<CADDI>>.
 
-// The compiler (and maybe assembler) can always (inefficiently!) articulate the 12-bit shift semantics of AUIPC %0, n; ADDIY %0, %0, m in a way that does not depend on the AUIPC shift and guarantees not going OOB -- that is, oblivious to representation concerns -- by using a temporary register (%1) and emitting (for positive n, without loss of generality; the negative case is similar):
+// The compiler (and maybe assembler) can always (inefficiently!) articulate the 12-bit shift semantics of AUIPC %0, n; YADDI %0, %0, m in a way that does not depend on the AUIPC shift and guarantees not going OOB -- that is, oblivious to representation concerns -- by using a temporary register (%1) and emitting (for positive n, without loss of generality; the negative case is similar):
 //
 // AUIPC %0, 0
 //
 //   ; if m < 0, step 2Ki shorter than AUIPC would have taken us
 // LUI %1, (m >= 0) ? n : (n - 1)  ; other sequences possible for small n.
-// ADDY %0, %0, %1                 ; this gets us "most of" the way to (n << 12) + m.
+// YADD %0, %0, %1                 ; this gets us "most of" the way to (n << 12) + m.
 //
 //   ; if m < 0, reach upwards from 2 Ki shy of where 12-bit AUIPC would have taken us
-// ADDIY %0, %0, ((m >= 0) ? m : (0x1000 - m))
+// YADDI %0, %0, ((m >= 0) ? m : (0x1000 - m))
 //
 // Proof sketch: Assume n > 0 throughout. AUIPC n is used only when the cap in pc has at least (n - 1) * 2 KiB of in-bounds addresses above the current offset, because the expected counterparts of AUIPC (ADDI and loads and stores) use signed 12-bit displacements.
 // That is, AUIPC n may "overshoot" the intended target by up to 2 KiB, the furthest negative reach of these displacements. Put differently, in the integer base, AUIPC %0, n; ADDI %0, %0, m leaves %0 displaced from pc by at minimum n * 2 Ki - 2 Ki or (n - 1) * 2 Ki (when m = 0x800) and at most (n - 1) * 2 Ki + (2 Ki - 1) or n * 2 Ki - 1 (when m = 0x7FF).
-// To reach the same set of targets while remaining in bounds, we need to step in the same direction: one, LUI (n - 1); ADDY, that gets us (n - 1) * 2 KiB of the way, and the other that gets us the last bit of the way there.
+// To reach the same set of targets while remaining in bounds, we need to step in the same direction: one, LUI (n - 1); YADD, that gets us (n - 1) * 2 KiB of the way, and the other that gets us the last bit of the way there.
 //
-// In practice, of course, the toolchain may be able to fold the last ADDYI into the counterpart/subsequent instructions, and may be able to reuse the intermediate result (from ADDY) just like existing toolchains.
+// In practice, of course, the toolchain may be able to fold the last YADDI into the counterpart/subsequent instructions, and may be able to reuse the intermediate result (from YADD) just like existing toolchains.
 // (CHERIoT making its AUIPC shift 11 means that we can always guarantee that the first step is in bounds, and our toolchain picks the correspondingly different immediates to its AUIPC and counterpart instructions.)


### PR DESCRIPTION
This suggestion makes sense since using the Y prefix is more consistent with VADD vs ADDIW. The operation the RVY ADD does is actually slightly different: it operates only on the lower XLEN bits+rep check, and is not a YLEN wide add operation as would be the case for ADD(I)Y. Make the same change for the SH*ADD instruction as well.