### PR TITLE
Typo fixes: Dscratch0/1. Debug CSRs are no longer renamed.

### DIFF
--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -79,7 +79,7 @@ apply.
 
 ==== Core Debug Registers
 
-{cheri_base_ext_name} and extends debug CSRs that are designated to
+{cheri_base_ext_name} extends debug CSRs that are designated to
 hold addresses to be able to hold capabilities. The extended debug CSRs are
 listed in xref:dcsrnames-renamed[xrefstyle=short].
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -79,8 +79,8 @@ apply.
 
 ==== Core Debug Registers
 
-{cheri_base_ext_name} renames and extends debug CSRs that are designated to
-hold addresses to be able to hold capabilities. The renamed debug CSRs are
+{cheri_base_ext_name} and extends debug CSRs that are designated to
+hold addresses to be able to hold capabilities. The extended debug CSRs are
 listed in xref:dcsrnames-renamed[xrefstyle=short].
 
 The <<pcc>> must grant <<asr_perm>> to access debug CSRs. This permission is
@@ -99,8 +99,8 @@ Debug Program Counter (dpc)::
 .Debug program counter
 include::img/dpcreg.edn[]
 
-[#dscratch0,reftext="dscratch1"]
-Debug Scratch Register 1 (dscratch1)::
+[#dscratch0,reftext="dscratch0"]
+Debug Scratch Register 0 (dscratch0)::
 <<dscratch0>> is an optional DXLEN-bit scratch register that can be used by implementations which need it.
 +
 .Debug scratch 0 register


### PR DESCRIPTION
Fix minor typos in the spec:

- Use `dscratch0` where it was obviously meant instead of `dscratch1`.

- Debug CSRs are no longer renamed by RVY - they retain their original name.