### PR TITLE
Omit redundant changelog section from default build

### DIFF
--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -85,7 +85,7 @@ include::insns/zcmt_cmjt.adoc[]
 
 endif::[]
 
-ifdef::cheri_standalone_spec[]
+ifndef::cheri_ratification_v1_only[]
 
 == ISA changes since 0.9.5
 


### PR DESCRIPTION
This is covered in the release notes on github
