### PR TITLE
clarify subset in yss and ybld

### DIFF
--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -34,7 +34,9 @@ Set `{cd}.tag=1` if:
 . `{cs1}.tag=1`, and
 . `{cs1}` passes all <<section_cap_integrity,integrity>> checks, and
 . `{cs1}` is not sealed, and
-. `{cs2}` 's permissions and bounds are equal to or a subset of `{cs1}` 's, and
+. `{cs2}` has no permission bit set in it's <<AP-field>> which is not set in `{cs1}` 's, and
+. `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
+. `{cs1}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
 . `{cs2}` passes all <<section_cap_integrity,integrity>> checks, and
 . any extension-specific constraints on <<CBLD>> hold.
 +

--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -34,7 +34,7 @@ Set `{cd}.tag=1` if:
 . `{cs1}.tag=1`, and
 . `{cs1}` passes all <<section_cap_integrity,integrity>> checks, and
 . `{cs1}` is not sealed, and
-. `{cs2}` has no permission granted in its <<AP-field>> or <<SDP-field>> which is granted by `{cs1}`, and
+. all permissions granted by either the <<AP-field>> or <<SDP-field>> of `{cs2}` are also granted by those of `{cs1}`, and
 . `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
 . `{cs1}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
 . `{cs2}` passes all <<section_cap_integrity,integrity>> checks, and

--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -34,7 +34,7 @@ Set `{cd}.tag=1` if:
 . `{cs1}.tag=1`, and
 . `{cs1}` passes all <<section_cap_integrity,integrity>> checks, and
 . `{cs1}` is not sealed, and
-. `{cs2}` has no permission bit set in it's <<AP-field>> which is not set in `{cs1}` 's, and
+. `{cs2}` has no permission granted in its <<AP-field>> or <<SDP-field>> which is granted by `{cs1}`, and
 . `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
 . `{cs1}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
 . `{cs2}` passes all <<section_cap_integrity,integrity>> checks, and

--- a/src/cheri/insns/scss_32bit.adoc
+++ b/src/cheri/insns/scss_32bit.adoc
@@ -14,7 +14,7 @@ endif::[]
 include::new_encoding_note.adoc[]
 
 Synopsis::
-Capability Subset
+{SCSS_DESC}
 
 Mnemonic::
 `{scss_lc} rd, {cs1}, {cs2}`
@@ -25,7 +25,9 @@ include::wavedrom/scss.adoc[]
 Description::
 `rd` is set to 1 if:
 . the {ctag} of capabilities `{cs1}` and `{cs2}` are equal, and
-. `{cs2}` 's permissions and bounds are equal to or a subset of `{cs1}` 's, and
+. `{cs2}` has no permission bit set in it's <<AP-field>> which is not set in `{cs1}` 's, and
+. `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
+. `{cs1}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
 . neither `{cs1}` nor `{cs2}` fail any <<section_cap_integrity,integrity>> checks
 . any extension-specific constraints capability subset relationships hold.
 

--- a/src/cheri/insns/scss_32bit.adoc
+++ b/src/cheri/insns/scss_32bit.adoc
@@ -25,7 +25,7 @@ include::wavedrom/scss.adoc[]
 Description::
 `rd` is set to 1 if:
 . the {ctag} of capabilities `{cs1}` and `{cs2}` are equal, and
-. `{cs2}` has no permission granted in its <<AP-field>> or <<SDP-field>> which is granted by `{cs1}`, and
+. all permissions granted by either the <<AP-field>> or <<SDP-field>> of `{cs2}` are also granted by those of `{cs1}`, and
 . `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
 . `{cs1}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
 . neither `{cs1}` nor `{cs2}` fail any <<section_cap_integrity,integrity>> checks

--- a/src/cheri/insns/scss_32bit.adoc
+++ b/src/cheri/insns/scss_32bit.adoc
@@ -25,7 +25,7 @@ include::wavedrom/scss.adoc[]
 Description::
 `rd` is set to 1 if:
 . the {ctag} of capabilities `{cs1}` and `{cs2}` are equal, and
-. `{cs2}` has no permission bit set in it's <<AP-field>> which is not set in `{cs1}` 's, and
+. `{cs2}` has no permission granted in its <<AP-field>> or <<SDP-field>> which is granted by `{cs1}`, and
 . `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
 . `{cs1}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
 . neither `{cs1}` nor `{cs2}` fail any <<section_cap_integrity,integrity>> checks


### PR DESCRIPTION
Avoiding using the word subset when it hasn't been defined
