### PR TITLE
Clarify that illegal AP states are reserved for RV64Y

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -477,7 +477,7 @@ endif::[]
 Capability encoding formats may impose additional constraints to reduce the number of bits necessary to represent permissions.
 
 .<<CLRPERM>> base rules for <<rv64y_cap_description,{rv64y_uni_base_name}>>
-[float="center",align="center",cols="2,2,4",options="header"]
+[#base_clrperm_rule_summary,float="center",align="center",cols="2,2,4",options="header"]
 |===
 | <<CLRPERM>> Rule                          | Permission   | Valid only if
 | [[perm_req:base:c:r-or-w,base-1]]base-1   | <<c_perm>>   | <<r_perm>> or <<w_perm>>

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -477,7 +477,7 @@ endif::[]
 Capability encoding formats may impose additional constraints to reduce the number of bits necessary to represent permissions.
 
 
-.Base permission rules for <<rv64y_cap_description,{rv64y_uni_base_name}>>
+.Base permission rules Architectural Permissions
 [#base_clrperm_rule_summary,float="center",align="center",cols="2,2,4",options="header"]
 |===
 | <<CLRPERM>> Rule                          | Permission   | Valid only if

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -477,7 +477,7 @@ endif::[]
 Capability encoding formats may impose additional constraints to reduce the number of bits necessary to represent permissions.
 
 
-.Base permission rules Architectural Permissions
+.<<CLRPERM>> base rules
 [#base_clrperm_rule_summary,float="center",align="center",cols="2,2,4",options="header"]
 |===
 | <<CLRPERM>> Rule                          | Permission   | Valid only if

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -476,7 +476,8 @@ endif::[]
 
 Capability encoding formats may impose additional constraints to reduce the number of bits necessary to represent permissions.
 
-.<<CLRPERM>> base rules for <<rv64y_cap_description,{rv64y_uni_base_name}>>
+
+.Base permission rules for <<rv64y_cap_description,{rv64y_uni_base_name}>>
 [#base_clrperm_rule_summary,float="center",align="center",cols="2,2,4",options="header"]
 |===
 | <<CLRPERM>> Rule                          | Permission   | Valid only if

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -79,10 +79,10 @@ A permission is granted if its corresponding bit, and those of any dependent per
 otherwise, the capability does not grant that permission.
 
 Certain combinations of permissions are impractical.
-For example, <<c_perm>> is superfluous when the capability does not grant either <<r_perm>> or <<w_perm>>
+For example, <<c_perm>> is superfluous when the capability does not grant either <<r_perm>> or <<w_perm>>.
 Therefore, it is only legal to encode a subset of all combinations and any invalid states are _reserved_ in the <<AP-field>> encoding.
 
-NOTE: Reserved states can be used in future to allow different formats to be encoded within the <<AP-field>>.
+NOTE: Reserved states can be used in the future to allow additional permissions to be encoded within the <<AP-field>>.
 
 .Encoding of architectural permissions for {rv64y_uni_base_name}
 [#cap_perms_encoding64,align="center",options=header,cols="^10%,90%",width="75%"]

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -78,7 +78,9 @@ The permissions field is {cap_rv64_perms_width} bits wide and is encoded using o
 A permission is granted if its corresponding bit, and those of any dependent permissions, are set;
 otherwise, the capability does not grant that permission.
 
-The rules in <<base_clrperm_rule_summary>> are enforced and any invalid states are _reserved_ in the <<AP-field>> encoding.
+Certain combinations of permissions are impractical.
+For example, <<c_perm>> is superfluous when the capability does not grant either <<r_perm>> or <<w_perm>>
+Therefore, it is only legal to encode a subset of all combinations and any invalid states are _reserved_ in the <<AP-field>> encoding.
 
 NOTE: Reserved states can be used in future to allow different formats to be encoded within the <<AP-field>>.
 

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -77,10 +77,10 @@ endif::[]
 The permissions field is {cap_rv64_perms_width} bits wide and is encoded using one bit per architectural permission as shown in xref:cap_perms_encoding64[xrefstyle=short].
 A permission is granted if its corresponding bit, and those of any dependent permissions, are set;
 otherwise, the capability does not grant that permission.
-Certain combinations of permissions are impractical. For example, <<c_perm>> is superfluous when the capability does not grant either <<r_perm>> or <<w_perm>>.
-Therefore, it is only legal to encode a subset of all combinations, but this capability encoding does not make use of this redundancy as there are sufficient reserved bits.
 
-NOTE: In the future, if there are no further remaining reserved bits, but extensions need to allocate further capability metadata bits, it will be possible to use the redundancy to create a future version of this encoding that is fully _compatible for all software_ but with observable differences in the in-memory representation of capabilities.
+The rules in <<base_clrperm_rule_summary>> are enforced and any invalid states are _reserved_ in the <<AP-field>> encoding.
+
+NOTE: Reserved states can be used in future to allow different formats to be encoded within the <<AP-field>>.
 
 .Encoding of architectural permissions for {rv64y_uni_base_name}
 [#cap_perms_encoding64,align="center",options=header,cols="^10%,90%",width="75%"]


### PR DESCRIPTION
If we clarify that such states are reserved, then in future states like C without R or W can be assigned a new meaning, such as SE/US permission.