### PR TITLE
Move Zca table

### DIFF
--- a/src/cheri_isa_tables.adoc
+++ b/src/cheri_isa_tables.adoc
@@ -39,6 +39,19 @@ In general, this is restricted to changing whether input/output operands read/wr
 include::{generated_dir}/{rvy_zicsr_mod_file_name}.adoc[]
 |==============================================================================
 
+[#rvy_zca_insn_table, reftext="{rvy_zca_ext_name}"]
+=== {rvy_zca_ext_name}
+
+These 16-bit instructions are supported by any {cheri_base_ext_name} core that includes the standard C extension.
+Zcf and Zcd are incompatible with RVY.
+
+.{rvy_zca_ext_name} instruction extension
+[#{rvy_zca_file_name}]
+[width="100%",options=header,cols="2,5",]
+|==============================================================================
+include::{generated_dir}/{rvy_zca_file_name}.adoc[]
+|==============================================================================
+
 [#rvy_sentry_insn_table, reftext="{rvy_sentry_insn_ext_name}"]
 === {rvy_sentry_insn_ext_name}
 
@@ -67,18 +80,7 @@ include::{generated_dir}/{rvy_bndsrdw_insn_file_name}.adoc[]
 
 endif::[]
 
-[#rvy_zca_insn_table, reftext="{rvy_zca_ext_name}"]
-=== {rvy_zca_ext_name}
 
-These 16-bit instructions are supported by any {cheri_base_ext_name} core that includes the standard C extension.
-They are incompatible with Zcf (RV32) and Zcd (RV64).
-
-.{rvy_zca_ext_name} instruction extension
-[#{rvy_zca_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_zca_file_name}.adoc[]
-|==============================================================================
 
 ifdef::cheri_standalone_spec[]
 <<<


### PR DESCRIPTION
Addresses the following ARC comment: "this should be listed next to
zicsr not after cheri-specific extensions"
