### PR TITLE
ARC cleanup including renaming hybrid modes and M-bit->P-bit

### DIFF
--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -116,7 +116,7 @@ include::{generated_dir}/new_instructions_table_body.adoc[]
 . 0.9.5 had SH[123]ADD, and the .UW forms, replaced by capability versions.
 .. This is no longer the case, so now the capability versions have new encodings.
 . There is no longer an SH4ADD instruction (i.e., the integer version).
-. The <<{SENTRY}>> instruction is now in a separate extension {rvy_sentry_insn_ext_name}.
+. The <<{SENTRY}>> instruction is now in a separate extension Zysentry.
 
 ====
 

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -118,8 +118,8 @@ endif::support_varxlen[]
 :ctag_cap:   Capability tag
 :ctag_title: Capability Tag
 
-:cheri_int_mode_name: pass:quotes[_(Non-CHERI) Address Mode_]
-:cheri_cap_mode_name: pass:quotes[_(CHERI) Capability Mode_]
+:cheri_int_mode_name: pass:quotes[_Pointer Mode_]
+:cheri_cap_mode_name: pass:quotes[_Capability Mode_]
 
 :c_cheri_base_ext_names:   C or Zca, {cheri_base_ext_name}
 :c_cheri_default_ext_names: C or Zca, {cheri_default_ext_name}

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -29,12 +29,6 @@ endif::support_varxlen[]
 
 // 32-bit encodings added by RVY
 :rvy_file_name:            {cheri_base_ext_name}_insns_table_body
-// 32-bit encoding for YSENTRY
-:rvy_sentry_insn_ext_name:      Zysentry
-:rvy_sentry_insn_file_name:     {rvy_sentry_insn_ext_name}_insns_table_body
-// 32-bit encoding for YBLD
-:rvy_bld_insn_ext_name:      Zybld
-:rvy_bld_insn_file_name:     {rvy_bld_insn_ext_name}_insns_table_body
 // 32-bit encodings modified by RVY
 :rvy_i_mod_ext_name:       RVI ({cheri_base_ext_name} modified behavior)
 :rvy_i_mod_file_name:      {cheri_base_ext_name}_I_mod_insns_table_body

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -118,7 +118,7 @@ endif::support_varxlen[]
 :ctag_cap:   Capability tag
 :ctag_title: Capability Tag
 
-:cheri_int_mode_name: pass:quotes[_Pointer Mode_]
+:cheri_int_mode_name: pass:quotes[_Address Mode_]
 :cheri_cap_mode_name: pass:quotes[_Capability Mode_]
 
 :c_cheri_base_ext_names:   C or Zca, {cheri_base_ext_name}

--- a/src/cheri/cheri_csr_tables.adoc
+++ b/src/cheri/cheri_csr_tables.adoc
@@ -44,8 +44,8 @@ include::{generated_dir}/csr_alias_action_table_body.adoc[]
 
 XLEN bits of extended YLEN-wide CSRs are written when executing
 <<CSRRWI_CHERI>>, <<CSRRC_CHERI>>, <<CSRRS_CHERI>>, <<CSRRCI_CHERI>> or <<CSRRSI_CHERI>> regardless of the
-CHERI execution mode. When using <<CSRRW_CHERI>>, YLEN bits are written when the
-CHERI execution mode is {cheri_cap_mode_name} and XLEN bits are written when
+CHERI Execution Mode. When using <<CSRRW_CHERI>>, YLEN bits are written when the
+CHERI Execution Mode is {cheri_cap_mode_name} and XLEN bits are written when
 the mode is {cheri_int_mode_name}; therefore, writing XLEN bits with <<CSRRW_CHERI>>
 is only possible when {cheri_default_ext_name} is implemented.
 
@@ -58,8 +58,8 @@ include::{generated_dir}/new_csr_write_action_table_body.adoc[]
 
 XLEN bits of YLEN-wide CSRs added in {cheri_default_ext_name} are
 written when executing <<CSRRWI_CHERI>>, <<CSRRC_CHERI>>, <<CSRRS_CHERI>>, <<CSRRCI_CHERI>> or
-<<CSRRSI_CHERI>> regardless of the CHERI execution mode. YLEN bits are always written
-when using <<CSRRW_CHERI>> regardless of the CHERI execution mode.
+<<CSRRSI_CHERI>> regardless of the CHERI Execution Mode. YLEN bits are always written
+when using <<CSRRW_CHERI>> regardless of the CHERI Execution Mode.
 
 NOTE: Implementations which allow misa.C to be writable need to legalize `__x__epc`
  on _reading_ if the misa.C value has changed since the value was written as this

--- a/src/cheri/cheri_isa_tables.adoc
+++ b/src/cheri/cheri_isa_tables.adoc
@@ -39,30 +39,6 @@ In general, this is restricted to changing whether input/output operands read/wr
 include::{generated_dir}/{rvy_zicsr_mod_file_name}.adoc[]
 |==============================================================================
 
-[#rvy_sentry_insn_table, reftext="{rvy_sentry_insn_ext_name}"]
-=== {rvy_sentry_insn_ext_name}
-
-{rvy_sentry_insn_ext_name} adds the {SENTRY} instruction.
-
-.{rvy_sentry_insn_ext_name} instruction extension
-[#{rvy_sentry_insn_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_sentry_insn_file_name}.adoc[]
-|==============================================================================
-
-[#rvy_bld_insn_table, reftext="{rvy_bld_insn_ext_name}"]
-=== {rvy_bld_insn_ext_name}
-
-{rvy_bld_insn_ext_name} adds the {CBLD} instruction.
-
-.{rvy_bld_insn_ext_name} instruction extension
-[#{rvy_bld_insn_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_bld_insn_file_name}.adoc[]
-|==============================================================================
-
 ifndef::cheri_ratification_v1_only[]
 
 [#rvy_bndsrdw_insn_table, reftext="{rvy_bndsrdw_insn_ext_name}"]

--- a/src/cheri/csv/CHERI_CSR.csv
+++ b/src/cheri/csv/CHERI_CSR.csv
@@ -4,30 +4,30 @@ Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply
 direct write if address didn't change","✔","","✔","Sdext","Debug Program Counter Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "dscratch0_y","0x7b2","dscratch0","D","DRW","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","Sdext","Debug Scratch Capability 0","v1","","","","","","","","","","","","","","","","","","","",""
 "dscratch1_y","0x7b3","dscratch1","D","DRW","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","Sdext","Debug Scratch Capability 1","v1","","","","","","","","","","","","","","","","","","","",""
+"mscratch_y","0x340","mscratch","M","MRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","M-mode","Machine Scratch Capability","v1","","","","","","","","","","","","","","","","","","","",""
+"sscratch_y","0x140","sscratch","S","SRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","S-mode","Supervisor Scratch Capability","v1","","","","","","","","","","","","","","","","","","","",""
+"vsscratch_y","0x240","vsscratch","VS","HRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","H","Virtual Supervisor Scratch Capability","post-v1","","","","","","","","","","","","","","","","","","","",""
 "mtvec_y","0x305","mtvec","M","MRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","✔","","","M-mode","Machine Trap-Vector Base-Address Capability","v1","","","","","","","","","","","","","","","","","","","",""
-"mscratch_y","0x340","mscratch","M","MRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","M-mode","Machine Scratch Capability","v1","","","","","","","","","","","","","","","","","","","",""
-"mepc_y","0x341","mepc","M","MRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
-Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
-direct write if address didn't change","✔","","✔","M-mode","Machine Exception Program Counter Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "stvec_y","0x105","stvec","S","SRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","✔","","","S-mode","Supervisor Trap-Vector Base-Address Capability","v1","","","","","","","","","","","","","","","","","","","",""
-"sscratch_y","0x140","sscratch","S","SRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","S-mode","Supervisor Scratch Capability","v1","","","","","","","","","","","","","","","","","","","",""
-"sepc_y","0x141","sepc","S","SRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
-Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
-direct write if address didn't change","✔","","✔","S-mode","Supervisor Exception Program Counter Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "vstvec_y","0x205","vstvec","VS","HRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change, including the MODE field in the address for simplicity.
 Vector range check ^*^ if vectored mode is programmed.","✔","","","H","Virtual Supervisor Trap-Vector Base-Address Capability","post-v1","","","","","","","","","","","","","","","","","","","",""
-"vsscratch_y","0x240","vsscratch","VS","HRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","H","Virtual Supervisor Scratch Capability","post-v1","","","","","","","","","","","","","","","","","","","",""
+"mepc_y","0x341","mepc","M","MRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
+Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
+direct write if address didn't change","✔","","✔","M-mode","Machine Exception Program Counter Capability","v1","","","","","","","","","","","","","","","","","","","",""
+"sepc_y","0x141","sepc","S","SRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
+Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
+direct write if address didn't change","✔","","✔","S-mode","Supervisor Exception Program Counter Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "vsepc_y","0x241","vsepc","VS","HRW, <<asr_perm>>","Nominally <<root-rx-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","✔","H","Virtual Supervisor Exception Program Counter Capability","post-v1","","","","","","","","","","","","","","","","","","","",""
@@ -42,7 +42,7 @@ Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply
 direct write if address didn't change","","✔","","{cheri_default_ext_name}","User Default Data Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "drootcsel","0x7ba","","D","DRW","0","Ignore","Ignore","","","","Sdext","Multiplexing selector for <<drootc>>","v1","","","","","","","","","","","","","","","","","","","",""
 "drootc","0x7bd","","D","DRW","nominally <<root-rx-cap>>","Ignore","Ignore","","","","Sdext","Source of authority in debug mode, writes are ignored","v1","","","","","","","","","","","","","","","","","","","",""
-"utidc","0x480","","U","Read: U, Write: U, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","User thread ID","v1","","","","","","","","","","","","","","","","","","","",""
-"stidc","0x580","","S","Read: S, Write: S, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Supervisor thread ID","v1","","","","","","","","","","","","","","","","","","","",""
-"vstidc","0xA80","","H","Read: VS, Write: VS, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Virtual supervisor thread ID","post-v1","","","","","","","","","","","","","","","","","","","",""
 "mtidc","0x780","","M","Read: M, Write: M, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Machine thread ID","v1","","","","","","","","","","","","","","","","","","","",""
+"vstidc","0xA80","","H","Read: VS, Write: VS, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Virtual supervisor thread ID","post-v1","","","","","","","","","","","","","","","","","","","",""
+"stidc","0x580","","S","Read: S, Write: S, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","Supervisor thread ID","v1","","","","","","","","","","","","","","","","","","","",""
+"utidc","0x480","","U","Read: U, Write: U, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","direct write","","","","{cheri_base_ext_name}","User thread ID","v1","","","","","","","","","","","","","","","","","","","",""

--- a/src/cheri/csv/CHERI_ISA.csv
+++ b/src/cheri/csv/CHERI_ISA.csv
@@ -18,9 +18,9 @@ AUIPC_CHERI,AUIPCC,{rvy_i_mod_ext_name},✔,✔,,,,AUIPC,,,{AUIPC_CHERI_DESC},,,
 {SCHI_BASE},N/A,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCHI_BASE_DESC},,,,,,,,,v1
 {SCHI},SCHI,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCHI_DESC},,,,,,,,,v1
 {SCEQ},SCEQ,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCEQ_DESC},,,,,,,,,v1
-{SENTRY},SENTRY,{rvy_sentry_insn_ext_name},✔,✔,,,OP,R-type,,,{SENTRY_DESC},,,,,,,,,v1
+{SENTRY},SENTRY,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SENTRY_DESC},,,,,,,,,v1
 {SCSS},SCSS,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCSS_DESC},,,,,,,,,v1
-{CBLD},CBLD,{rvy_bld_insn_ext_name},✔,✔,,,OP,R-type,,,{CBLD_DESC},,,,,,,,,v1
+{CBLD},CBLD,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{CBLD_DESC},,,,,,,,,v1
 {YSUNSEAL},N/A,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{YSUNSEAL_DESC},,,,,,,,,v1
 {SCBNDS},SCBNDS,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCBNDS_DESC},,,,,,,,,v1
 {SCBNDSI},SCBNDSI,{cheri_base_ext_name},✔,✔,,,OP,I-type,,,{SCBNDSI_DESC},,,,,,,,,v1

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -192,13 +192,13 @@ It exposes the capability selected by <<drootcsel>>.
 If {cheri_default_ext_name} is implemented,
 the <<root-rx-cap>> exposed when <<drootcsel>> is `0` is further specified as follows:
 
-* The <<m_bit>> is reset to {cheri_int_mode_name} ({INT_MODE_VALUE}).
-* The debugger can set the <<m_bit>> to {cheri_cap_mode_name} ({CAP_MODE_VALUE}) by executing <<MODESW_CAP>> from the program buffer.
-** Executing <<MODESW_CAP>> causes execution of subsequent instructions from the program buffer, starting from the next instruction, to be executed in {cheri_cap_mode_name}. It also sets the CHERI execution mode to {cheri_cap_mode_name} on future entry into debug mode.
+* The <<p_bit>> is reset to {cheri_int_mode_name} ({INT_MODE_VALUE}).
+* The debugger can set the <<p_bit>> to {cheri_cap_mode_name} ({CAP_MODE_VALUE}) by executing <<MODESW_CAP>> from the program buffer.
+** Executing <<MODESW_CAP>> causes execution of subsequent instructions from the program buffer, starting from the next instruction, to be executed in {cheri_cap_mode_name}. It also sets the CHERI Execution Mode to {cheri_cap_mode_name} on future entry into debug mode.
 ** Therefore to enable use of a CHERI debugger, a single <<MODESW_CAP>> only needs to be executed once from the program buffer after resetting the core.
-** The debugger can also execute <<MODESW_INT>> to change the mode back to {cheri_int_mode_name}, which also affects the execution of the next instruction in the program buffer, updates the <<m_bit>> of this capability and controls which CHERI execution mode to enter on the next entry into debug mode.
+** The debugger can also execute <<MODESW_INT>> to change the mode back to {cheri_int_mode_name}, which also affects the execution of the next instruction in the program buffer, updates the <<p_bit>> of this capability and controls which CHERI Execution Mode to enter on the next entry into debug mode.
 
-The <<m_bit>> of this capability is _only_ updated by executing <<MODESW_CAP>> or <<MODESW_INT>> from the program buffer.
+The <<p_bit>> of this capability is _only_ updated by executing <<MODESW_CAP>> or <<MODESW_INT>> from the program buffer.
 
 .Debug root capability register
 include::img/drootcreg.edn[]
@@ -217,7 +217,7 @@ shown in xref:default-csrnames-added[xrefstyle=short].
 {cheri_default_ext_name} allows <<MODESW_CAP>> and <<MODESW_INT>> to execute in debug mode.
 
 When entering debug mode, whether the core enters {cheri_int_mode_name} or
-{cheri_cap_mode_name} is controlled by the <<m_bit>> in the <<drootc>> capability selected by <<drootcsel>> value 0.
+{cheri_cap_mode_name} is controlled by the <<p_bit>> in the <<drootc>> capability selected by <<drootcsel>> value 0.
 
 The current mode can be read by setting <<drootcsel>> to `0` and then reading <<drootc>>.
 

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -174,7 +174,7 @@ The new TID bit controls access to the <<stidc>> (really <<vstidc>>) CSR.
 
 Hypervisor virtual-machine load (<<HLV_CAP>>) and store (<<HSV_CAP>>)
 instructions read or write YLEN bits from memory as though V=1. These
-instructions change behavior depending on the CHERI execution mode although
+instructions change behavior depending on the CHERI Execution Mode although
 the instruction's encoding remains unchanged.
 
 When in {cheri_cap_mode_name}, the hypervisor

--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -21,10 +21,13 @@ include::wavedrom/cbld.adoc[]
 
 Description::
 Copy `{cs2}` to `{cd}`.
+ifndef::cheri_ratification_v1_only[]
 +
+// This only applies once we include non-ambient otypes
 If `{cd}.ct` (that is, its <<sec_cap_type>>) is
 neither 0 nor an <<sec_cap_type_ambient,ambient>> type, then
 set `{cd}.ct` to 0.
+endif::[]
 +
 Set `{cd}.tag=1` if:
 +
@@ -39,18 +42,21 @@ Otherwise, set `{cd}.tag=0`
 
 NOTE: The <<section_cap_integrity,integrity>> check on `{cs2}` is required to prevent authorising a capability with a lack of integrity.
  The <<section_cap_integrity,integrity>> check on `{cs1}` is optional.
-
+ifndef::cheri_ratification_v1_only[]
 NOTE: <<CBLD>> will construct a sealed capability only if its type is <<sec_cap_type_ambient,ambiently available>>.
+endif::[]
 
 NOTE: <<CBLD>> is typically used alongside <<SCHI>> to build
 capabilities from integer values.
+
+NOTE: <<CBLD>> can be used to speed up operations such as paging in memory after swap.
 
 NOTE: When `{cs1}` is `{creg}0` <<CBLD>> will copy `{cs2}` to `{cd}` and clear `{cd}.tag`.
 However future extensions may add additional behavior to update currently reserved fields,
 and so software should not assume `{cs1}==0` to be a pseudo-instruction for {ctag} clearing.
 
 Included in::
-<<rvy_bld_insn_table>>
+<<rvy_insn_table>>
 
 Operation::
 +

--- a/src/cheri/insns/cbo.zero.adoc
+++ b/src/cheri/insns/cbo.zero.adoc
@@ -25,7 +25,7 @@ Description::
 A `cbo.zero` instruction performs stores of zeros to the full set of bytes
 corresponding to the cache block whose effective address is the base address
 specified in `{cs1}`. An implementation may or may not update the entire set of
-bytes atomically although each individual write must atomically clear the {ctag}
+bytes atomically although each individual write must atomically set the {ctag} to zero
 bit of the corresponding aligned YLEN-bit location. The authorizing capability
 for this instruction is `{cs1}`.
 

--- a/src/cheri/insns/gcmode_32bit.adoc
+++ b/src/cheri/insns/gcmode_32bit.adoc
@@ -13,14 +13,14 @@ Encoding::
 include::wavedrom/gcmode.adoc[]
 
 Description::
-Decode the CHERI execution mode from the capability in `{cs1}` and write the
+Decode the CHERI Execution Mode from the capability in `{cs1}` and write the
 result to `rd`.
 +
 Set `rd` to 0 if `{cs1}` does not grant <<x_perm>>
 +
 Set `rd` to 0 if any <<section_cap_integrity,integrity>> checks failed.
 +
-Otherwise set `rd` according to `{cs1}` 's CHERI execution mode (<<m_bit>>):
+Otherwise set `rd` according to `{cs1}` 's CHERI Execution Mode (<<p_bit>>):
 +
 1. Set `rd` to {CAP_MODE_VALUE} for {cheri_cap_mode_name}, or,
 +

--- a/src/cheri/insns/int_mode_remapping_pcc.adoc
+++ b/src/cheri/insns/int_mode_remapping_pcc.adoc
@@ -1,1 +1,1 @@
-_If {cheri_default_ext_name} is implemented and the CHERI execution mode is {cheri_int_mode_name} then the base address is `rs1` and the authorizing capability is <<pcc>>._
+_If {cheri_default_ext_name} is implemented and the CHERI Execution Mode is {cheri_int_mode_name} then the base address is `rs1` and the authorizing capability is <<pcc>>._

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -14,33 +14,41 @@ include::wavedrom/ct-unconditional-2.adoc[]
 
 include::base_isa_extension.adoc[]
 
-
 Description::
 Indirect jump to the target capability in `{cs1}` with an address offset.
 +
+ifndef::cheri_ratification_v1_only[]
 NOTE: The  description below contains three hooks for extending <<JALR_CHERI>> behavior, used by extensions to give a large degree of extensibility.
- Unless an extension, such as <<section_rvy_sentry_insn_ext>>, is implemented which explicitly reference any of the hooks, then take no action for any of them.
+ Unless an instruction, such as <<SENTRY>>, is implemented which explicitly reference any of the hooks, then take no action for any of them.
 +
+endif::[]
 Operationally, copy `{cs1}` to the target <<pcc>> and then...
 +
 . Compute the target <<pcc>> address in two steps, each using the semantics of the <<SCADDR>> instruction:
 .. Increment the address of the target <<pcc>> by the sign-extended 12-bit `offset`, and
 .. set bit zero of the target <<pcc>> address to zero.
+ifndef::cheri_ratification_v1_only[]
 . HOOK 1: Optionally clear the {ctag} of the target <<pcc>> depending on the <<sec_cap_type>> value and the numerical values of `{cd}` and `{cs1}`
-. Unseal the target <<pcc>> if it is a <<sentry_cap>>, or clear the {ctag} if it is any other sealed type.
+endif::[]
+. Unseal the target <<pcc>> if it is a <<sentry_cap>>.
+ifndef::cheri_ratification_v1_only[]
+. Clear the {ctag} of the target <<pcc>> if it is any other sealed type.
+endif::[]
 . If `{cd}≠{creg}0`, compute the return capability and install it to `{cd}`:
-.. add the width of this instruction to the current <<pcc>> using the semantics of the <<SCADDR>> instructions, and
+.. add the width of this instruction to the current <<pcc>> using the semantics of the <<SCADDR>> instruction, and
+ifndef::cheri_ratification_v1_only[]
 .. HOOK 2: Optionally seal the return capability as a <<sentry_cap>> with a <<sec_cap_type>> defined by the implemented extensions.
 . HOOK 3: Optionally make other architectural state updates.
+endif::[]
 . Jump to the target <<pcc>>.
 +
-[NOTE]
-=====
-When a sealed capability is passed as the input to <<JALR_CHERI>>, its address must have bit zero clear and the instruction must have a zero offset, or the target <<pcc>> will have its {ctag} set to zero, since updates to its address are interpreted with <<SCADDR>> semantics.
-=====
+NOTE: Future {cheri_base_ext_name} extensions are permitted to introduce additional restrictions on the behaviour of JALR, by extending the number of available values in the <<sec_cap_type>> field in the capability encoding format.
+ One such example is CHERIoT differentiating between a forward and backward edge <<sentry_cap>>.
++
+NOTE: When any sealed capability is passed as the input to <<JALR_CHERI>>, its address must have bit zero clear and the instruction must have a zero offset, or the target <<pcc>> will have its {ctag} set to zero, since updates to its address are interpreted with the semantics of the <<SCADDR>> instruction.
+ As such, a <<sentry_cap>> defines a secure function entry point, and as such the offset in the JALR instruction must be zero.
++
 NOTE: A future extension may raise an exception on the <<JALR_CHERI>> instruction itself if the target <<pcc>> will raise a {cheri_excep_name_pc} at the target.
-NOTE: A sentry defines a secure function entry point, and as such the offset in the JALR instruction must be zero.
- This is enforced by the use of <<SCADDR>> to add the offset which clears the tag of all sealed capabilities if the offset is non-zero.
 
 Included in::
 <<rvy_i_mod_insn_table>>

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -28,11 +28,11 @@ Operationally, copy `{cs1}` to the target <<pcc>> and then...
 .. Increment the address of the target <<pcc>> by the sign-extended 12-bit `offset`, and
 .. set bit zero of the target <<pcc>> address to zero.
 ifndef::cheri_ratification_v1_only[]
-. HOOK 1: Optionally clear the {ctag} of the target <<pcc>> depending on the <<sec_cap_type>> value and the numerical values of `{cd}` and `{cs1}`
+. HOOK 1: Optionally set the {ctag} to zero of the target <<pcc>> depending on the <<sec_cap_type>> value and the numerical values of `{cd}` and `{cs1}`
 endif::[]
 . Unseal the target <<pcc>> if it is a <<sentry_cap>>.
 ifndef::cheri_ratification_v1_only[]
-. Clear the {ctag} of the target <<pcc>> if it is any other sealed type.
+. Set the {ctag} to zero of the target <<pcc>> if it is any other sealed type.
 endif::[]
 . If `{cd}≠{creg}0`, compute the return capability and install it to `{cd}`:
 .. add the width of this instruction to the current <<pcc>> using the semantics of the <<SCADDR>> instruction, and

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -26,7 +26,7 @@ If the PMA is _CHERI {ctag_title}_ then load the associated {ctag}, otherwise se
 +
 The {ctag} may also be cleared under platform specified conditions.
 +
-NOTE: Extensions may also specify conditions which clear the {ctag}.
+NOTE: Extensions may also specify conditions which set the {ctag} to zero.
 +
 Use the YLEN-bit data and the {ctag} to determine the value of `{cd}` as specified below.
 +

--- a/src/cheri/insns/modesw_32bit.adoc
+++ b/src/cheri/insns/modesw_32bit.adoc
@@ -18,10 +18,10 @@ Encoding::
 include::wavedrom/modesw_32bit.adoc[]
 
 Description::
-Set the current CHERI execution mode in <<pcc>>.
+Set the current CHERI Execution Mode in <<pcc>>.
 +
-* {MODESW_CAP}: If the current mode in <<pcc>> is {cheri_int_mode_name} ({INT_MODE_VALUE}), then the <<m_bit>> in <<pcc>> is set to {cheri_cap_mode_name} ({CAP_MODE_VALUE}). Otherwise no effect.
-* {MODESW_INT}: If the current mode in <<pcc>> is {cheri_cap_mode_name} ({CAP_MODE_VALUE}), then the <<m_bit>> in <<pcc>> is set to {cheri_int_mode_name} ({INT_MODE_VALUE}). Otherwise no effect.
+* {MODESW_CAP}: If the current mode in <<pcc>> is {cheri_int_mode_name} ({INT_MODE_VALUE}), then the <<p_bit>> in <<pcc>> is set to {cheri_cap_mode_name} ({CAP_MODE_VALUE}). Otherwise no effect.
+* {MODESW_INT}: If the current mode in <<pcc>> is {cheri_cap_mode_name} ({CAP_MODE_VALUE}), then the <<p_bit>> in <<pcc>> is set to {cheri_int_mode_name} ({INT_MODE_VALUE}). Otherwise no effect.
 
 Included in::
 <<rvy_hybrid_insn_table>>

--- a/src/cheri/insns/scmode_32bit.adoc
+++ b/src/cheri/insns/scmode_32bit.adoc
@@ -24,7 +24,7 @@ Copy `{cs1}` to `{cd}`.
 +
 If `{cs1}` is sealed or if `{cs1}` fails any <<section_cap_integrity,integrity>> check, then set `{cd}.tag=0`.
 +
-Otherwise, if `{cs1}` grants <<x_perm>> then update the <<m_bit>> of `{cd}` to:
+Otherwise, if `{cs1}` grants <<x_perm>> then update the <<p_bit>> of `{cd}` to:
 +
 1. {cheri_cap_mode_name} if the least significant bit of `rs2` is {CAP_MODE_VALUE}, or,
 +

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -20,13 +20,17 @@ Description::
 Copy `{cs1}` to `{cd}`.
 +
 Set the capability type (<<sec_cap_type>>) of `{cd}` to
-the <<sec_cap_type_ambient,ambient>> value specified by the capability encoding
-given the permissions granted by the capability in `{cs1}`.
+ifdef::cheri_ratification_v1_only[]
+the value `1`, representing a sentry type.
+endif::[]
+ifndef::cheri_ratification_v1_only[]
+the <<sec_cap_type_ambient,ambient>> value specified by the capability encoding given the permissions granted by the capability in `{cs1}`.
+endif::[]
 +
 Set `{cd}.tag=0` if `{cs1}` is sealed.
 
 Included in::
-<<rvy_sentry_insn_table>>
+<<rvy_insn_table>>
 
 Operation::
 +

--- a/src/cheri/insns/yseal_32bit.adoc
+++ b/src/cheri/insns/yseal_32bit.adoc
@@ -55,7 +55,7 @@ That is, some encodings may be able to represent
 a valid capability with a given non-zero <<sec_cap_type>>
 only if other properties of that capability hold,
 such as it granting, or not granting, a particular permission.
-As such, {YSEAL} may clear the {ctag} of the result in `{cd}`
+As such, {YSEAL} may set the {ctag} to zero of the result in `{cd}`
 depending on these other aspects of its `{cs2}` input,
 even if some capabilities can be sealed with
 the type called for by the address of `{cs1}`.

--- a/src/cheri/insns/yseal_32bit.adoc
+++ b/src/cheri/insns/yseal_32bit.adoc
@@ -17,7 +17,7 @@ Construct, into `{cd}`, a sealed copy of the unsealed capability in `{cs2}`, usi
 +
 Copy `{cs2}` into `{cd}`, and then...
 +
-. Clear the {ctag} of the capability in `{cd}` if any of the following hold:
+. Set the {ctag} to zero of the capability in `{cd}` if any of the following hold:
 +
 --
 - `{cs2}` is sealed (has a non-zero <<sec_cap_type>> value)

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -24,7 +24,7 @@ Set `{cd}.tag=1` if:
 . `{cs1}.tag=1`, and
 . `{cs1}` passes all <<section_cap_integrity,integrity>> checks, and
 . `{cs1}` is not sealed (that is, `{cs1}` has zero <<sec_cap_type>>), and
-. `{cs2}.tag` is set, and
+. `{cs2}.tag=1`, and
 . `{cs2}` passes all <<section_cap_integrity,integrity>> checks, and
 . `{cs2}` is sealed (that is, `{cs2}` has non-zero <<sec_cap_type>>), and
 . `{cs2}` 's permissions and bounds are equal to or a subset of `{cs1}` 's, and

--- a/src/cheri/insns/yunseal_32bit.adoc
+++ b/src/cheri/insns/yunseal_32bit.adoc
@@ -17,7 +17,7 @@ Construct, into `{cd}`, an unsealed copy of the capability in `{cs2}`, using the
 +
 Copy `{cs2}` into `{cd}`, and then...
 +
-. Clear the {ctag} of the capability in `{cd}` if any of the following hold:
+. Set the {ctag} to zero of the capability in `{cd}` if any of the following hold:
 +
 --
 - `{cs1}` has a clear `{ctag}`

--- a/src/cheri/insns/zcm_common.adoc
+++ b/src/cheri/insns/zcm_common.adoc
@@ -1,1 +1,1 @@
-_If Zcherihybrid is implemented and the CHERI execution mode is {cheri_int_mode_name} then the table access is checked against <<pcc>> bounds_.
+_If Zcherihybrid is implemented and the CHERI Execution Mode is {cheri_int_mode_name} then the table access is checked against <<pcc>> bounds_.

--- a/src/cheri/insns/zcmt_cmjalt.adoc
+++ b/src/cheri/insns/zcmt_cmjalt.adoc
@@ -29,7 +29,7 @@ Redirect instruction fetch via the jump table defined by the indexing via `jvt.a
 +
 The target <<pcc>> is calculated by replacing the current <<pcc>> address with the value read from the jump table, and is updated using the semantics of the <<SCADDR>> instruction.
 +
-If the <<jvt_y>> check fails, then clear the {ctag} of the target <<pcc>>.
+If the <<jvt_y>> check fails, then set the {ctag} to zero of the target <<pcc>>.
 
 include::zcm_common.adoc[]
 

--- a/src/cheri/insns/zcmt_cmjt.adoc
+++ b/src/cheri/insns/zcmt_cmjt.adoc
@@ -29,7 +29,7 @@ Redirect instruction fetch via the jump table defined by the indexing via `jvt.a
 +
 The target <<pcc>> is calculated by replacing the current <<pcc>> address with the value read from the jump table, and is updated using the semantics of the <<SCADDR>> instruction.
 +
-If the <<jvt_y>> check fails, then clear the {ctag} of the target <<pcc>>.
+If the <<jvt_y>> check fails, then set the {ctag} to zero of the target <<pcc>>.
 
 include::zcm_common.adoc[]
 

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -58,8 +58,6 @@ cases they will have some behavioral differences and/or new instructions operati
 ifndef::cheri_ratification_v1_only[]
 |<<rv32y,RV32Y>>                                            | Base ISA additions and capability formats for RV32
 endif::[]
-|<<section_rvy_sentry_insn_ext>>                            | Ambient capability sealing instruction
-|<<section_rvy_bld_insn_ext>>                               | Extension for building capabilities
 ifndef::cheri_ratification_v1_only[]
 |<<rvy_bndsrdw_insn_ext>>                                   | Extension for setting bounds round down to representable length
 endif::[]

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -8,7 +8,9 @@ endif::[]
 {cheri_default_ext_name} is an optional extension to {cheri_base_ext_name} which adds the ability to dynamically change the base architecture of the hart between CHERI ({cheri_base_ext_name}) and standard RISC-V (RV32[IE]/RV64[IE]).
 
 The ability to choose between these two behaviors is referred to as switching between _CHERI Execution Modes_.
-The mode is controlled by a new bit allocated in the capability metadata (the <<p_bit>>) and <<p_bit>> in the <<pcc>> controls the current CHERI Execution Mode.
+The mode is controlled by a new bit allocated in the capability metadata (the <<p_bit>>) and the <<p_bit>> in the <<pcc>> controls the current CHERI Execution Mode.
+
+NOTE: The <<p_bit>> determines how pointers are represented, either as _Addresses_ or as _Capabilities_.
 
 {cheri_default_ext_name} adds the instructions shown in <<{rvy_hybrid_file_name}>> which add the ability to query and update the current mode.
 

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -5,26 +5,27 @@ ifdef::cheri_standalone_spec[]
 WARNING: This chapter will appear in the unpriv spec somewhere after the Zicsr chapter (since it depends on Zicsr).
 endif::[]
 
-{cheri_default_ext_name} is an optional extension to {cheri_base_ext_name} which adds the ability to dynamically change the base architecture of the hart between  CHERI ({cheri_base_ext_name}) and standard RISC-V (RVI/RVE).
+{cheri_default_ext_name} is an optional extension to {cheri_base_ext_name} which adds the ability to dynamically change the base architecture of the hart between CHERI ({cheri_base_ext_name}) and standard RISC-V (RV32[IE]/RV64[IE]).
 
-The ability to choose between these two behaviors is referred to as switching between _CHERI Execution Modes_. The mode is controlled by a new bit (the <<m_bit>>) allocated in the <<pcc>>.
+The ability to choose between these two behaviors is referred to as switching between _CHERI Execution Modes_.
+The mode is controlled by a new bit allocated in the capability metadata (the <<p_bit>>) and <<p_bit>> in the <<pcc>> controls the current CHERI Execution Mode.
 
-{cheri_default_ext_name} adds the instructions shown in <<rvy_hybrid_insn_table>> which add the ability to query and update the current mode.
+{cheri_default_ext_name} adds the instructions shown in <<{rvy_hybrid_file_name}>> which add the ability to query and update the current mode.
 
-{cheri_default_ext_name} also adds a new unprivileged CSR: the default data capability, <<ddc>>. <<ddc>> is used to authorize all data memory accesses when executing RVI/RVE code.
+{cheri_default_ext_name} also adds a new unprivileged CSR: the default data capability, <<ddc>> that is used to authorize all data memory accesses when executing RV32[IE]/RV64[IE] code.
 
-NOTE: Together with <<pcc>>, <<ddc>> allows confining code runs to a compartment (also called a _sandbox_), where all data memory and instruction memory accesses are bounded to fixed memory regions. These compartments have full binary compatibility with all existing ratified RISC-V base architectures and extensions, i.e., non-CHERI-aware programs that execute unmodified.
-Provided that the privileged execution environment has set up <<ddc>> and <<pcc>> appropriately, non-CHERI-aware programs will execute unmodified (as long as they don't attempt to access memory out of the defined bounds).
+NOTE: Together with <<pcc>>, <<ddc>> allows confining code runs to a compartment (also called a _sandbox_), where all data memory and instruction memory accesses are bounded to fixed memory regions. These compartments have full binary compatibility with all existing ratified RV32[IE]/RV64[IE] base ISAs and extensions, i.e., non-CHERI-aware programs that execute unmodified.
+Provided that the execution environment has set up <<ddc>> and <<pcc>> appropriately, non-CHERI-aware programs will execute unmodified (as long as they don't attempt to access memory out of the defined bounds).
 
-{cheri_base_ext_name} implementations which support {cheri_default_ext_name} are typically referred to as CHERI Hybrid, whereas implementations which do not support {cheri_default_ext_name} are typically referred to as CHERI purecap.
+{cheri_base_ext_name} implementations which support {cheri_default_ext_name} are typically referred to as CHERI Hybrid, whereas implementations which do not support {cheri_default_ext_name} are typically referred to as CHERI Purecap.
 
-[#cheri_execution_mode,reftext="CHERI Execution Mode"]
-=== CHERI Execution Modes
+[#cheri_execution_mode,reftext="CHERI Pointer Execution Mode"]
+=== CHERI Pointer Execution Modes
 
-The two execution modes are:
+The two CHERI Pointer Execution Modes are:
 
 {cheri_int_mode_name}::
-Executing with the RVI (or RVE) base ISA.
+Executing with the RV32[IE]/RV64[IE] base ISA.
 +
 NOTE: If RVC encodings are supported, load/store encodings will revert to their non-CHERI encodings, such as <<C_LOAD_CAP>> reverting to C.FSD for RV64/{cheri_base64_ext_name}.
 This behavior is summarized in
@@ -35,7 +36,7 @@ endif::[]
 +
 NOTE: Instructions which are _modified_ on an {cheri_base_ext_name} architecture (see <<{rvy_i_mod_file_name}>>) _revert to their standard behavior_.
 +
-All <<rvy_insn_table>> instructions, and associated CSRs, are available in addition to RVI/RVE and all supported non-CHERI extensions.
+All instructions listed in <<{rvy_file_name}>>, and associated CSRs, are available in addition to RV32[IE]/RV64[IE] and all supported non-CHERI extensions.
 +
 The authorizing capability for memory access is <<ddc>> (as opposed to `rs1`).
 That is, all memory accesses, including <<PREFETCH_W_CHERI>> and <<PREFETCH_R_CHERI>>, are implicitly authorized by <<ddc>> and only the memory address is sourced from `rs1`.
@@ -43,56 +44,52 @@ That is, all memory accesses, including <<PREFETCH_W_CHERI>> and <<PREFETCH_R_CH
 +
 NOTE: <<ddc>> is also used to authorize {cheri_base_ext_name} specific memory instructions such as <<LOAD_CAP>> and <<STORE_CAP>>.
 +
-All CSR accesses to YLEN CSRs only access the lower XLEN bits, and, if writing, update the CSR using the semantics of the <<SCADDR>> instruction (see xref:zicsr-section-default[xrefstyle=short]).
+NOTE: Any prefetches which fail authorization execute as nops.
++
+All CSR reads of YLEN CSRs only access the lower XLEN bits, and, writes update the CSR using the semantics of the <<SCADDR>> instruction (see xref:zicsr-section-default[xrefstyle=short]).
 
 {cheri_cap_mode_name}::
 Executing with the {cheri_base_ext_name} base ISA.
 
-The _<<cheri_execution_mode>>_ is key in providing backwards compatibility with the base RV32I/RV64I ISA.
-RISC-V software is able to execute unchanged in implementations supporting {cheri_default_ext_name} provided that the privileged environment sets up <<ddc>> and <<pcc>> appropriately.
+The _<<cheri_execution_mode>>_ is key in providing backwards compatibility with the base RV32[IE]/RV64[IE] ISAs.
+RISC-V software is able to execute unchanged in implementations supporting {cheri_default_ext_name} provided that the <<ddc>> and <<pcc>> are configured appropriately.
 
-NOTE: The CHERI execution mode is always {cheri_cap_mode_name} on implementations that support {cheri_base_ext_name}, but not {cheri_default_ext_name}.
+NOTE: The CHERI Execution Mode is always {cheri_cap_mode_name} on implementations that support {cheri_base_ext_name}, but not {cheri_default_ext_name}.
 
 [NOTE]
 ====
-Software is referred to as _purecap_ if it utilizes CHERI capabilities for all
+Software is referred to as _Purecap_ if it utilizes CHERI capabilities for all
 memory accesses -- including loads, stores and instruction fetches -- rather
 than integer addresses. Purecap software requires the CHERI RISC-V hart to
-support {cheri_base_ext_name}. Software is referred to as _hybrid_ if it uses
+support {cheri_base_ext_name}. Software is referred to as _Hybrid_ if it uses
 integer addresses *or* CHERI capabilities for memory accesses. Hybrid software
 requires the CHERI RISC-V hart to support {cheri_base_ext_name} and
 {cheri_default_ext_name}.
 ====
 
-[#m_bit,reftext="M-bit"]
+[#p_bit,reftext="P-bit"]
 ==== CHERI Execution Mode Encoding
 
-The _<<cheri_execution_mode>>_ is determined by a bit in the metadata of the <<pcc>> called the <<m_bit>>.
-{cheri_default_ext_name} adds a new _<<cheri_execution_mode>>_ field (M) to the capability format.
-This field needs to be present only in capabilities granting <<x_perm>>,
-as it is only ever architecturally interpreted on the capability resident in <<pcc>>.
+The <<p_bit>> (P) is only relevant for capabilities which grant <<x_perm>>, as it only architecturally has an effect on the <<pcc>>.
 
-NOTE: While the <<m_bit>> can also be read/written explicitly using <<GCMODE>>/<<SCMODE>>, it only affects machine state once installed into <<pcc>>.
+NOTE: While the <<p_bit>> can also be read/written explicitly using <<GCMODE>>/<<SCMODE>>, it only affects machine state once installed into <<pcc>>.
 
-Capabilities not granting <<x_perm>> may or may not have a defined M field,
+Capabilities not granting <<x_perm>> may or may not have a defined <<p_bit>> field,
 and attempting to update this field may be a no-op.
-{cheri_default_ext_name} is compatible only with capability encodings that specify transport of the M-bit (see <<rv64y_cap_description>>, for example).
+{cheri_default_ext_name} is compatible only with capability encodings that specify transport of the <<p_bit>> (see <<rv64y_cap_description>>, for example).
 
-* Mode (M)={CAP_MODE_VALUE} indicates {cheri_cap_mode_name}.
-* Mode (M)={INT_MODE_VALUE} indicates {cheri_int_mode_name}.
+* CHERI Execution Mode (P)={CAP_MODE_VALUE} indicates {cheri_cap_mode_name}.
+* CHERI Execution Mode (P)={INT_MODE_VALUE} indicates {cheri_int_mode_name}.
 
-IMPORTANT: Since indirect jumps copy the full target capability into <<pcc>>, it allows indirect jumps to change between modes (see <<sec_changing_cheri_execution_mode>>).
+NOTE: A value of {INT_MODE_VALUE} represents {cheri_int_mode_name} hence the bit is named the <<p_bit>>.
 
-When executing <<CLRPERM>>, if <<x_perm>> is removed when the <<m_bit>> is set, and the capability encoding still permits representing the <<m_bit>>, then the <<m_bit>> must be set to zero.
+IMPORTANT: Since indirect jumps copy the full target capability into <<pcc>> they can change between modes (see <<sec_changing_cheri_execution_mode>>).
 
-NOTE: Only <<rv64y_cap_description>> encodes the <<m_bit>> when <<x_perm>> is not granted.
-
-//#I don't understand this statement, as <<MODESW_CAP>> can be executed at any time#
-//The <<m_bit>> of the <<pcc>>, may be overridden by the execution environment which may not grant permission to enter {cheri_cap_mode_name}.
+When executing <<CLRPERM>>, if <<x_perm>> is removed when the <<p_bit>> is set, and the capability encoding still permits representing the <<p_bit>>, then the <<p_bit>> must be set to zero.
 
 [#sec_changing_cheri_execution_mode]
 ==== Changing CHERI Execution Mode
-The <<m_bit>> of <<pcc>> can be updated by the instructions listed in <<tab_cheri_mode_sw_summary>>:
+The <<p_bit>> of <<pcc>> can be updated by the instructions listed in <<tab_cheri_mode_sw_summary>>:
 
 .{cheri_default_ext_name} instructions that can perform mode changes
 [#tab_cheri_mode_sw_summary,%autowidth,options=header,align="center",cols="2,2,4"]
@@ -103,9 +100,9 @@ The <<m_bit>> of <<pcc>> can be updated by the instructions listed in <<tab_cher
 | <<MODESW_CAP>> |{cheri_int_mode_name}| {MODESW_CAP_DESC}
 |=======================
 
-NOTE: When <<JALR_CHERI>> copies `rs1` into <<pcc>> it includes copying the <<m_bit>> and so setting the <<cheri_execution_mode>> of the target instruction.
+NOTE: When <<JALR_CHERI>> copies `rs1` into <<pcc>> it includes copying the <<p_bit>> and so setting the <<cheri_execution_mode>> of the target instruction.
 
-The <<m_bit>> of a <<x_perm>>-granting capability can be read and written by the instructions listed in <<tab_hybrid_summary>>:
+The <<p_bit>> of a <<x_perm>>-granting capability can be read and written by the instructions listed in <<tab_hybrid_summary>>:
 
 .{cheri_default_ext_name} instructions to observe and update the mode in a capability
 [#tab_hybrid_summary,%autowidth,options=header,align="center",cols="1,4"]
@@ -115,13 +112,13 @@ The <<m_bit>> of a <<x_perm>>-granting capability can be read and written by the
 |<<GCMODE>>    |{GCMODE_DESC}
 |=======================
 
-NOTE: In addition to the mode switching instructions, the current mode can also be updated by setting the <<m_bit>> of a target capability using <<SCMODE>> followed by a <<JALR_CHERI>>.
+NOTE: In addition to the mode switching instructions, the current mode can also be updated by setting the <<p_bit>> of a target capability using <<SCMODE>> followed by a <<JALR_CHERI>>.
 
 [#sec_m_bit_hybrid_rule]
-==== Representation of the <<m_bit>> in the capability encoding
+==== Representation of the <<p_bit>> in the capability encoding
 
 For capabilities that do not grant <<x_perm>>,
-<<m_bit>> must always be interpreted and reported as {cap_mode_value} representing {cheri_cap_mode_name}.
+<<p_bit>> must always be interpreted and reported as {cap_mode_value} representing {cheri_cap_mode_name}.
 
 NOTE: While this is not phrased as an additional rule for <<CLRPERM>> to follow,
 beyond those of <<sec_permission_transitions>>,
@@ -131,8 +128,8 @@ in their representation of architectural CHERI capabilities.
 [#m_bit_observe,reftext="Observing the CHERI Execution Mode"]
 ==== Observing the CHERI Execution Mode
 
-The effective CHERI execution mode cannot be determined just by reading the <<m_bit>> from <<pcc>> since it also depends on the execution environment.
-The following code sequence demonstrates how a program can observe the current, effective CHERI execution mode.
+The effective CHERI Execution Mode cannot be determined just by reading the <<p_bit>> from <<pcc>> since it also depends on the execution environment.
+The following code sequence demonstrates how a program can observe the current, effective CHERI Execution Mode.
 It will write, to `x1`, the value `1` for {cheri_cap_mode_name} (wherein `pc` has a set {ctag})
 or `0` for {cheri_int_mode_name} (wherein `pc` is just an address and has a clear {ctag}):
 
@@ -180,19 +177,12 @@ possibly a <<root-rw-cap>> capability).
 include::img/ddcreg.edn[]
 
 [#zicsr-section-default]
-=== Changes to Zicsr Instructions
+=== Zicsr in {cheri_int_mode_name}
 
-When in {cheri_int_mode_name}, there is a special rule for updating extended CSRs (e.g., JVT when Zcmt becomes available for RVY).
-These are CSRs that are XLEN-wide for RVI/RVE but YLEN-wide for {cheri_base_ext_name}.
+Additionally to <<rvy_csr_classes>>, when in {cheri_int_mode_name}, extended CSRs are always accessed as XLEN-wide for compatibility.
+As a result, CSRRW writes to extended CSRs use the semantics of the <<SCADDR>> instruction to determine the final written value.
 
-* Writing an extended CSR writes the address field (XLEN bits) only, and the full CSR is updated using the semantics of the <<SCADDR>> instruction.
-* Reading an extended CSR reads the address field (XLEN bits) only.
-
-Accesses to extended CSRs in {cheri_int_mode_name} must access only XLEN bits for compatibility, and so use the semantics of the <<SCADDR>> instruction to determine the final written value.
-
-YLEN-wide CSRs are accessed identically in either <<cheri_execution_mode>>.
-
-.YLEN-bit CSR and Extended CSR access summary for {cheri_default_ext_name}
+.YLEN-bit CSR and Extended CSR access summary for {cheri_int_mode_name}.
 [#clen_access_summary_default,%autowidth,options=header,align="center"]
 |=======================
 |                   2+| YLEN-bit CSR^1^           2+| Extended CSR^2^
@@ -209,7 +199,7 @@ YLEN-wide CSRs are accessed identically in either <<cheri_execution_mode>>.
 
 ^1^ e.g., <<utidc>>
 
-^2^ e.g., JVT when Zcmt becomes available for RVY
+^2^ e.g., JVT
 
 ifndef::cheri_ratification_v1_only[]
 ifndef::cheri_standalone_spec[]

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -671,8 +671,8 @@ Write Permission (W)::
 Execute Permission (X)::
  See the unprivileged manual for the definition of X-permission.
 
-[#m_bit, reftext="M-bit"]
-M-bit::
+[#p_bit, reftext="P-bit"]
+P-bit::
  See the unprivileged manual for the definition of the M-bit.
 
 [#pcc, reftext="pc"]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -674,7 +674,7 @@ and associated {ctag}s, as shown in <<base_cap_registers>>.
 // The register can be referred to either way - as `{creg}1` accessing all YLEN bits or as `{creg}1` accessing only the address field (i.e., the lower XLEN bits).
 // For the ABI register names the `y` prefix is added, e.g., `{abi_creg}sp` to refer to all YLEN bits, and so the assembler can refer to either `sp` or `{abi_creg}sp` depending on the instruction operand.
 
-The zero register is extended with zero metadata and a zero {ctag}: this is called the <<null-cap>> capability.
+The zero register (`x0`) is extended with zero metadata and a zero {ctag}: this is called the <<null-cap>> capability.
 
 [#pcc,reftext="{pcc}"]
 ==== The Program Counter Capability (`{pcc}`)
@@ -840,6 +840,8 @@ All CSRs that can hold addresses are extended to YLEN bits.
 ** e.g., _jvt_ from the "Zcmt" extension
 * YLEN-bit CSRs, which are added by {cheri_base_ext_name} and contain addresses
 ** e.g., <<utidc>>
+
+NOTE: Zcmt is not yet available for {cheri_base_arch_name}.
 
 When accessing CSRs these rules are followed:
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -841,7 +841,7 @@ All CSRs that can hold addresses are extended to YLEN bits.
 * YLEN-bit CSRs, which are added by {cheri_base_ext_name} and contain addresses
 ** e.g., <<utidc>>
 
-NOTE: Zcmt is not yet available for {cheri_base_arch_name}.
+NOTE: Zcmt is not yet available for {cheri_base_ext_name}.
 
 When accessing CSRs these rules are followed:
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -9,6 +9,14 @@ This chapter introduces a new base ISA called {cheri_base64_ext_name} that exten
 In the future, 32-bit bases ({cheri_base32_ext_name}) will also be defined with near identically behavior but a different in-memory representation, so this chapter uses the term {cheri_base_ext_name} to refer to the behavior common between all bases.
 The {cheri_base_ext_name} base can be composed with other standard options to bases such as E (16-registers), Zfinx and endianness.
 
+All CHERI implementations must also specify a capability encoding format.
+
+This chapter also specifies <<rv64y_cap_description>> which is the capability encoding format for {cheri_base64_ext_name} systems.
+
+ifdef::cheri_ratification_v1_only[]
+Future versions of this specification will include capability encoding formats for {cheri_base32_ext_name}
+endif::[]
+
 === CHERI Overview
 
 CHERI enhances the base ISA by adding hardware memory access control.
@@ -271,21 +279,23 @@ architecture: normal bounds check rules should be followed.
 This metadata value indicates the type of the capability and determines which operations the capability authorizes.
 Which capability types a given CHERI platform supports is a function of the extensions and <<sec_cap_encoding_formats>> in use.
 The capability encoding specifies a mapping between some bits within the capability format (usually described as "the CT field") and the capability types.
-The mapping must be able to encode type `0` but has few other requirements.
-It need not, for example, be interpreted as an (un)signed binary rendering of CT values.
-Standard capability type mapping is shown in <<table_capability_types>>, and shows values from {rv64y_uni_base_name} as an example.
+The capability encoding must be able to encode type `0`.
+The standard capability type mapping is shown in <<table_capability_types>>, which is in use in all capability encoding formats unless otherwise specified.
 
 [#table_capability_types]
 .Capability type mapping in the {rv64y_uni_base_name} base
 [width="80%",options=header,align=left,cols="1,1,5"]
 |===
-| Type Name | Integer Value | Description
-| Unsealed  | 0             | Unsealed capability granting access to memory
-| Sentry    | 1             | Immutable sealed entry point
+| Type Name      | Integer Value | Description
+| Unsealed       | 0             | _Unsealed_ capability granting access to memory
+| <<sentry_cap>> | 1             | Immutable _sealed_ entry point
 |===
 
+NOTE: Capabilities sealed with a <<sec_cap_type>> of type `1` are dubbed "sentries" (a portmanteau of "sealed entries").
+
 NOTE: The integer value in the table above defines the architectural capability type (i.e., the result of the <<GCTYPE>> instruction) but does not need to be encoded that way in memory.
-Other base ISAs may provide different type mappings, but the value `0` must always represent an unsealed capability.
+
+NOTE: Other encoding formats may provide different type mappings, but the value `0` must _always_ represent an unsealed capability.
 
 [#unsealed_cap,reftext="unsealed capability"]
 Unsealed capabilities::
@@ -296,20 +306,25 @@ All CHERI systems must support unsealed capabilities.
 Sealed capabilities::
 Capabilities with `CT≠0` are sealed against modification and cannot be dereferenced to access memory.
 Instructions that operate on capabilities will produce a result with a cleared {ctag} if the source capability is sealed and the operation would alter its address, bounds, or permissions.
-Extensions that augment capability metadata must describe their interaction(s) with sealed capabilities.
+Extensions that extend the capability metadata must describe their interaction(s) with sealed capabilities.
 
 Given a capability with `CT=0`,
 deriving a capability with `CT≠0` is termed "sealing"
 (or "sealing with type ``x``" when a particular output ``CT=x`` is meant).
+
 In the other direction,
 deriving a `CT=0` capability from a `CT≠0` capability is termed "unsealing"
 (or "unsealing from type ``x``" when a particular input ``CT=x`` is meant).
-In general, each of these actions may require *authority*
-to operate at the non-zero type;
-extensions will specify how software expresses this authority
-for types not defined above.
 
-Capability encodings may also make the set of <<sec_cap_type>> values
+ifndef::cheri_ratification_v1_only[]
+
+[NOTE]
+====
+In general, each of sealing and unsealing actions may require *authority*
+to operate on the non-zero type;
+capability encoding formats which define types other than the ones in <<table_capability_types>> will specify how software expresses this authority.
+
+Capability encoding formats may also make the set of <<sec_cap_type>> values
 that may be used to seal a particular capability
 depend on the permissions granted by that capability.
 For example, it can be a useful space optimization to differentiate
@@ -318,35 +333,48 @@ from those not granting <<x_perm>>;
 the <<x_perm>> in the capability encoding effectively adds
 an additional bit to the <<sec_cap_type>> field.
 
-NOTE: <<rv64y_cap_description>> does not avail itself of this option,
-but, for example, the {cheri_base32_ext_name} CHERIoT capability encodings do.
+Capability encoding formats will explicitly state whether these are relevant to them.
+
+They are not used by <<rv64y_cap_description>>, but are by the CHERIoT formats.
+====
 
 [#sec_cap_type_ambient]
 Ambient sealing type::
 Some capability types are said to be "ambiently available" (or just "ambient")
 if they do not require specific authority to seal a capability (with that type).
-For example, if <<section_rvy_sentry_insn_ext>> is available on a given platform,
+For example, if the <<YSENTRY>> instruction is available on a given platform,
 the type with which it seals capabilities is considered ambiently available.
-(With the capabilities of <<rv64y_cap_description>>, that would be type `1`.)
+(For the capability encoding format specified by <<rv64y_cap_description>>, that would be type `1`.)
+endif::[]
 
 [#sentry_cap,reftext="sentry capability"]
 Sentry capability type::
-It is useful to have *immutable* function pointers within a CHERI software system.
+Sentry capabilities provide *immutable* function pointers within a CHERI software system.
 <<sealed_cap,Sealed capabilities>> are a natural foundation, providing immutability.
+
+Sentry capabilities can establish a form of control-flow integrity between mutually distrusting code.
+
+ifndef::cheri_ratification_v1_only[]
 The <<JALR_CHERI>> instruction may unseal capabilities of particular, encoding-specified types before installing them into the <<pcc>>.
-Capabilities sealed with such a type are dubbed "sentries" (a portmanteau of "sealed entries").
 The <<JALR_CHERI>> instruction may also _seal_ the return pointers it generates with encoding-specified types.
+endif::[]
+
+ifdef::cheri_ratification_v1_only[]
+
+Control-flow integrity is achieved using <<JALR_CHERI>>:
+
+* <<JALR_CHERI>> _unseals_ <<sentry_cap, sentry capabilities>> before installing them into the <<pcc>>.
+* <<JALR_CHERI>> _seals_ the return pointers it generates as <<sentry_cap, sentry capabilities>> before writing them to `{cd}`.
+
+NOTE: Therefore the same type can be used as immutable code pointers for both forward and backward control flow edges.
+ A future extension may define more restrictive _forward-only_ and _backward-only_ sentry capabilities that can only be used by calls and returns respectively.
+endif::[]
 
 #TODO: ARC COMMENT: "sentries" is a bad choice for a shortened form of "sealed entries" as the standard english or even CS connotation of sentry doesn't match with a sealed entry.#
-
-NOTE: Sentry capabilities can establish a form of control-flow integrity between mutually distrusting code.
 
 NOTE: In addition to using sealed capabilities as sentries for secure entry points, sealed capabilities can also be useful to software as secure software tokens.
  <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
  A future extension may add an unseal instruction for performance.
-
-NOTE: The set of {cheri_base_ext_name} base ISAs do not make any use of non-zero `CT` values.
- The capability encoding format only needs to encode `CT` information if any extensions (such as {rvy_sentry_insn_ext_name}) are present which support non-zero `CT` values.
 
 [#AP-field, reftext="AP-field"]
 ==== Architectural Permissions (AP)
@@ -905,6 +933,8 @@ Special instructions are provided to copy capabilities or derive a new capabilit
 |<<SCBNDS>>   | {SCBNDS_DESC}
 |<<SCBNDSR>>  | {SCBNDSR_DESC}
 |<<YSUNSEAL>> | {YSUNSEAL_DESC}
+|<<SENTRY>>   | {SENTRY_DESC}
+|<<CBLD>>     | {CBLD_DESC}
 |=======================
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>
@@ -916,6 +946,8 @@ include::insns/schi_32bit.adoc[]
 include::insns/scbnds_32bit.adoc[]
 include::insns/scbndsr_32bit.adoc[]
 include::insns/ysunseal_32bit.adoc[]
+include::insns/sentry_32bit.adoc[]
+include::insns/cbld_32bit.adoc[]
 
 <<<
 
@@ -1181,38 +1213,3 @@ NOTE: Further domain specialized capability encoding formats are expected in the
 include::rvy32-encoding.adoc[]
 
 endif::[]
-
-:leveloffset: -1
-
-[#section_rvy_sentry_insn_ext,reftext="{rvy_sentry_insn_ext_name}"]
-== "{rvy_sentry_insn_ext_name}" Extension for Creation of Sentry Capabilities
-
-The {rvy_sentry_insn_ext_name} extension:
-
-. Defines one <<sentry_cap>> type, the unrestricted sentry type with a <<sec_cap_type>> of `1`.
-.. These _unrestricted sentry_ capabilities can be used as immutable code pointers for both forward and backward control flow edges.
-NOTE: A future extension may define more restrictive _forward-only_ and _backward-only_ sentry capabilities that can only be used by calls and returns respectively.
-. Adds the <<SENTRY>> instruction to allow sealing capabilities as sentries with <<sec_cap_type>> of `1`.
-
-=== Interaction with <<JALR_CHERI>>
-
-{rvy_sentry_insn_ext_name} adds sealing and unsealing behavior to <<JALR_CHERI>>:
-
-. For HOOK 2: Seal the return capability as a sentry.
-
-=== Added instructions
-
-include::insns/sentry_32bit.adoc[]
-
-[#section_rvy_bld_insn_ext,reftext="{rvy_bld_insn_ext_name}"]
-== "{rvy_bld_insn_ext_name}" Extension for Building Capabilities
-
-The {rvy_bld_insn_ext_name} extension adds the <<CBLD>> instruction to capabilities with a superset authority to validate (i.e. set the {ctag}) of a capability with lesser authority.
-
-NOTE: This instruction can be used to speed up operations such as paging in memory after swap.
-
-NOTE: CHERIoT implementations do not use {CBLD}, so this instruction is part of an optional extension instead of the {cheri_base_ext_name} base ISA.
-
-=== Added instructions
-
-include::insns/cbld_32bit.adoc[]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -827,7 +827,8 @@ to reject executables that expect unknown or known-incompatible CHERI features o
 
 endif::[]
 
-==== Extended CSRs
+[#rvy_csr_classes]
+==== CSR Classes
 
 All CSRs that can hold addresses are extended to YLEN bits.
 
@@ -836,7 +837,7 @@ All CSRs that can hold addresses are extended to YLEN bits.
 * XLEN-bit CSRs, which do not contain addresses
 ** e.g., _fcsr_ from the "F" extension
 * XLEN-bit CSRs extended to YLEN bits, which are able to contain addresses (referred to as _extended CSRs_)
-** e.g., _jvt_ from the "Zcmt" extension, once the {cheri_base_ext_name} version becomes available.
+** e.g., _jvt_ from the "Zcmt" extension
 * YLEN-bit CSRs, which are added by {cheri_base_ext_name} and contain addresses
 ** e.g., <<utidc>>
 

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -93,14 +93,12 @@ Known extension (in)compatibilities are listed in <<rv32y_cheriot_encoding1_ext_
 |==============================================================================
 | Extension                    | Comment
 | <<section_cheri_hybrid_ext>> | Not supported (<<m_bit>> not defined)
-| <<section_rvy_sentry_insn_ext>> | Not compatible without other extensions (no <<sec_cap_type_ambient,ambient>> <<sec_cap_type>> values defined herein)
 | <<section_zylevels1>>        | Compatible (recommended)
 ifndef::cheri_ratification_v1_only[]
 | <<section_zyseal>>           | Compatible (recommended)
 | <<sec_zycheriot_unpriv>>     | Compatible (recommended)
 | <<sec_zycheriot_priv>>       | Compatible (recommended)
 endif::[]
-| <<section_rvy_bld_insn_ext>> | Compatible (will build exclusively unsealed capabilities without other extensions)
 | All RVY versions of other standard extensions | Compatible if the extension is compatible with RV32E
 |==============================================================================
 

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -92,7 +92,7 @@ Known extension (in)compatibilities are listed in <<rv32y_cheriot_encoding1_ext_
 [#rv32y_cheriot_encoding1_ext_summary,width="100%",options=header,]
 |==============================================================================
 | Extension                    | Comment
-| <<section_cheri_hybrid_ext>> | Not supported (<<m_bit>> not defined)
+| <<section_cheri_hybrid_ext>> | Not supported (<<p_bit>> not defined)
 | <<section_zylevels1>>        | Compatible (recommended)
 ifndef::cheri_ratification_v1_only[]
 | <<section_zyseal>>           | Compatible (recommended)

--- a/src/cheri/rvy-cheriot-isa-unpriv.adoc
+++ b/src/cheri/rvy-cheriot-isa-unpriv.adoc
@@ -22,8 +22,9 @@ counterparts found in the {cheriot_priv_ext_name} extension.
 {cheriot_unpriv_ext_name} assumes the presence of
 both the <<section_zylevels1>> and <<section_zyseal>> extensions.
 The present specification presumes the *absence*
-of both the <<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and
-<<section_rvy_sentry_insn_ext>> extensions.
+of both the <<SENTRY>> and
+<<CBLD>> instruction from <<rvy_insn_table>>.
+It also redefines the values allocated in the <<sentry_cap>> field.
 
 [NOTE]
 =====
@@ -36,7 +37,7 @@ we have not yet found a compelling reason to formally specify this composition.
 [NOTE]
 =====
 While {cheriot_unpriv_ext_name} is nominally compatible with
-<<section_rvy_sentry_insn_ext>>,
+<<SENTRY>>,
 the operating system written for link:https://cheriot.org[CHERIoT]
 has a security model that presumes the absence of ambient sealing,
 and so this specification does not

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -260,7 +260,7 @@ Compared to <<rv64y_cap_description,{rv64y_uni_base_name}>>, this encoding uses 
 
 // ===== <<AUIPC_CHERI>> Representability
 //
-// The capabilities of this chapter have sufficient <<section_rep_check_concept,representability>> such that sequences used to form XLEN-bit addresses (such as <<AUIPC_CHERI>>+<<LOAD_CAP>>) will not clear the {ctag}.
+// The capabilities of this chapter have sufficient <<section_rep_check_concept,representability>> such that sequences used to form XLEN-bit addresses (such as <<AUIPC_CHERI>>+<<LOAD_CAP>>) will not set the {ctag} to zero.
 
 [#section_special_caps_encoding32]
 === Encoding of Special Capabilities

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -25,8 +25,8 @@ NOTE: Reserved bits must be 0 in valid capabilities and are available for future
 Certain bits of the capability encoding are only used if certain extensions are implemented and are reserved otherwise:
 
 <<section_cheri_hybrid_ext>>::
-When {cheri_default_ext_name} is supported, capabilities include an <<m_bit>> (which is encoded as part of the <<AP-field-encoding32>>).
-If not supported the <<m_bit>> is reserved and reads as zero.
+When {cheri_default_ext_name} is supported, capabilities include an <<p_bit>> (which is encoded as part of the <<AP-field-encoding32>>).
+If not supported the <<p_bit>> is reserved and reads as zero.
 
 <<section_zylevels1>>::
 If <<section_zylevels1>> is available, additional values of the `AP,M` field are allocated, otherwise they are reserved for any valid capability.
@@ -49,7 +49,7 @@ This capability encoding has the following properties that affect the observable
 | EW        | {cap_rv32_exp_width} | Exponent width
 | CAP_MAX_E | {cap_rv32_exp_max}   | Maximum exponent value
 | enableL8  | 1                    | Whether the encoding format includes the L~8~ bit
-| AP_MBit   | 1                    | Whether the <<m_bit>> is encoded in the AP-field
+| AP_MBit   | 1                    | Whether the <<p_bit>> is encoded in the AP-field
 | AP_MAX    | 0x8/0x9^1^           | Value of the AP field giving maximum permissions
 |==============================================================================
 
@@ -91,7 +91,7 @@ Quadrants 2 and 3 are arranged to implicitly grant future permissions which may 
 Quadrant 0 does the opposite -- the encodings are allocated _not_ to implicitly add future permissions, and so granting future permissions will require new encodings.
 Quadrant 1 encodes permissions for executable capabilities.
 
-The <<m_bit>> is encoded as bit zero of the <<AP-field-encoding32>> for the executable quadrant and only assigned meaning when the implementation supports {cheri_default_ext_name} (_and_ <<x_perm>> is set).
+The <<p_bit>> is encoded as bit zero of the <<AP-field-encoding32>> for the executable quadrant and only assigned meaning when the implementation supports {cheri_default_ext_name} (_and_ <<x_perm>> is set).
 
 <<<
 [#default-cap-AP-no-zylevels1]
@@ -111,7 +111,7 @@ The <<m_bit>> is encoded as bit zero of the <<AP-field-encoding32>> for the exec
 | 5   | ✔ | ✔ |   |   |     |   | N/A | Data RW
 | 6-7   8+| reserved
 9+| *Quadrant 1: Executable capabilities*
-9+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
+9+| bit[0] - <<p_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
 | Field[2:0] | R | W | C | LM | X | ASR | Mode^1^ | Notes
 | 0-1   | ✔ | ✔ | ✔ | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
 | 2-3   | ✔ |   | ✔ | ✔ | ✔ |     | Mode^1^  | Execute + Data & Cap RO
@@ -135,7 +135,7 @@ The <<m_bit>> is encoded as bit zero of the <<AP-field-encoding32>> for the exec
 | 7       | ✔ | ✔ | ✔ | ✔ |   |     | N/A | Data & Cap RW
 |==============================================================================
 
-^1^ _Mode (<<m_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
+^1^ _Mode (<<p_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
 is supported. Despite being encoded here it is *not* an architectural permission._
 
 NOTE: When {rv32y_uni_base_name} there are many reserved permission encodings (see
@@ -166,7 +166,7 @@ If <<section_zylevels1>> is absent, the following rules are run once _in order_:
 | RV32-base-5      | <<lm_perm>>  | <<c_perm>> (supersedes <<perm_req:base:lm:c-and-r>>)
 | RV32-base-6      | <<x_perm>>   | (<<c_perm>> and <<lm_perm>>) or not (<<c_perm>> or <<lm_perm>>)
 | RV32-base-7      | <<asr_perm>> | <<w_perm>> and <<c_perm>> and <<x_perm>> (supersedes <<perm_req:base:asr:x>>)
-| RV32-base-8      | <<m_bit>>    | <<x_perm>> and {cheri_default_ext_name} is implemented
+| RV32-base-8      | <<p_bit>>    | <<x_perm>> and {cheri_default_ext_name} is implemented
 |===
 
 [#default-cap-AP-zylevels1]
@@ -186,7 +186,7 @@ If <<section_zylevels1>> is absent, the following rules are run once _in order_:
 | 5   | ✔ | ✔ |   |   |   |   |   |   | N/A | Data RW
 | 6-7   10+| reserved
 11+| *Quadrant 1: Executable capabilities*
-11+| bit[0] - <<m_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
+11+| bit[0] - <<p_bit>> ({CAP_MODE_VALUE}-{cheri_cap_mode_name}, {INT_MODE_VALUE}-{cheri_int_mode_name})
 |Field[2:0]| R | W | C | LM | LG | SL | X | ASR | Mode^1^ | Notes
 | 0-1   | ✔ | ✔ | ✔ | ✔  | ✔  | ✔ | ✔ |  ✔  | Mode^1^  | Execute + Data & Cap RW + ASR
 | 2-3   | ✔ |   | ✔ | ✔  | ✔  |   | ✔ |     | Mode^1^  | Execute + Data & Cap RO
@@ -211,7 +211,7 @@ If <<section_zylevels1>> is absent, the following rules are run once _in order_:
 | 7       | ✔ | ✔ | ✔ | ✔  | ✔  |   |   |     | N/A | Data & Cap RW (no <<zylevels1_sl_perm>>)
 |==============================================================================
 
-^1^ _Mode (<<m_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
+^1^ _Mode (<<p_bit>>) can only be set on a valid capability when {cheri_default_ext_name}
 is supported, otherwise such encodings are reserved. Despite being encoded here it is *not* an architectural permission._
 
 The following rules are run once _in order_:
@@ -234,10 +234,10 @@ The following rules are run once _in order_:
   (<<c_perm>> and <<lm_perm>> and <<zylevels1_lg_perm>> and not <<w_perm>>) or +
   not (<<c_perm>> or <<lm_perm>> or <<zylevels1_lg_perm>> or <<zylevels1_sl_perm>>)
 | RV32-l1-10       | <<asr_perm>>          | <<w_perm>> and <<c_perm>> and <<x_perm>> (supersedes <<perm_req:base:asr:x>>)
-| RV32-l1-11       | <<m_bit>>             | <<x_perm>> and {cheri_default_ext_name} is implemented
+| RV32-l1-11       | <<p_bit>>             | <<x_perm>> and {cheri_default_ext_name} is implemented
 |===
 
-For RV32, the encodings which have the <<m_bit>> set to {int_mode_value} for {cheri_int_mode_name}
+For RV32, the encodings which have the <<p_bit>> set to {int_mode_value} for {cheri_int_mode_name}
 are only valid if {cheri_default_ext_name} is implemented.
 Otherwise those encodings represent invalid permissions.
 
@@ -304,7 +304,7 @@ are presumed absent in NULL capabilities.
 ==== Infinite Capability Encoding
 
 This encoding is for an _Infinite_ capability value, which grants all permissions while its bounds also cover the whole address space.
-It includes <<x_perm>> and so includes the <<m_bit>> if {cheri_default_ext_name} is supported.
+It includes <<x_perm>> and so includes the <<p_bit>> if {cheri_default_ext_name} is supported.
 This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capability.
 
 .Field values of the Infinite capability
@@ -327,7 +327,7 @@ This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capabil
 |==============================================================================
 
 ^1^If {cheri_default_ext_name} is supported, then the infinite capability must represent {cheri_int_mode_name} for compatibility with standard RISC-V code.
-Therefore, the <<m_bit>> is set to {INT_MODE_VALUE} in the <<AP-field-encoding32>>, giving the value 0x9.
+Therefore, the <<p_bit>> is set to {INT_MODE_VALUE} in the <<AP-field-encoding32>>, giving the value 0x9.
 
 ^2^If an infinite capability is used as a constant in either hardware or software, then the address field will typically be set to zero.
 If the address field is non-zero then it is still referred to as an infinite capability, and it still has the authority to authorize all memory accesses.

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -62,7 +62,6 @@ See xref:cap_perms_encoding32[xrefstyle=short].
 | Extension                    | Comment
 | <<section_cheri_hybrid_ext>> | Compatible
 | <<section_zylevels1>>        | Compatible
-| <<section_rvy_sentry_insn_ext>> | Compatible
 ifndef::cheri_ratification_v1_only[]
 | <<section_zyseal>>           | Will be compatible once new permissions are encoded
 endif::[]

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -61,7 +61,6 @@ This capability encoding has the following properties that affect the observable
 |==============================================================================
 | Extension                    | Comment
 | <<section_cheri_hybrid_ext>> | Compatible
-| <<section_rvy_sentry_insn_ext>> | Compatible
 ifndef::cheri_ratification_v1_only[]
 | <<section_zylevels1>>        | Compatible
 | <<section_zyseal>>           | Will be compatible once new permissions are encoded
@@ -125,6 +124,9 @@ The value of the <<SDP-field64>> bits of the <<GCPERM>> result maps 1:1 to the <
 [#section_cap_sealed]
 ==== Capability Type (CT) Encoding
 
+The <<sec_cap_type>> field is as specified in <<table_capability_types>>.
+
+ifndef::cheri_ratification_v1_only[]
 ifdef::cheri_v9_annotations[]
 WARNING: *CHERI v9:* There is now a 1-bit otype (sentry or unsealed) and the old CHERI v9 otype no longer exists.
 The base CHERI-RISC-V standard does not have support for CHERI v9 CSEAL for sealed capabilities with object types and only has <<SENTRY>> for sealed entry (sentry) capabilities.
@@ -137,8 +139,7 @@ The value `1` is...
 * considered <<sec_cap_type_ambient,ambiently available>> for <<CBLD>>,
 
 * used as the type for capabilities sealed by <<SENTRY>> instructions,
-  regardless of the input capability's permission,
-  if <<section_rvy_sentry_insn_ext>> is present in the platform.
+  regardless of the input capability's permission.
 
 Additionally, <<JALR_CHERI>> both
 
@@ -149,7 +150,6 @@ Additionally, <<JALR_CHERI>> both
 <<JALR_CHERI>> places no constraints on the triple of input <<sec_cap_type>> value, `{cd}` selector, and `{cs1}` selector.
 That is, <<JALR_CHERI>> will, as directed, attempt to jump to any unsealed or sealed capability in any register regardless of which register comes to hold the sealed return pointer.
 
-ifndef::cheri_ratification_v1_only[]
 [NOTE]
 =====
 The permission encodings of <<rv64y_cap_description>> do not provide mappings for

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -26,8 +26,8 @@ NOTE: Reserved bits must be 0 in valid capabilities and are available for future
 The encoding diagram above of the capability format includes some fields which depend upon the presence of extensions:
 
 <<section_cheri_hybrid_ext>>::
-When {cheri_default_ext_name} is supported, capabilities include an <<m_bit>> (bit 52).
-If the capability does not grant <<x_perm>> or {cheri_default_ext_name} is not supported, the <<m_bit>> is always _reserved_ and so must be zero in valid capabilities.
+When {cheri_default_ext_name} is supported, capabilities include an <<p_bit>> (bit 52).
+If the capability does not grant <<x_perm>> or {cheri_default_ext_name} is not supported, the <<p_bit>> is always _reserved_ and so must be zero in valid capabilities.
 
 ifndef::cheri_ratification_v1_only[]
 <<section_zylevels1>>::
@@ -52,7 +52,7 @@ This capability encoding has the following properties that affect the observable
 | EW        | {cap_rv64_exp_width} | Exponent width
 | CAP_MAX_E | {cap_rv64_exp_max}   | Maximum exponent value
 | enableL8  | 0                    | Whether the encoding format includes the L~8~ bit
-| AP_MBit   | 0                    | Whether the <<m_bit>> is encoded in the AP-field
+| AP_MBit   | 0                    | Whether the <<p_bit>> is encoded in the AP-field
 | AP_MAX    | ones                 | Value of the AP field giving maximum permissions
 |==============================================================================
 
@@ -109,11 +109,11 @@ endif::[]
 
 NOTE: Future extensions may define new permissions and, if so, must augment the above table.
 
-[#M-field-encoding64, reftext="M-field encoding"]
-==== Capability Mode (M) Encoding
+[#P-field-encoding64, reftext="P-field encoding"]
+==== Capability Mode (P) Encoding
 
-The <<m_bit>> is only assigned meaning when the implementation supports {cheri_default_ext_name} _and_ <<x_perm>> is set.
-In valid capabilities, the bit assigned to the <<m_bit>> must be zero if <<x_perm>> isn't set.
+The <<p_bit>> is only assigned meaning when the implementation supports {cheri_default_ext_name} _and_ <<x_perm>> is set.
+In valid capabilities, the bit assigned to the <<p_bit>> must be zero if <<x_perm>> isn't set.
 
 [#SDP-field64, reftext="SDP-field"]
 ==== Software-Defined Permissions (SDP) Encoding
@@ -518,9 +518,6 @@ This gives useful guarantees, such that if an executed instruction is in
 <<pcc>> bounds, then it is also guaranteed that the next linear instruction
 is _representable_.
 
-// ===== <<AUIPC_CHERI>> Representability
-//
-// The capabilities of this chapter have sufficient <<section_rep_check_concept,representability>> such that sequences used to form XLEN-bit addresses (such as <<AUIPC_CHERI>>+<<LOAD_CAP>>) will not clear the {ctag}.
 
 [#section_special_caps_encoding]
 === Encoding of Special Capabilities
@@ -544,7 +541,7 @@ expanded base is 0 and top is 2^XLEN^.
 | {ctag_title}             | zero   | Capability is not valid
 | <<SDP-field64,SDP>>        | zeros  | Grants no permissions
 | <<AP-field,AP>>          | zeros  | Grants no permissions
-| <<m_bit,M>>^1^           | zero   | No meaning since non-executable ({cheri_default_ext_name} only)
+| <<p_bit,P>>^1^           | zero   | No meaning since non-executable ({cheri_default_ext_name} only)
 | CT       | zero   | Unsealed
 | EF       | zero   | Internal exponent format
 | L~8~^2^  | zero   | Top address reconstruction bit
@@ -571,7 +568,7 @@ are presumed absent in NULL capabilities.
 
 This encoding is for an _Infinite_ capability value, which
 grants all permissions while its bounds also cover the whole address space.
-It includes <<x_perm>> and so includes the <<m_bit>> if {cheri_default_ext_name} is supported.
+It includes <<x_perm>> and so includes the <<p_bit>> if {cheri_default_ext_name} is supported.
 This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capability.
 
 .Field values of the Infinite capability
@@ -582,7 +579,7 @@ This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capabil
 | {ctag_title}  | one   | Capability is valid
 | SDP           | ones  | Grants all permissions
 | AP            | AP_MAX | Grants all permissions
-| <<m_bit,M>>^1^   | {INT_MODE_VALUE_WORD} | CHERI execution mode
+| <<p_bit,P>>^1^   | {INT_MODE_VALUE_WORD} | CHERI pointer execution mode
 | CT            | zero  | Unsealed
 | EF            | zero  | Internal exponent format
 | L~8~^2^       | zero  | Top address reconstruction bit

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -22,7 +22,7 @@ The fundamental rule for any CHERI system is that the {ctag} and data are always
 . Update any data bytes without also writing the {ctag}
 .. This implies setting the {ctag} to zero if a non-CHERI aware bus master overwrites a capability in memory
 . Read a {ctag} value with mismatched (stale or newer) data
-. Set the {ctag} without also writing the data.
+. Write a {ctag} without also writing the data.
 
 NOTE: Clearing {ctag}s in memory does not necessarily require updating the associated data.
 

--- a/src/cheri/vector-integration.adoc
+++ b/src/cheri/vector-integration.adoc
@@ -1,18 +1,19 @@
 [#section_cheri_vector_integration, reftext="Vector \"V\" ({cheri_base_ext_name})"]
 == Vector "V" Extension ({cheri_base_ext_name})
 
-The Vector extension is orthogonal to {cheri_base_ext_name} because the vector registers do not support {ctag}s.
+The Vector extension for {cheri_base_ext_name} does not support {ctag}s in the vector registers.
+Consequently, vector stores will always clear {ctag}s in memory.
 
 NOTE: A future extension may allow {ctag}s to be stored in vector registers.
   Until that time, vector load and store instructions must not be used to implement generic
   memory copying in software, such as the `memcpy()` standard C library function,
+  that requires capabilities to be preserved,
   because the vector registers do not hold capabilities, so the {ctag}s of any
   copied capabilities will be set to 0 in the destination memory.
 
 Under {cheri_base_ext_name}, vector loads and stores follow the standard rules for _active_ elements:
 
 * Only _active_ elements are subject to CHERI exception checks.
-* If there are no _active_ elements then no CHERI exceptions will be raised.
 * CHERI exceptions are only raised on fault-only-first loads if element 0 is both _active_ and fails any exception checks.
 
 Additionally, the standard {cheri_base_ext_name} rule that all loads and stores where the base register is `x0` are reserved applies to all vector memory access instructions.

--- a/src/cheri/zyseal.adoc
+++ b/src/cheri/zyseal.adoc
@@ -7,8 +7,7 @@ IMPORTANT: {not_v1_ratification_package_freeze}
 === Explicit Sealing and Unsealing Operations
 
 The {cheri_base_ext_name} base architecture defines <<sealed_cap, sealed capabilities>>.
-The <<CBLD>>, <<JALR_CHERI>>, and <<YSUNSEAL>> instruction
-and the <<section_rvy_sentry_insn_ext>> extension
+The <<CBLD>>, <<JALR_CHERI>>, <<SENTRY>> and <<YSUNSEAL>> instructions
 allow platforms to build and consume sealed capabilities in
 particular ways.
 This extension introduces a more general,

--- a/src/cheri_isa_tables.adoc
+++ b/src/cheri_isa_tables.adoc
@@ -39,30 +39,6 @@ In general, this is restricted to changing whether input/output operands read/wr
 include::{generated_dir}/{rvy_zicsr_mod_file_name}.adoc[]
 |==============================================================================
 
-[#rvy_sentry_insn_table, reftext="{rvy_sentry_insn_ext_name}"]
-=== {rvy_sentry_insn_ext_name}
-
-{rvy_sentry_insn_ext_name} adds the {SENTRY} instruction.
-
-.{rvy_sentry_insn_ext_name} instruction extension
-[#{rvy_sentry_insn_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_sentry_insn_file_name}.adoc[]
-|==============================================================================
-
-[#rvy_bld_insn_table, reftext="{rvy_bld_insn_ext_name}"]
-=== {rvy_bld_insn_ext_name}
-
-{rvy_bld_insn_ext_name} adds the {CBLD} instruction.
-
-.{rvy_bld_insn_ext_name} instruction extension
-[#{rvy_bld_insn_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_bld_insn_file_name}.adoc[]
-|==============================================================================
-
 ifndef::cheri_ratification_v1_only[]
 
 [#rvy_bndsrdw_insn_table, reftext="{rvy_bndsrdw_insn_ext_name}"]

--- a/src/hypervisor.adoc
+++ b/src/hypervisor.adoc
@@ -2703,7 +2703,7 @@ for <<stidc>>, so that instructions that normally read or modify
 <<stidc>> actually access <<vstidc>> instead.
 When V=0, <<vstidc>> does not directly affect the
 behavior of the machine.
-On reset the {ctag} of <<vstidc>> will be set to 0 and the remainder
+On reset the {ctag} of <<vstidc>> will be set to zero and the remainder
 of the data is UNSPECIFIED.
 
 .Virtual supervisor thread identifier capability register


### PR DESCRIPTION
I've started from #994 to avoid merge problems later

I've reordered the CSRs in the CSV so that they are more logically grouped, as it makes the behaviour summary table much easier to read.

Most of the edits are very minor - but it does include renaming the CHERI Execution Modes to:

* Pointer Mode
* Capability Mode

As the metadata bit = 1 for Pointer Mode I've renamed it from M to P