### PR TITLE
Fix YAMASK draft opcode allocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DOCS := riscv-privileged riscv-unprivileged riscv-cheri riscv-cheri-full
 
 RELEASE_TYPE ?= draft
 GIT_SHORT_HASH ?= -$(shell git rev-parse --short HEAD || true)
-NEXT_VERSION = v0.9.8.1
+NEXT_VERSION = v0.9.8.2
 ifeq ($(RELEASE_TYPE), draft)
 CHERI_SPEC_VERSION ?= $(NEXT_VERSION)-draft$(GIT_SHORT_HASH)
 else

--- a/src/cheri/insns/wavedrom/cram.adoc
+++ b/src/cheri/insns/wavedrom/cram.adoc
@@ -5,9 +5,9 @@
   {bits:  7, name: 'opcode',     attr: ['7', 'RVY-A=1111011'],    type: 8},
   {bits:  5, name: 'rd',         attr: ['5', 'dest'],             type: 2},
   {bits:  3, name: 'funct3',     attr: ['3', 'RVY-R=000'],        type: 8},
-  {bits:  5, name: '{cs1}',      attr: ['5', 'src'],              type: 4},
-  {bits:  5, name: 'funct5',     attr: ['5', '{CRAM}=00110'],     type: 3},
-  {bits:  7, name: 'funct7',     attr: ['7', 'RVY-2OP-YX=1111010'], type: 3},
+  {bits:  5, name: 'rs1',        attr: ['5', 'src'],              type: 4},
+  {bits:  5, name: 'funct5',     attr: ['5', '{CRAM}=00000'],     type: 3},
+  {bits:  7, name: 'funct7',     attr: ['7', 'RVY-2OP-XX=1111000'], type: 3},
 ]}
 ....
 

--- a/src/cheri/insns/wavedrom/gcmode.adoc
+++ b/src/cheri/insns/wavedrom/gcmode.adoc
@@ -6,7 +6,7 @@
   {bits:  5, name: 'rd',         attr: ['5', 'dest'],             type: 2},
   {bits:  3, name: 'funct3',     attr: ['3', 'RVY-R=000'],        type: 8},
   {bits:  5, name: '{cs1}',      attr: ['5', 'src'],              type: 4},
-  {bits:  5, name: 'funct5',     attr: ['5', '{GCMODE}=00111'],   type: 3},
+  {bits:  5, name: 'funct5',     attr: ['5', '{GCMODE}=00110'],   type: 3},
   {bits:  7, name: 'funct7',     attr: ['7', 'RVY-2OP-YX=1111010'], type: 3},
 ]}
 ....

--- a/src/cheri/scripts/rvy_instruction_encodings.py
+++ b/src/cheri/scripts/rvy_instruction_encodings.py
@@ -562,7 +562,7 @@ def get_custom3_insts():
         next_r2type("YLENR", rs1="{cs1}", rd="rd"),
         next_r2type("YTAGR", rs1="{cs1}", rd="rd"),
         next_r2type("YTYPER", rs1="{cs1}", rd="rd"),
-        next_r2type("YAMASK", rs1="{cs1}", rd="rd"),
+        next_r2type("YAMASK", rs1="rs1", rd="rd"),
         next_r2type("YSENTRY", rs1="{cs1}", rd="{cd}", ext="Zysentry"),
         next_r2type("YMODER", rs1="{cs1}", rd="rd", ext="Zyhybrid"),
     ]


### PR DESCRIPTION
It was accidentally flagged as having a YLEN input even though it is actually only XLEN. Since we encode this in the opcode allocation it ended up in the wrong bucket. This also YMODER causes YMODER to move, but since it's just one instruction and the final opcodes are not completely frozen it probably does not make sense to add a new RESERVED instruction and keep YMODER where it was before.