### PR TITLE
FIX: Avoid accidental HTML <em> tags in PlantUML diagrams.

### DIFF
--- a/src/cheri/app-hybrid-usage.adoc
+++ b/src/cheri/app-hybrid-usage.adoc
@@ -63,9 +63,9 @@ end box
 
 K -> K: Prepare User DDC & PCC
 K -> K: Write target PCC to sepc\n(mode bit = {INT_MODE_VALUE})
-K -> U: Execute ""sret"" (Switches to {cheri_int_mode_name})
+K -> U: Execute ""sret"" (Switches to {cheri_int_mode_name_nofmt})
 U -> U: Execute App code
-U -> K: Trigger ""ecall"" or Exception (Switches to {cheri_cap_mode_name})
+U -> K: Trigger ""ecall"" or Exception (Switches to {cheri_cap_mode_name_nofmt})
 K -> K: Handle System Call
 
 @enduml
@@ -100,9 +100,9 @@ end box
 
 M -> M: Create Library Code Capability\n(mode bit = {CAP_MODE_VALUE})
 M -> M: Set DDC to NULL
-M -> L: Call via ""JALR_CHERI"" (Switches to {cheri_cap_mode_name})
+M -> L: Call via ""JALR_CHERI"" (Switches to {cheri_cap_mode_name_nofmt})
 L -> L: Execute Sandboxed Code
-L -> M: Return via return capability (Switches to {cheri_int_mode_name})
+L -> M: Return via return capability (Switches to {cheri_int_mode_name_nofmt})
 M -> M: Restore DDC
 
 @enduml
@@ -137,9 +137,9 @@ end box
 
 P -> P: Create Non-CHERI Code Capability\n(mode bit = {INT_MODE_VALUE})
 P -> P: Load capability into DDC\n(heap, globals, stack)
-P -> N: Call via ""JALR_CHERI"" (Switches to {cheri_int_mode_name})
+P -> N: Call via ""JALR_CHERI"" (Switches to {cheri_int_mode_name_nofmt})
 N -> N: Execute Legacy Code
-N -> P: Return via return capability (Switches to {cheri_cap_mode_name})
+N -> P: Return via return capability (Switches to {cheri_cap_mode_name_nofmt})
 P -> P: Restore DDC to NULL
 
 @enduml
@@ -171,17 +171,17 @@ box "Runtime (RVY Purecap)" #LightCyan
 participant "C++ Runtime" as R
 end box
 
-note over J: Running in {cheri_int_mode_name}
+note over J: Running in {cheri_int_mode_name_nofmt}
 
 == Accessing C Runtime Data ==
-J -> J: Execute ""MODESW_CAP"" (Switches to {cheri_cap_mode_name})
+J -> J: Execute ""MODESW_CAP"" (Switches to {cheri_cap_mode_name_nofmt})
 J -> J: Access runtime data using\nexplicit capabilities
-J -> J: Execute ""MODESW_INT"" (Switches to {cheri_int_mode_name})
+J -> J: Execute ""MODESW_INT"" (Switches to {cheri_int_mode_name_nofmt})
 
 == Calling Runtime Helpers ==
-J -> R: Call helper (Sentry Capability) (Switches to {cheri_cap_mode_name})
+J -> R: Call helper (Sentry Capability) (Switches to {cheri_cap_mode_name_nofmt})
 R -> R: Execute safe runtime code
-R -> J: Return to JIT code (Switches to {cheri_int_mode_name})
+R -> J: Return to JIT code (Switches to {cheri_int_mode_name_nofmt})
 
 @enduml
 ....

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -122,8 +122,10 @@ endif::support_varxlen[]
 :ctag_cap:   Capability tag
 :ctag_title: Capability Tag
 
-:cheri_int_mode_name: pass:quotes[_Integral Pointer Mode_]
-:cheri_cap_mode_name: pass:quotes[_Capability Pointer Mode_]
+:cheri_int_mode_name_nofmt: Integral Pointer Mode
+:cheri_cap_mode_name_nofmt: Capability Pointer Mode
+:cheri_int_mode_name: pass:quotes,attributes[_{cheri_int_mode_name_nofmt}_]
+:cheri_cap_mode_name: pass:quotes,attributes[_{cheri_cap_mode_name_nofmt}_]
 
 :c_cheri_base_ext_names:    Zca, {cheri_base_ext_name}
 :c_cheri_default_ext_names: Zca, {cheri_default_ext_name}

--- a/src/cheri/contributors.adoc
+++ b/src/cheri/contributors.adoc
@@ -23,6 +23,7 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Maja Malenko <maja.malenko@codasip.com>
 * A. Theodore Markettos <theo.markettos@cl.cam.ac.uk>
 * Alfredo Mazzinghi <alfredo.mazzinghi@cl.cam.ac.uk>
+* Dave McEwan <dave.mcewan@codasip.com>
 * David McKay <david.mckay@codasip.com>
 * Jamie Melling <jamie.melling@codasip.com>
 * Stuart Menefy <stuart.menefy@codasip.com>


### PR DESCRIPTION
Before this PR, the 4 UML diagrams in appendix Hybrid Mode Usage Models had accidental HTML tags:
<img width="1017" height="402" alt="image" src="https://github.com/user-attachments/assets/2c7e8dbc-8f74-4072-b7b4-bf604c2d3f3b" />


After this PR:
<img width="784" height="345" alt="image" src="https://github.com/user-attachments/assets/56f6cfd4-59b4-4e10-855a-8e25cfcf1377" />



The current Docker image doesn't have the italics variant of the font used in PlantUML diagrams, so using `//foo//` renders the same as `foo`. This is made clear in the diagrams by using attribute suffix `_nofmt`.