### PR TITLE
Fix YTOPR description

### DIFF
--- a/src/cheri/insns/gctop_32bit.adoc
+++ b/src/cheri/insns/gctop_32bit.adoc
@@ -18,7 +18,7 @@ Encoding::
 include::wavedrom/gctop.adoc[]
 
 Description::
-Decode the base integer address from `{cs1}` 's bounds and write the result to `rd`.
+Decode the top integer address from `{cs1}` 's bounds, saturated to 2^MXLEN^-1, and write the result to `rd`.
 +
 include::malformed_return_0.adoc[]
 +


### PR DESCRIPTION
YTOPR referred to the base and didn't mention saturation.
This is what was intended, so no change, just fixing the doc.
