### PR TITLE
Use the correct YBNDSWI encoding

### DIFF
--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -47,7 +47,7 @@ include::malformed_cs1_clear_tag.adoc[]
 <<SCBNDSI>> decodes the 9-bit immediate value `imm[8:0]` to the requested length `result` as follows:
 
 * If `imm[8:0] == 0`, `result` is `4096`.
-* If `imm[8] == 0` and `imm[8:0] > 0`, `result` is `imm[7:0]`.
+* If `imm[8] == 0` and `imm[7:0] != 0`, `result` is `imm[7:0]`.
 * If `imm[8] == 1`, `result` is decoded as follows:
 ** If `imm[7:5] != 0`, `result` is `imm[7:0] << 4`.
 ** If `imm[7:5] == 0`, `result` is `(imm[7:0] << 4) | (imm[4] ? 8 : 256)`.

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -47,10 +47,10 @@ include::malformed_cs1_clear_tag.adoc[]
 <<SCBNDSI>> decodes the 9-bit immediate value `imm[8:0]` to the requested length `result` as follows:
 
 * If `imm[8:0] == 0`, `result` is `4096`.
-* If `imm[8] == 0` and `imm[7:0] > 0`, `result[7:0] = imm[7:0]` with all other bits set to `0`.
-* If `imm[8] == 1`, `result` is decoded as follows, with all other bits set to `0`:
-** If `imm[7:4] != 0000`, then `result[11:4] = imm[7:0]`.
-** If `imm[7:4] == 0000`, then `result[8] = 1`, `result[7:4] = imm[3:0]`, `result[3] = 1`.
+* If `imm[8] == 0` and `imm[8:0] > 0`, `result` is `imm[7:0]`.
+* If `imm[8] == 1`, `result` is decoded as follows:
+** If `imm[7:5] != 0`, `result` is `imm[7:0] << 4`.
+** If `imm[7:5] == 0`, `result` is `(imm[7:0] << 4) | (imm[4] ? 8 : 256)`.
 
 +
 The resulting logical encodable regions and step sizes are summarized in the table below:
@@ -63,15 +63,13 @@ The resulting logical encodable regions and step sizes are summarized in the tab
 | `1, 2, ..., 255`
 | `imm[8] == 0` and `imm[7:0] > 0`
 
-.2+<| 8-byte granular
-.2+<| `256, 264, ..., 504`
-| `imm[8] == 1` and `imm[7:4] == 0001` (even multiples of 8)
-
-| `imm[8] == 1` and `imm[7:4] == 0000` (odd multiples of 8)
+| 8-byte granular
+| `256, 264, ..., 504`
+| `imm[8:5] == 1000`
 
 .2+<| 16-byte granular
 | `512, 528, ..., 4080`
-| `imm[8] == 1` and `imm[7:4] >= 0010`
+| `imm[8] == 1` and `imm[7:5] != 000`
 
 | `4096`
 | `imm[8:0] == 0`
@@ -80,8 +78,15 @@ The resulting logical encodable regions and step sizes are summarized in the tab
 [NOTE]
 ====
 This immediate encoding scheme achieves coverage of almost all observed immediate values while decoding the 9-bit immediate field without any adders or variable shifts.
-The linear range, stride-16 range, and stride-8 region are decoded via simple multiplexers and bit wiring.
 Mapping `imm == 0` to `4096` reclaims the redundant zero encoding (already covered by `{scbnds_lc} dst, src, x0`) to support highly common page-sized objects.
+
+// The hardware implementation is a simple bit-remapping: +
+// `result[12] = (imm[8:0] == 0)`, +
+// `result[11:9] = imm[8] ? imm[7:5] : 0`, +
+// `result[8] = imm[8] ? (imm[7:5] == 0 || imm[4]) : 0`, +
+// `result[7:4] = imm[8] ? imm[3:0] : imm[7:4]`, +
+// `result[3] = imm[8] ? (imm[7:4] == 1) : imm[3]`, +
+// and `result[2:0] = imm[8] ? 0 : imm[2:0]`.
 ====
 
 Included in::

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -48,9 +48,8 @@ include::malformed_cs1_clear_tag.adoc[]
 
 * If `imm[8:0] == 0`, `result` is `4096`.
 * If `imm[8] == 0` and `imm[7:0] != 0`, `result` is `imm[7:0]`.
-* If `imm[8] == 1`, `result` is decoded as follows:
-** If `imm[7:5] != 0`, `result` is `imm[7:0] << 4`.
-** If `imm[7:5] == 0`, `result` is `256 | (imm[3:0] << 4) | (imm[4] << 3)`.
+* If `imm[8] == 1` and `imm[7:5] == 0`, `result` is `256 | (imm[3:0] << 4) | (imm[4] << 3)`.
+* Otherwise, `result` is `imm[7:0] << 4`.
 
 +
 The resulting logical encodable regions and step sizes are summarized in the table below:
@@ -69,7 +68,7 @@ The resulting logical encodable regions and step sizes are summarized in the tab
 
 .2+<| 16-byte granular
 | `512, 528, ..., 4080`
-| `imm[8] == 1` and `imm[7:5] != 000`
+| `imm[8:5] > 1000`
 
 | `4096`
 | `imm[8:0] == 0`

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -50,7 +50,7 @@ include::malformed_cs1_clear_tag.adoc[]
 * If `imm[8] == 0` and `imm[7:0] != 0`, `result` is `imm[7:0]`.
 * If `imm[8] == 1`, `result` is decoded as follows:
 ** If `imm[7:5] != 0`, `result` is `imm[7:0] << 4`.
-** If `imm[7:5] == 0`, `result` is `(imm[7:0] << 4) | (imm[4] ? 8 : 256)`.
+** If `imm[7:5] == 0`, `result` is `256 | (imm[3:0] << 4) | (imm[4] << 3)`.
 
 +
 The resulting logical encodable regions and step sizes are summarized in the table below:
@@ -83,9 +83,9 @@ Mapping `imm == 0` to `4096` reclaims the redundant zero encoding (already cover
 // The hardware implementation is a simple bit-remapping: +
 // `result[12] = (imm[8:0] == 0)`, +
 // `result[11:9] = imm[8] ? imm[7:5] : 0`, +
-// `result[8] = imm[8] ? (imm[7:5] == 0 || imm[4]) : 0`, +
+// `result[8] = imm[8] ? (imm[7:5] == 0b000 || imm[4]) : 0`, +
 // `result[7:4] = imm[8] ? imm[3:0] : imm[7:4]`, +
-// `result[3] = imm[8] ? (imm[7:4] == 1) : imm[3]`, +
+// `result[3] = imm[8] ? (imm[7:4] == 0b0001) : imm[3]`, +
 // and `result[2:0] = imm[8] ? 0 : imm[2:0]`.
 ====
 

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -80,12 +80,12 @@ This immediate encoding scheme achieves coverage of almost all observed immediat
 Mapping `imm == 0` to `4096` reclaims the redundant zero encoding (already covered by `{scbnds_lc} dst, src, x0`) to support highly common page-sized objects.
 
 The hardware implementation is a simple bit-remapping: +
-`result[12] = (imm[8:0] == 0)`, +
-`result[11:9] = imm[8] ? imm[7:5] : 0`, +
-`result[8] = imm[8] ? (imm[7:5] == 0b000 || imm[4]) : 0`, +
-`result[7:4] = imm[8] ? imm[3:0] : imm[7:4]`, +
-`result[3] = imm[8] ? (imm[7:4] == 0b0001) : imm[3]`, +
-and `result[2:0] = imm[8] ? 0 : imm[2:0]`.
+`result[12] = (imm[8:0] == 0);` +
+`result[11:9] = imm[8] ? imm[7:5] : 0;` +
+`result[8] = imm[8] ? (imm[7:5] == 0b000 || imm[4]) : 0;` +
+`result[7:4] = imm[8] ? imm[3:0] : imm[7:4];` +
+`result[3] = imm[8] ? (imm[7:4] == 0b0001) : imm[3];` +
+`result[2:0] = imm[8] ? 0 : imm[2:0];`.
 ====
 
 Included in::

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -80,13 +80,13 @@ The resulting logical encodable regions and step sizes are summarized in the tab
 This immediate encoding scheme achieves coverage of almost all observed immediate values while decoding the 9-bit immediate field without any adders or variable shifts.
 Mapping `imm == 0` to `4096` reclaims the redundant zero encoding (already covered by `{scbnds_lc} dst, src, x0`) to support highly common page-sized objects.
 
-// The hardware implementation is a simple bit-remapping: +
-// `result[12] = (imm[8:0] == 0)`, +
-// `result[11:9] = imm[8] ? imm[7:5] : 0`, +
-// `result[8] = imm[8] ? (imm[7:5] == 0b000 || imm[4]) : 0`, +
-// `result[7:4] = imm[8] ? imm[3:0] : imm[7:4]`, +
-// `result[3] = imm[8] ? (imm[7:4] == 0b0001) : imm[3]`, +
-// and `result[2:0] = imm[8] ? 0 : imm[2:0]`.
+The hardware implementation is a simple bit-remapping: +
+`result[12] = (imm[8:0] == 0)`, +
+`result[11:9] = imm[8] ? imm[7:5] : 0`, +
+`result[8] = imm[8] ? (imm[7:5] == 0b000 || imm[4]) : 0`, +
+`result[7:4] = imm[8] ? imm[3:0] : imm[7:4]`, +
+`result[3] = imm[8] ? (imm[7:4] == 0b0001) : imm[3]`, +
+and `result[2:0] = imm[8] ? 0 : imm[2:0]`.
 ====
 
 Included in::


### PR DESCRIPTION
While updating the YBNDSWI encoding for the Custom-3 move, I accidentally transcribed the wrong candidate encoding (I used the candidate with inverted polarity of imm[4]). The reason we ultimately chose this scheme as the preferred one is that it has the same gate count as the one I accidentally transcribed, but a slightly simpler encoder (one fewer branch needed in the LLVM/GCC backends).


Fixes: https://github.com/riscv/riscv-cheri/issues/1031