### PR TITLE
Move YSENTRY into the base and rename it

### DIFF
--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -116,7 +116,7 @@ include::{generated_dir}/new_instructions_table_body.adoc[]
 . 0.9.5 had SH[123]ADD, and the .UW forms, replaced by capability versions.
 .. This is no longer the case, so now the capability versions have new encodings.
 . There is no longer an SH4ADD instruction (i.e., the integer version).
-. The <<{SENTRY}>> instruction is now in a separate extension {rvy_sentry_insn_ext_name}.
+. The <<{SENTRY}>> instruction is now in a separate extension Zysentry.
 
 ====
 

--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -116,7 +116,7 @@ include::{generated_dir}/new_instructions_table_body.adoc[]
 . 0.9.5 had SH[123]ADD, and the .UW forms, replaced by capability versions.
 .. This is no longer the case, so now the capability versions have new encodings.
 . There is no longer an SH4ADD instruction (i.e., the integer version).
-. The <<{SENTRY}>> instruction is now in a separate extension Zysentry.
+. The YSENTRY instruction is now in a separate extension Zysentry.
 
 ====
 

--- a/src/cheri/app-cheri-instructions.adoc
+++ b/src/cheri/app-cheri-instructions.adoc
@@ -116,7 +116,7 @@ include::{generated_dir}/new_instructions_table_body.adoc[]
 . 0.9.5 had SH[123]ADD, and the .UW forms, replaced by capability versions.
 .. This is no longer the case, so now the capability versions have new encodings.
 . There is no longer an SH4ADD instruction (i.e., the integer version).
-. The YSENTRY instruction is now in a separate extension Zysentry.
+. The {SENTRY} instruction was merged into {YSEAL} in the base ISA.
 
 ====
 

--- a/src/cheri/app-hybrid-usage.adoc
+++ b/src/cheri/app-hybrid-usage.adoc
@@ -179,7 +179,7 @@ J -> J: Access runtime data using\nexplicit capabilities
 J -> J: Execute ""MODESW_INT"" (Switches to {cheri_int_mode_name_nofmt})
 
 == Calling Runtime Helpers ==
-J -> R: Call helper (Secure Entry Point Capability) (Switches to {cheri_cap_mode_name_nofmt})
+J -> R: Call helper (Sealed Entry Point Capability) (Switches to {cheri_cap_mode_name_nofmt})
 R -> R: Execute safe runtime code
 R -> J: Return to JIT code (Switches to {cheri_int_mode_name_nofmt})
 

--- a/src/cheri/app-hybrid-usage.adoc
+++ b/src/cheri/app-hybrid-usage.adoc
@@ -156,7 +156,7 @@ The main difference is that the generated code (running in {cheri_int_mode_name}
 * **Accessing C Runtime Data:** The code can access data in the surrounding C++ runtime using explicit capability-based load/store operations.
   At the same time, it uses standard integer addresses for its own heap via <<ddc>>.
   This can be achieved by executing <<MODESW_CAP>> before the memory access and <<MODESW_INT>> to return back to address interpretation.
-* **Calling Runtime Helpers:** Runtime helper functions are given to the code as sentry capabilities.
+* **Calling Runtime Helpers:** Runtime helper functions are given to the code as a <<sentry_cap>>.
    When the code calls these helpers, the processor automatically switches back to {cheri_cap_mode_name}.
   This lets the runtime run with full safety before returning to the JIT code.
 +
@@ -179,7 +179,7 @@ J -> J: Access runtime data using\nexplicit capabilities
 J -> J: Execute ""MODESW_INT"" (Switches to {cheri_int_mode_name_nofmt})
 
 == Calling Runtime Helpers ==
-J -> R: Call helper (Sentry Capability) (Switches to {cheri_cap_mode_name_nofmt})
+J -> R: Call helper (Secure Entry Point Capability) (Switches to {cheri_cap_mode_name_nofmt})
 R -> R: Execute safe runtime code
 R -> J: Return to JIT code (Switches to {cheri_int_mode_name_nofmt})
 

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -406,6 +406,10 @@ endif::support_varxlen[]
 :YSEAL_LC:   yseal
 :YSEAL_DESC: Seal a capability
 
+:SENTRY:      YSENTRY
+:SENTRY_LC:   ysentry
+:SENTRY_DESC: Create a sealed entry point capability
+
 :YUNSEAL:    YUNSEAL
 :YUNSEAL_LC: yunseal
 :YUNSEAL_DESC: Unseal a capability authorized using an unsealing capability

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -30,9 +30,6 @@ endif::support_varxlen[]
 
 // 32-bit encodings added by RVY
 :rvy_file_name:            {cheri_base_ext_name}_insns_table_body
-// 32-bit encoding for YSENTRY
-:rvy_sentry_insn_ext_name:      Zysentry
-:rvy_sentry_insn_file_name:     {rvy_sentry_insn_ext_name}_insns_table_body
 // 32-bit encodings modified by RVY
 :rvy_i_mod_ext_name:       RVI ({cheri_base_ext_name} modified behavior)
 :rvy_i_mod_file_name:      {cheri_base_ext_name}_I_mod_insns_table_body
@@ -334,9 +331,9 @@ endif::support_varxlen[]
 :SH4ADD_CHERI:    YSH4ADD
 :SH4ADD_CHERI_LC: ysh4add
 
-:SENTRY:                  YSENTRY
-:SENTRY_LC:               ysentry
-:SENTRY_DESC:             Seal capability as a sentry
+:SENTRY:                  YUSEAL
+:SENTRY_LC:               yuseal
+:SENTRY_DESC:             Unauthorized seal capability
 
 :SH1ADD_UW_CHERI:    YSH1ADD.UW
 :SH1ADD_UW_CHERI_LC: ysh1add.uw
@@ -411,11 +408,11 @@ endif::support_varxlen[]
 
 :YSEAL:      YSEAL
 :YSEAL_LC:   yseal
-:YSEAL_DESC: Seal a capability using a sealing capability
+:YSEAL_DESC: Seal a capability authorized using a sealing capability
 
 :YUNSEAL:    YUNSEAL
 :YUNSEAL_LC: yunseal
-:YUNSEAL_DESC: Unseal a capability using an unsealing capability
+:YUNSEAL_DESC: Unseal a capability authorized using an unsealing capability
 
 // Variables for register names
 // Prefix for numbered registers

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -331,10 +331,6 @@ endif::support_varxlen[]
 :SH4ADD_CHERI:    YSH4ADD
 :SH4ADD_CHERI_LC: ysh4add
 
-:SENTRY:                  YUSEAL
-:SENTRY_LC:               yuseal
-:SENTRY_DESC:             Unauthorized seal capability
-
 :SH1ADD_UW_CHERI:    YSH1ADD.UW
 :SH1ADD_UW_CHERI_LC: ysh1add.uw
 :SH2ADD_UW_CHERI:    YSH2ADD.UW
@@ -408,7 +404,7 @@ endif::support_varxlen[]
 
 :YSEAL:      YSEAL
 :YSEAL_LC:   yseal
-:YSEAL_DESC: Seal a capability authorized using a sealing capability
+:YSEAL_DESC: Seal a capability
 
 :YUNSEAL:    YUNSEAL
 :YUNSEAL_LC: yunseal

--- a/src/cheri/cheri_isa_tables.adoc
+++ b/src/cheri/cheri_isa_tables.adoc
@@ -208,18 +208,6 @@ include::insns/prefetch.w.adoc[]
 <<<
 endif::[]
 
-[#rvy_sentry_insn_table, reftext="{rvy_sentry_insn_ext_name}"]
-=== {rvy_sentry_insn_ext_name}
-
-{rvy_sentry_insn_ext_name} adds the {SENTRY} instruction.
-
-.{rvy_sentry_insn_ext_name} instruction extension
-[#{rvy_sentry_insn_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_sentry_insn_file_name}.adoc[]
-|==============================================================================
-
 ifndef::cheri_ratification_v1_only[]
 
 [#rvy_bndsrdw_insn_table, reftext="{rvy_bndsrdw_insn_ext_name}"]

--- a/src/cheri/csv/CHERI_ISA.csv
+++ b/src/cheri/csv/CHERI_ISA.csv
@@ -18,7 +18,7 @@ AUIPC_CHERI,AUIPCC,{rvy_i_mod_ext_name},✔,✔,,,,AUIPC,,,{AUIPC_CHERI_DESC},,,
 {SCHI_BASE},N/A,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCHI_BASE_DESC},,,,,,,,,v1
 {SCHI},SCHI,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCHI_DESC},,,,,,,,,v1
 {SCEQ},SCEQ,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCEQ_DESC},,,,,,,,,v1
-{SENTRY},SENTRY,{rvy_sentry_insn_ext_name},✔,✔,,,OP,R-type,,,{SENTRY_DESC},,,,,,,,,v1
+{SENTRY},SENTRY,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SENTRY_DESC},,,,,,,,,v1
 {SCSS},SCSS,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCSS_DESC},,,,,,,,,v1
 {CBLD},CBLD,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{CBLD_DESC},,,,,,,,,v1
 {YSUNSEAL},N/A,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{YSUNSEAL_DESC},,,,,,,,,v1

--- a/src/cheri/csv/CHERI_ISA.csv
+++ b/src/cheri/csv/CHERI_ISA.csv
@@ -18,7 +18,7 @@ AUIPC_CHERI,AUIPCC,{rvy_i_mod_ext_name},✔,✔,,,,AUIPC,,,{AUIPC_CHERI_DESC},,,
 {SCHI_BASE},N/A,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCHI_BASE_DESC},,,,,,,,,v1
 {SCHI},SCHI,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCHI_DESC},,,,,,,,,v1
 {SCEQ},SCEQ,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCEQ_DESC},,,,,,,,,v1
-{SENTRY},SENTRY,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SENTRY_DESC},,,,,,,,,v1
+{YSEAL},YSEAL,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{YSEAL_DESC},,,,,,,,,v1
 {SCSS},SCSS,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCSS_DESC},,,,,,,,,v1
 {CBLD},CBLD,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{CBLD_DESC},,,,,,,,,v1
 {YSUNSEAL},N/A,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{YSUNSEAL_DESC},,,,,,,,,v1
@@ -80,5 +80,4 @@ SH3ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word
 SH4ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
 HLV_CAP,HLV.C,{rvy_h_ext_name},✔,✔,,,SYSTEM,,,,Hypervisor virtual machine load capability,V=1,MODE==U AND hstatus.HU=0,,,,,,,post-v1
 HSV_CAP,HSV.C,{rvy_h_ext_name},✔,✔,,,SYSTEM,,,,Hypervisor virtual machine store capability,V=1,MODE==U AND hstatus.HU=0,,,,,,,post-v1
-{YSEAL},N/A,{cheri_seal_ext_name},✔,✔,,,OP,R-type,,,{YSEAL_DESC},,,,,,,,,post-v1
 {YUNSEAL},N/A,{cheri_seal_ext_name},✔,✔,,,OP,R-type,,,{YUNSEAL_DESC},,,,,,,,,post-v1

--- a/src/cheri/insns/dret.adoc
+++ b/src/cheri/insns/dret.adoc
@@ -14,7 +14,7 @@ include::wavedrom/dret.adoc[]
 
 Description::
 <<DRET_CHERI>> returns from debug mode.
-It unseals <<dpc_y>> if it is sealed as a <<sentry_cap>> and writes the result into <<pcc>>.
+It unseals <<dpc_y>> if it is sealed and writes the result into <<pcc>>.
 It also restores <<ddc>> from <<dddc>>.
 
 NOTE: The <<DRET_CHERI>> instruction is a documented method of exiting debug mode.

--- a/src/cheri/insns/dret.adoc
+++ b/src/cheri/insns/dret.adoc
@@ -14,7 +14,7 @@ include::wavedrom/dret.adoc[]
 
 Description::
 <<DRET_CHERI>> returns from debug mode.
-It unseals <<dpc_y>> if it is sealed and writes the result into <<pcc>>.
+It unseals <<dpc_y>> if it is a <<sentry_cap>> and writes the result into <<pcc>>.
 It also restores <<ddc>> from <<dddc>>.
 
 NOTE: The <<DRET_CHERI>> instruction is a documented method of exiting debug mode.

--- a/src/cheri/insns/jal_32bit.adoc
+++ b/src/cheri/insns/jal_32bit.adoc
@@ -19,7 +19,7 @@ Direct jump with an address offset.
 +
 . The target address is obtained by adding the sign-extended 20-bit J-immediate to `<<pcc>>.address`.
 . The target <<pcc>> is obtained by applying the target address to the <<pcc>> of the JAL instruction, using the semantics of the <<SCADDR>> instruction.
-. The <<pcc>> of the next instruction is _sealed_ and written to `{cd}`.
+. The <<pcc>> of the next instruction is sealed as a <<sentry_cap>> and written to `{cd}`.
 . Jump to the target <<pcc>>.
 +
 NOTE: A future extension may raise an exception on the branch instruction itself if fetching a minimum sized instruction at the target <<pcc>> will raise a _{cheri_excep_name_pc}_.

--- a/src/cheri/insns/jal_32bit.adoc
+++ b/src/cheri/insns/jal_32bit.adoc
@@ -19,11 +19,8 @@ Direct jump with an address offset.
 +
 . The target address is obtained by adding the sign-extended 20-bit J-immediate to `<<pcc>>.address`.
 . The target <<pcc>> is obtained by applying the target address to the <<pcc>> of the JAL instruction, using the semantics of the <<SCADDR>> instruction.
-. The <<pcc>> of the next instruction is _sealed_ as a _backward-edge_ <<sentry_cap>> and written to `{cd}`.
+. The <<pcc>> of the next instruction is _sealed_ and written to `{cd}`.
 . Jump to the target <<pcc>>.
-+
-NOTE: If the only supported <<sec_cap_type>> is zero, then no backward-edge <<sentry_cap, sentry capabilities>> exist, and so _sealing_ has no effect.
- This behavior requires non-zero <<sec_cap_type>> values to be implemented, such as by the <<section_rvy_sentry_insn_ext>> extension.
 +
 NOTE: A future extension may raise an exception on the branch instruction itself if fetching a minimum sized instruction at the target <<pcc>> will raise a _{cheri_excep_name_pc}_.
   Performing the <<pcc>> bounds check at the branch source instead of on instruction fetch is helpful for debugging and can simplify the implementation of CPUs with very short pipelines.

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -44,6 +44,8 @@ In this case the specialized operation becomes:
  . The <<pcc>> of the next instruction is written to `{cd}`.
  . Jump to the target <<pcc>>.
 ====
++
+NOTE: The standard software calling convention uses 'x1' as the link register.
 endif::[]
 ifndef::generic_JALR[]
 // simple description with only unrestricted sentries
@@ -54,14 +56,11 @@ Indirect jump to the target capability in `{cs1}` with an address offset.
 . The target address is obtained by adding the sign-extended 12-bit I-immediate to `{cs1}.address`, then setting the least-significant bit of the result to zero.
 . Unseal the target <<pcc>> if it is a <<sentry_cap>>, `{cs1}.address[0]` is zero, and the I-immediate is zero.
 . Set the address of the target <<pcc>> to the target address using the semantics of the <<SCADDR>> instruction.
-. The <<pcc>> of the next instruction is sealed and written to `{cd}`.
+. The <<pcc>> of the next instruction is sealed as a <<sentry_cap>> and written to `{cd}`.
 . Jump to the target <<pcc>>.
-+
 endif::[]
 +
 NOTE: A future extension may raise an exception on the <<JALR_CHERI>> instruction itself if the target <<pcc>> will raise a {cheri_excep_name_pc} at the target.
-+
-NOTE: The standard software calling convention uses 'x1' as the link register.
 
 Included in::
 <<rvy_i_mod_insn_table>>

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -14,12 +14,13 @@ include::wavedrom/ct-unconditional-2.adoc[]
 
 include::base_isa_extension.adoc[]
 
+ifdef::generic_JALR[]
+//full description including backwards/forwards-edge sentries
 Description::
 Indirect jump to the target capability in `{cs1}` with an address offset.
 +
 NOTE: The description below is generic, and implementations which need control-flow-integrity will include at least one extension which defines one or more <<sentry_cap, sentry capabilities>>.
  All such extensions are required to detail the specialized behavior of JALR to remove any ambiguity.
- For example, see <<section_rvy_sentry_insn_ext>>.
 +
 . `{cs1}` is written to the target <<pcc>>.
 . If `{cd}`≠x0, `{cs1}` is _sealed_ and `{cs1}` is not a _forward-edge_ <<sentry_cap>>, then the behavior is _reserved_^1^.
@@ -43,6 +44,20 @@ In this case the specialized operation becomes:
  . The <<pcc>> of the next instruction is written to `{cd}`.
  . Jump to the target <<pcc>>.
 ====
+endif::[]
+ifndef::generic_JALR[]
+//simple descrption with unrestricted sentries
+Description::
+Indirect jump to the target capability in `{cs1}` with an address offset.
++
+. `{cs1}` is written to the target <<pcc>>.
+. The target address is obtained by adding the sign-extended 12-bit I-immediate to `{cs1}.address`, then setting the least-significant bit of the result to zero.
+. Unseal the target <<pcc>> if it is sealed, `{cs1}.address[0]` is zero, and the I-immediate is zero.
+. Set the address of the target <<pcc>> to the target address using the semantics of the <<SCADDR>> instruction.
+. The <<pcc>> of the next instruction is sealed and written to `{cd}`.
+. Jump to the target <<pcc>>.
++
+endif::[]
 +
 NOTE: A future extension may raise an exception on the <<JALR_CHERI>> instruction itself if the target <<pcc>> will raise a {cheri_excep_name_pc} at the target.
 +

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -46,13 +46,13 @@ In this case the specialized operation becomes:
 ====
 endif::[]
 ifndef::generic_JALR[]
-//simple descrption with unrestricted sentries
+// simple description with only unrestricted sentries
 Description::
 Indirect jump to the target capability in `{cs1}` with an address offset.
 +
 . `{cs1}` is written to the target <<pcc>>.
 . The target address is obtained by adding the sign-extended 12-bit I-immediate to `{cs1}.address`, then setting the least-significant bit of the result to zero.
-. Unseal the target <<pcc>> if it is sealed, `{cs1}.address[0]` is zero, and the I-immediate is zero.
+. Unseal the target <<pcc>> if it is a <<sentry_cap>>, `{cs1}.address[0]` is zero, and the I-immediate is zero.
 . Set the address of the target <<pcc>> to the target address using the semantics of the <<SCADDR>> instruction.
 . The <<pcc>> of the next instruction is sealed and written to `{cd}`.
 . Jump to the target <<pcc>>.

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -16,12 +16,12 @@ Mnemonic::
 Encoding::
 include::wavedrom/sentry.adoc[]
 
-NOTE: `{cs1}{ne}x0` is currently reserved.
+NOTE: `{cs1}{ne}x0` is currently _reserved_.
 
 Description::
 Copy `{cs2}` to `{cd}`.
 +
-Seal the capability in `{cd}` by setting `{cd}.ct=1` if `{cs1}=x0`.
+Seal the capability in `{cd}` by setting `{cd}.ct=1`.
 +
 Set `{cd}.tag=0` if `{cs2}` is sealed.
 +
@@ -52,7 +52,11 @@ Encoding::
 {SENTRY} is a pseudoinstruction for <<YSEAL>> with `{cs1}=x0`.
 
 Description::
-Seal the capability in `{cs2}` as a sealed entry point capability and write the result to `{cd}`.
+Copy `{cs2}` to `{cd}`.
++
+Seal the capability in `{cd}` by setting `{cd}.ct=1`.
++
+Set `{cd}.tag=0` if `{cs2}` is sealed.
 
 Included in::
 <<rvy_insn_table>>

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -1,5 +1,5 @@
-[#SENTRY,reftext="{SENTRY}"]
-==== {SENTRY}
+[#YSEAL,reftext="{YSEAL}"]
+==== {YSEAL}
 
 include::new_encoding_note.adoc[]
 
@@ -8,28 +8,31 @@ NOTE: *CHERI v9 Note:* this instruction was called CSEALENTRY.
 endif::[]
 
 Synopsis::
-{SENTRY_DESC}
+{YSEAL_DESC}
 
 Mnemonic::
-`{sentry_lc} {cd}, {cs1}`
+`{yseal_lc} {cd}, {cs1}, {cs2}`
 
 Encoding::
 include::wavedrom/sentry.adoc[]
 
+NOTE: '{cs1}{ne}x0' is currently reserved.
+
 Description::
-Copy `{cs1}` to `{cd}`.
+Copy `{cs2}` to `{cd}`.
 +
-Seal the capability in `{cd}` by setting `{cd}.ct=1`.
+Seal the capability in `{cd}` by setting `{cd}.ct=1` if `{cs1}=x0`.
 +
-Set `{cd}.tag=0` if `{cs1}` is sealed.
+Set `{cd}.tag=0` if `{cs2}` is sealed.
 +
-NOTE: This is an unauthorized sealing instruction of type 1, future extensions may require authority to be able to perform the sealing action of different <<CT-field>> values.
+NOTE: Future extensions may allow `{cs1}{ne}x0` to specify an authorising capability to perform the sealing action, and also to specify the destination <<CT-field>> value.
 +
 NOTE: If the capability encoding format does not support a <<CT-field>> of type 1, then this instruction is _reserved_.
+ Future capability formats may redefine the behavior for <<CT-field>> values greater than 1.
 
 Included in::
 <<rvy_insn_table>>
 
 Operation::
 +
-sail::execute[clause="SENTRY(_, _)",part=body,unindent]
+TODO

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -25,7 +25,8 @@ Seal the capability in `{cd}` by setting `{cd}.ct=1`.
 +
 Set `{cd}.tag=0` if `{cs2}` is sealed.
 +
-NOTE: Future extensions may allow `{cs1}{ne}x0` to specify an authorizing capability to perform the sealing action, and also to specify the destination <<sec_cap_type>> value.
+NOTE: A future extension may allow `{cs1}{ne}x0` to specify an authorizing capability to perform the sealing action, and also to specify the destination <<sec_cap_type>> value.
+ The same extension is likely to add privileged state to _disallow_ the use of `{cs1}=x0` for sealing the output without an authorizing capability.
 +
 NOTE: If the capability encoding format does not support a <<CT-field>> of type 1, then this instruction is _reserved_.
  Future capability formats may redefine the behavior for <<CT-field>> values greater than 1.

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -19,14 +19,16 @@ include::wavedrom/sentry.adoc[]
 Description::
 Copy `{cs1}` to `{cd}`.
 +
-Set the capability type (<<sec_cap_type>>) of `{cd}` to the value `1`, representing a sentry type.
-+
-NOTE: {SENTRY} does not require any permission to seal, and so is considered <<sec_cap_type_ambient,ambient>>.
+Seal the capability in `{cd}` by setting `{cd}.ct=1`.
 +
 Set `{cd}.tag=0` if `{cs1}` is sealed.
++
+NOTE: This is an unauthorized sealing instruction of type 1, future extensions may require authority to be able to perform the sealing action of different <<CT-field>> values.
++
+NOTE: If the capability encoding format does not support a <<CT-field>> of type 1, then this instruction is _reserved_.
 
 Included in::
-<<rvy_sentry_insn_table>>
+<<rvy_insn_table>>
 
 Operation::
 +

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -16,7 +16,7 @@ Mnemonic::
 Encoding::
 include::wavedrom/sentry.adoc[]
 
-NOTE: '{cs1}{ne}x0' is currently reserved.
+NOTE: `{cs1}{ne}x0` is currently reserved.
 
 Description::
 Copy `{cs2}` to `{cd}`.

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -54,7 +54,7 @@ Encoding::
 Description::
 Copy `{cs2}` to `{cd}`.
 +
-Seal the capability in `{cd}` by setting `{cd}.ct=1`.
+Seal the capability in `{cd}` as a <<sentry_cap>> by setting `{cd}.ct=1`.
 +
 Set `{cd}.tag=0` if `{cs2}` is sealed.
 

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -25,7 +25,7 @@ Seal the capability in `{cd}` by setting `{cd}.ct=1` if `{cs1}=x0`.
 +
 Set `{cd}.tag=0` if `{cs2}` is sealed.
 +
-NOTE: Future extensions may allow `{cs1}{ne}x0` to specify an authorising capability to perform the sealing action, and also to specify the destination <<CT-field>> value.
+NOTE: Future extensions may allow `{cs1}{ne}x0` to specify an authorizing capability to perform the sealing action, and also to specify the destination <<sec_cap_type>> value.
 +
 NOTE: If the capability encoding format does not support a <<CT-field>> of type 1, then this instruction is _reserved_.
  Future capability formats may redefine the behavior for <<CT-field>> values greater than 1.

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -36,3 +36,23 @@ Included in::
 Operation::
 +
 TODO
+
+<<<
+
+[#SENTRY,reftext="{SENTRY}"]
+==== {SENTRY}
+
+Synopsis::
+{SENTRY_DESC}
+
+Mnemonic::
+`{sentry_lc} {cd}, {cs2}`
+
+Encoding::
+{SENTRY} is a pseudoinstruction for <<YSEAL>> with `{cs1}=x0`.
+
+Description::
+Seal the capability in `{cs2}` as a sealed entry point capability and write the result to `{cd}`.
+
+Included in::
+<<rvy_insn_table>>

--- a/src/cheri/insns/wavedrom/sentry.adoc
+++ b/src/cheri/insns/wavedrom/sentry.adoc
@@ -5,9 +5,9 @@
   {bits:  7, name: 'opcode',     attr: ['7', 'RVY-A=1111011'],    type: 8},
   {bits:  5, name: '{cd}',       attr: ['5', 'dest'],             type: 2},
   {bits:  3, name: 'funct3',     attr: ['3', 'RVY-R=000'],        type: 8},
-  {bits:  5, name: '{cs1}',      attr: ['5', '0'],                type: 4},
-  {bits:  5, name: '{cs2}',      attr: ['5', 'src'],              type: 3},
-  {bits:  7, name: 'funct7',     attr: ['7', 'RVY-2OP-YY=0010111'], type: 3},
+  {bits:  5, name: '{cs1}',      attr: ['5', 'src1'],             type: 4},
+  {bits:  5, name: '{cs2}',      attr: ['5', 'src2'],             type: 4},
+  {bits:  7, name: 'funct7',     attr: ['7', '{YSEAL}=0010111'],  type: 3},
 ]}
 ....
 

--- a/src/cheri/insns/wavedrom/sentry.adoc
+++ b/src/cheri/insns/wavedrom/sentry.adoc
@@ -5,9 +5,9 @@
   {bits:  7, name: 'opcode',     attr: ['7', 'RVY-A=1111011'],    type: 8},
   {bits:  5, name: '{cd}',       attr: ['5', 'dest'],             type: 2},
   {bits:  3, name: 'funct3',     attr: ['3', 'RVY-R=000'],        type: 8},
-  {bits:  5, name: '{cs1}',      attr: ['5', 'src'],              type: 4},
-  {bits:  5, name: 'funct5',     attr: ['5', '{SENTRY}=00000'],   type: 3},
-  {bits:  7, name: 'funct7',     attr: ['7', 'RVY-2OP-YY=1111011'], type: 3},
+  {bits:  5, name: '{cs1}',      attr: ['5', '0'],                type: 4},
+  {bits:  5, name: '{cs2}',      attr: ['5', 'src'],              type: 3},
+  {bits:  7, name: 'funct7',     attr: ['7', 'RVY-2OP-YY=0010111'], type: 3},
 ]}
 ....
 

--- a/src/cheri/insns/yseal_32bit.adoc
+++ b/src/cheri/insns/yseal_32bit.adoc
@@ -1,21 +1,14 @@
 <<<
 
-[#YSEAL,reftext="{YSEAL}"]
-==== {YSEAL}
+[#YSEAL_ZYSEAL,reftext="{YSEAL} (Zyseal)"]
+==== {YSEAL} (Zyseal)
 
-Synopsis::
-{YSEAL_DESC}
+The behavior of the <<YSEAL>> instruction is extended to allow `{cs1}{ne}x0`.
 
-Mnemonic::
-`{YSEAL_LC} {cd}, {cs1}, {cs2}`
-
-Encoding::
-TODO
-
-Description::
+Extended Description::
 Construct, into `{cd}`, a sealed copy of the unsealed capability in `{cs2}`, using the type and authority from `{cs1}`.
 +
-Copy `{cs2}` into `{cd}`, and then...
+Copy `{cs2}` into `{cd}`, and then if `{cs1}{ne}x0`...
 +
 . Set the {ctag} of the capability in `{cd}` to zero if any of the following hold:
 +
@@ -31,7 +24,12 @@ Copy `{cs2}` into `{cd}`, and then...
 
 [NOTE]
 =====
-<<YSEAL>> uses the (in-bounds) _addresss_ of the authority in `{cs1}` as the
+If `{cs1}=x0` and <<CT-field>>=1 is not supported by the capability encoding format, then `{cs1}` is interpreted as a NULL capability causing `{cd}.tag=0`.
+=====
+
+[NOTE]
+=====
+<<YSEAL>> uses the (in-bounds) _address_ of the authority in `{cs1}` as the
 type in the resulting capability.
 If the authority has a nontrivial range,
 software can use <<SCADDR>> to select which type should be used.
@@ -62,7 +60,7 @@ the type called for by the address of `{cs1}`.
 =====
 
 Included in::
-{cheri_seal_ext_name}
+{cheri_base_ext_name}, extended in {cheri_seal_ext_name}
 
 Operation::
 +

--- a/src/cheri/insns/yseal_32bit.adoc
+++ b/src/cheri/insns/yseal_32bit.adoc
@@ -5,10 +5,10 @@
 
 The behavior of the <<YSEAL>> instruction is extended to allow `{cs1}{ne}x0`.
 
-Extended Description::
+Extended Description if `{cs1}{ne}x0`::
 Construct, into `{cd}`, a sealed copy of the unsealed capability in `{cs2}`, using the type and authority from `{cs1}`.
 +
-Copy `{cs2}` into `{cd}`, and then if `{cs1}{ne}x0`...
+Copy `{cs2}` into `{cd}`, and then...
 +
 . Set the {ctag} of the capability in `{cd}` to zero if any of the following hold:
 +
@@ -21,11 +21,6 @@ Copy `{cs2}` into `{cd}`, and then if `{cs1}{ne}x0`...
 --
 +
 . Set the <<sec_cap_type>> of `{cd}` to the address of `{cs1}`.
-
-[NOTE]
-=====
-If `{cs1}=x0` and <<CT-field>>=1 is not supported by the capability encoding format, then `{cs1}` is interpreted as a NULL capability causing `{cd}.tag=0`.
-=====
 
 [NOTE]
 =====

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -52,7 +52,6 @@ and so software should not assume `{cs1}==0` to be a pseudo-instruction for {cta
 // as appropriate for their intended uses.
 // =====
 
-ifndef::cheri_ratification_v1_only[]
 [NOTE]
 =====
 <<YSUNSEAL>> is intended to enable "superset unsealing"
@@ -76,6 +75,7 @@ This makes it easy for recipient software to ensure that received capabilities
 actually are handles to the recipient's objects.
 =====
 
+ifndef::cheri_ratification_v1_only[]
 [NOTE]
 =====
 While <<YSUNSEAL>> requires that the capability in its `{cs2}` is sealed,

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -61,7 +61,7 @@ Specifically, a software component can:
 
 1. allocate the memory for these objects from a region of address space,
 
-2. render capabilities to these objects opaque by sealing with <<YSEAL>> with <<CT-field>>=1,
+2. render capabilities to these objects opaque by sealing with <<YSEAL>>,
 
 3. distribute these handles to other software components, and
 

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -52,6 +52,7 @@ and so software should not assume `{cs1}==0` to be a pseudo-instruction for {cta
 // as appropriate for their intended uses.
 // =====
 
+ifndef::cheri_ratification_v1_only[]
 [NOTE]
 =====
 <<YSUNSEAL>> is intended to enable "superset unsealing"
@@ -60,8 +61,7 @@ Specifically, a software component can:
 
 1. allocate the memory for these objects from a region of address space,
 
-2. render capabilities to these objects opaque by sealing
-   (with, for example, the <<SENTRY>> instruction, if present),
+2. render capabilities to these objects opaque by sealing with <<SENTRY>>,
 
 3. distribute these handles to other software components, and
 
@@ -85,7 +85,7 @@ If the capability encoding defines multiple non-zero <<sec_cap_type>> values
 and software wishes to distinguish between them,
 it must use <<GCTYPE>> on the sealed capability.
 =====
-
+endif::[]
 Included in::
 <<rvy_insn_table>>
 

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -61,7 +61,7 @@ Specifically, a software component can:
 
 1. allocate the memory for these objects from a region of address space,
 
-2. render capabilities to these objects opaque by sealing with <<SENTRY>>,
+2. render capabilities to these objects opaque by sealing with <<YSEAL>> with <<CT-field>>=1,
 
 3. distribute these handles to other software components, and
 

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -59,7 +59,6 @@ cases they will have some behavioral differences and/or new instructions operati
 ifndef::cheri_ratification_v1_only[]
 |<<rv32y,RV32Y>>                                            | Base ISA additions and capability formats for RV32
 endif::[]
-|<<section_rvy_sentry_insn_ext>>                            | Capability sealing instruction to form a <<sentry_cap>>
 ifndef::cheri_ratification_v1_only[]
 |<<rvy_bndsrdw_insn_ext>>                                   | Extension for setting bounds round down to representable length
 endif::[]

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -716,9 +716,9 @@ Root Executable Capability::
 Capability Type (CT)::
  See the unprivileged manual for the definition of capability type values.
 
-[#sentry_cap,reftext="sentry capability"]
-Sentry Capabilities::
- See the unprivileged manual for the definition of sentry capabilities.
+[#sentry_cap,reftext="secure entrypont capability"]
+Secure Entry Point Capabilities::
+ See the unprivileged manual for the definition of secure entry point capabilities.
 
 [#null-cap,reftext="NULL"]
 NULL Capability::

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -716,9 +716,9 @@ Root Executable Capability::
 Capability Type (CT)::
  See the unprivileged manual for the definition of capability type values.
 
-[#sentry_cap,reftext="secure entrypont capability"]
-Secure Entry Point Capabilities::
- See the unprivileged manual for the definition of secure entry point capabilities.
+[#sentry_cap,reftext="sealed entry point capability"]
+Sealed Entry Point Capabilities::
+ See the unprivileged manual for the definition of sealed entry point capabilities.
 
 [#null-cap,reftext="NULL"]
 NULL Capability::

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -330,7 +330,7 @@ Ambient sealing type::
 Some capability types are said to be _ambiently available_ (or just _ambient_)
 if they do not require specific authority to seal a capability with that type.
 Therefore sentry types can be declared _ambient_.
-For example, if <<SENTRY>> is available on a given platform,
+For example, if <<CT-field>>=1 is available on a given platform,
 the type with which it seals capabilities is considered _ambiently available_.
 
 The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability encoding formats may add more types.
@@ -392,7 +392,7 @@ This is achieved using <<YSUNSEAL>>.
 
 Sealing::
 Given a capability with `CT=0`, deriving a capability with `CT≠0` is termed _sealing_.
-This is achieved using <<SENTRY>>.
+This is achieved using <<YSEAL>>.
 
 [#sentry_cap,reftext="secure entry point capability"]
 Control-flow Integrity::
@@ -984,7 +984,7 @@ Special instructions are provided to copy capabilities or derive a new capabilit
 |<<SCBNDSR>>  | {SCBNDSR_DESC}
 |<<YSUNSEAL>> | {YSUNSEAL_DESC}
 |<<CBLD>>     | {CBLD_DESC}
-|<<SENTRY>>   | {SENTRY_DESC}
+|<<YSEAL>>    | {YSEAL_DESC}
 |=======================
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -272,66 +272,87 @@ If such a capability exists then it must have been caused by a logic or memory f
 Unlike malformed bounds, the top overflowing is not treated as a special case in the
 architecture: normal bounds check rules should be followed.
 
-ifndef::cheri_ratification_v1_only[]
+
 [#sec_cap_type, reftext="CT-field"]
 ==== Capability Type (CT)
 
 This metadata value indicates the type of the capability and determines which operations the capability authorizes.
+For example, the <<sec_cap_type>> can be used to _seal_ capabilities against modification, to provide control flow integrity, and to provide immutable software tokens.
+ifndef::cheri_ratification_v1_only[]
 Which capability types a given CHERI platform supports is a function of the extensions and <<sec_cap_encoding_formats>> in use.
 The capability encoding specifies a mapping between some bits within the capability format (usually described as "the CT field") and the capability types.
 
 The capability encoding must be able to encode type `0` (_unsealed_).
 If any other sealed type exists, then they can be used to provide different levels of control-flow integrity.
+endif::[]
 
 [#unsealed_cap,reftext="unsealed capability"]
 Unsealed capabilities::
 When `CT=0`, the capability authorizes access to a region of memory as defined by the permissions and bounds.
-All CHERI systems must support unsealed capabilities.
+ifndef::cheri_ratification_v1_only[All CHERI systems must support unsealed capabilities.]
 
 [#sealed_cap,reftext="sealed capability"]
 Sealed capabilities::
 Capabilities with `CT≠0` are sealed against modification and cannot be dereferenced to access memory.
 Instructions that operate on capabilities will produce a result with the {ctag} set to zero if the source capability is sealed and the operation would alter its address, bounds, or permissions.
-Extensions that extend the capability metadata must describe their interaction(s) with sealed capabilities.
+ifndef::cheri_ratification_v1_only[Extensions that extend the capability metadata must describe their interaction(s) with sealed capabilities.]
 
+Sealing::
 Given a capability with `CT=0`,
 deriving a capability with `CT≠0` is termed _sealing_
-(or _sealing with type ``x``_ when a particular output ``CT=x`` is meant).
+ifndef::cheri_ratification_v1_only[(or _sealing with type ``x``_ when a particular output ``CT=x`` is meant)]
+.
+This is achieved using <<YSEAL>>.
 
-In the other direction,
-deriving a `CT=0` capability from a `CT≠0` capability is termed _unsealing_
-(or _unsealing from type ``x``_ when a particular input ``CT=x`` is meant).
+Unsealing::
+Given a capability with `CT≠0`,
+deriving a capability with `CT=0` is termed _unsealing_
+ifndef::cheri_ratification_v1_only[(or _unsealing from type ``x``_ when a particular input ``CT=x`` is meant)]
+.
+This is achieved using <<YSUNSEAL>>
+ifndef::cheri_ratification_v1_only[(or <<YUNSEAL>> if <<section_zyseal>> is implemented)]
+.
 
-[#sentry_cap,reftext="sentry capability"]
-Sentry capability type::
-Sentry capabilities provide *immutable* function pointers within a CHERI software system.
+[#sentry_cap,reftext="sealed entry point capability"]
+Sealed Entry Point Capability::
+Sealed entry point capabilities provide *immutable* function pointers within a CHERI software system.
+ifndef::cheri_ratification_v1_only[]
 <<sealed_cap,Sealed capabilities>> are a natural foundation, providing immutability.
 
 NOTE: Capabilities sealed with a specific <<sec_cap_type>> which can be unsealed when passed as an argument to <<JALR_CHERI>> are dubbed "sentries" (a portmanteau of "sealed entries").
+endif::[]
+ifdef::cheri_ratification_v1_only[]
 
-Sentries can establish a form of control-flow integrity between mutually distrusting code.
-Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not in the middle of a function.
+NOTE: Such function pointers are sometimes known as "sentries", a contraction of "sealed entries".
+endif::[]
 
-Any sentry type may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and are _unsealed_ on dereference.
-The returned `{cd}` value is also _sealed_ as a sentry.
+They can establish a form of control-flow integrity between mutually distrusting code.
+Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not elsewhere in a function.
 
+A sealed entry point capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
+The returned `{cd}` value is also written back as a <<sentry_cap>>.
+
+ifndef::cheri_ratification_v1_only[]
 Sentry types may be restricted to _forward-edge_ only and _backward-edge_ only transitions to further improve control-flow integrity.
 
 * When <<JALR_CHERI>> is used as a function call only _forward-edge_ sentries in `{cs1}` are _unsealed_ on dereference.
  The returned `{cd}` value is always _sealed_ as a _backward-edge_ sentry type.
 * When <<JALR_CHERI>> is used as a function return only _backward-edge_ sentries in `{cs1}` are _unsealed_ on dereference.
+endif::[]
 
-NOTE: In addition to using sealed capabilities as sentries for sealed entry points, sealed capabilities can also be useful to software as secure software tokens.
+NOTE: In addition to using sealed capabilities for sealed entry points, sealed capabilities can also be useful to software as secure software tokens.
  <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
  A future extension may add an unseal instruction for performance.
 
+ifndef::cheri_ratification_v1_only[]
 [#sec_cap_type_ambient, reftext="Ambient sealing type"]
 Ambient sealing type::
 Some capability types are said to be _ambiently available_ (or just _ambient_)
 if they do not require specific authority to seal a capability with that type.
 Therefore sentry types can be declared _ambient_.
-For example, if <<CT-field>>=1 is available on a given platform,
+For example, if <<SENTRY>> is available on a given platform,
 the type with which it seals capabilities is considered _ambiently available_.
+endif::[]
 
 The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability encoding formats may add more types.
 
@@ -341,11 +362,17 @@ The standard capability type mapping is shown in <<table_capability_types>>, ext
 |===
 | Type Name                     | Integer Value     | Description
 | Unsealed                      | 0                 | _Unsealed_ capability granting access to memory
+ifdef::cheri_ratification_v1_only[]
+| Sealed entry point capability | 1                 | _Sealed_ capability that can be used as a function entry point.
+endif::[]
+ifndef::cheri_ratification_v1_only[]
 | Unrestricted <<sentry_cap>>   | 1                 | Immutable _unrestricted sentry_ type for both _forward-edge_ and _backward-edge_ transitions.
 | Forward-edge  <<sentry_cap>>  | Extension defined | Immutable _sentry_ type for _forward-edge_ transitions.
 | Backward-edge <<sentry_cap>>  | Extension defined | Immutable _sentry_ type for _backward-edge_ transitions.
+endif::[]
 |===
 
+ifndef::cheri_ratification_v1_only[]
 NOTE: The integer value in the table above defines the architectural capability type (i.e., the result of the <<GCTYPE>> instruction) but does not need to be encoded that way in memory.
 
 NOTE: Other encoding formats may provide different type mappings, but the value `0` must _always_ represent an unsealed capability.
@@ -369,59 +396,9 @@ Capability encoding formats will explicitly state whether these are relevant to 
 
 They are not used by <<rv64y_cap_description>>, but are by the CHERIoT formats.
 ====
-
 endif::[]
-ifdef::cheri_ratification_v1_only[]
-[#sec_cap_type, reftext="CT-field"]
-==== Capability Type (CT)
 
-The Capability type field is used to _seal_ capabilities against modification, and also to provide control flow integrity.
-
-[#unsealed_cap,reftext="unsealed capability"]
-Unsealed capabilities::
-When `CT=0`, the capability authorizes access to a region of memory as defined by the permissions and bounds.
-
-[#sealed_cap,reftext="sealed capability"]
-Sealed capabilities::
-Capabilities with `CT≠0` are sealed against modification and cannot be dereferenced to access memory.
-Instructions that operate on capabilities will produce a result with the {ctag} set to zero if the source capability is sealed and the operation would alter its address, bounds, or permissions.
-
-Unsealing::
-Deriving a `CT=0` capability from a `CT≠0` capability is termed _unsealing_.
-This is achieved using <<YSUNSEAL>>.
-
-Sealing::
-Given a capability with `CT=0`, deriving a capability with `CT≠0` is termed _sealing_.
-This is achieved using <<YSEAL>>.
-
-[#sentry_cap,reftext="sealed entry point capability"]
-Control-flow Integrity::
-Sealed capabilities can be used as immutable function pointers, which can establish a form of control-flow integrity between mutually distrusting code.
-Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not in the elsewhere in a function.
-
-NOTE: Such function pointers are sometimes known as "sentries", a contraction of "sealed entries".
-
-A sealed capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
-The returned `{cd}` value is also _sealed_.
-
-NOTE: In addition to using sealed capabilities for sealed entry points, they can also be useful to software as secure software tokens.
- <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
- A future extension may add an unseal instruction for performance.
-
-The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability encoding formats may add more types.
-
-[#table_capability_types]
-.Standard capability type mapping
-[width="100%",options=header,align=left,cols="2,1,4"]
-|===
-| Type Name         | Integer Value     | Description
-| Unsealed          | 0                 | _Unsealed_ capability granting access to memory
-| Sealed capability | 1                 | _Sealed_ capability which can be used as a sealed entry point.
-|===
-
-NOTE: Future extensions may declare new <<CT-field>> values which place restrictions on their usage with <<JAL_CHERI>>/<<JALR_CHERI>> for improved CFI.
-
-endif::[]
+NOTE: Future extensions may declare new <<CT-field>> values which place restrictions on their usage (e.g. forward/backward-only control flow checks with <<JAL_CHERI>>/<<JALR_CHERI>> for improved CFI).
 
 [#AP-field, reftext="AP-field"]
 ==== Architectural Permissions (AP)

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -321,7 +321,7 @@ Sentry types may be restricted to _forward-edge_ only and _backward-edge_ only t
  The returned `{cd}` value is always _sealed_ as a _backward-edge_ sentry type.
 * When <<JALR_CHERI>> is used as a function return only _backward-edge_ sentries in `{cs1}` are _unsealed_ on dereference.
 
-NOTE: In addition to using sealed capabilities as sentries for secure entry points, sealed capabilities can also be useful to software as secure software tokens.
+NOTE: In addition to using sealed capabilities as sentries for sealed entry points, sealed capabilities can also be useful to software as secure software tokens.
  <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
  A future extension may add an unseal instruction for performance.
 
@@ -394,7 +394,7 @@ Sealing::
 Given a capability with `CT=0`, deriving a capability with `CT≠0` is termed _sealing_.
 This is achieved using <<YSEAL>>.
 
-[#sentry_cap,reftext="secure entry point capability"]
+[#sentry_cap,reftext="sealed entry point capability"]
 Control-flow Integrity::
 Sealed capabilities can be used as immutable function pointers, which can establish a form of control-flow integrity between mutually distrusting code.
 Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not in the elsewhere in a function.
@@ -404,7 +404,7 @@ NOTE: Such function pointers are sometimes known as "sentries", a contraction of
 A sealed capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
 The returned `{cd}` value is also _sealed_.
 
-NOTE: In addition to using sealed capabilities for secure entry points, they can also be useful to software as secure software tokens.
+NOTE: In addition to using sealed capabilities for sealed entry points, they can also be useful to software as secure software tokens.
  <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
  A future extension may add an unseal instruction for performance.
 
@@ -416,7 +416,7 @@ The standard capability type mapping is shown in <<table_capability_types>>, ext
 |===
 | Type Name         | Integer Value     | Description
 | Unsealed          | 0                 | _Unsealed_ capability granting access to memory
-| Sealed capability | 1                 | _Sealed_ capability which can be used as a secure entry point.
+| Sealed capability | 1                 | _Sealed_ capability which can be used as a sealed entry point.
 |===
 
 NOTE: Future extensions may declare new <<CT-field>> values which place restrictions on their usage with <<JAL_CHERI>>/<<JALR_CHERI>> for improved CFI.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -363,7 +363,7 @@ The standard capability type mapping is shown in <<table_capability_types>>, ext
 | Type Name                     | Integer Value     | Description
 | Unsealed                      | 0                 | _Unsealed_ capability granting access to memory
 ifdef::cheri_ratification_v1_only[]
-| Sealed entry point capability | 1                 | _Sealed_ capability that can be used as a function entry point.
+| Sealed entry point capability | 1                 | _Sealed_ capability that can be used as a function entry point or function return.
 endif::[]
 ifndef::cheri_ratification_v1_only[]
 | Unrestricted <<sentry_cap>>   | 1                 | Immutable _unrestricted sentry_ type for both _forward-edge_ and _backward-edge_ transitions.
@@ -961,10 +961,12 @@ Special instructions are provided to copy capabilities or derive a new capabilit
 |<<YSUNSEAL>> | {YSUNSEAL_DESC}
 |<<CBLD>>     | {CBLD_DESC}
 |<<YSEAL>>    | {YSEAL_DESC}
+|<<SENTRY>>^2^| {SENTRY_DESC}
 |=======================
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>
 
+^2^ <<SENTRY>> is a pseudoinstruction for <<YSEAL>>
 
 include::insns/acperm_32bit.adoc[]
 include::insns/cmv_32bit.adoc[]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -272,7 +272,7 @@ If such a capability exists then it must have been caused by a logic or memory f
 Unlike malformed bounds, the top overflowing is not treated as a special case in the
 architecture: normal bounds check rules should be followed.
 
-
+ifndef::cheri_ratification_v1_only[]
 [#sec_cap_type, reftext="CT-field"]
 ==== Capability Type (CT)
 
@@ -330,7 +330,7 @@ Ambient sealing type::
 Some capability types are said to be _ambiently available_ (or just _ambient_)
 if they do not require specific authority to seal a capability with that type.
 Therefore sentry types can be declared _ambient_.
-For example, if <<section_rvy_sentry_insn_ext>> is available on a given platform,
+For example, if <<SENTRY>> is available on a given platform,
 the type with which it seals capabilities is considered _ambiently available_.
 
 The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability encoding formats may add more types.
@@ -341,18 +341,14 @@ The standard capability type mapping is shown in <<table_capability_types>>, ext
 |===
 | Type Name                     | Integer Value     | Description
 | Unsealed                      | 0                 | _Unsealed_ capability granting access to memory
-| Unrestricted <<sentry_cap>>^1^| Extension defined | Immutable _unrestricted sentry_ type for both _forward-edge_ and _backward-edge_ transitions.
+| Unrestricted <<sentry_cap>>   | 1                 | Immutable _unrestricted sentry_ type for both _forward-edge_ and _backward-edge_ transitions.
 | Forward-edge  <<sentry_cap>>  | Extension defined | Immutable _sentry_ type for _forward-edge_ transitions.
 | Backward-edge <<sentry_cap>>  | Extension defined | Immutable _sentry_ type for _backward-edge_ transitions.
 |===
 
-^1^ <<section_rvy_sentry_insn_ext>> defines a <<sentry_cap>> of this type.
-
 NOTE: The integer value in the table above defines the architectural capability type (i.e., the result of the <<GCTYPE>> instruction) but does not need to be encoded that way in memory.
 
 NOTE: Other encoding formats may provide different type mappings, but the value `0` must _always_ represent an unsealed capability.
-
-ifndef::cheri_ratification_v1_only[]
 
 [NOTE]
 ====
@@ -373,6 +369,57 @@ Capability encoding formats will explicitly state whether these are relevant to 
 
 They are not used by <<rv64y_cap_description>>, but are by the CHERIoT formats.
 ====
+
+endif::[]
+ifdef::cheri_ratification_v1_only[]
+[#sec_cap_type, reftext="CT-field"]
+==== Capability Type (CT)
+
+The Capability type field is used to _seal_ capabilities against modification, and also to provide control flow integrity.
+
+[#unsealed_cap,reftext="unsealed capability"]
+Unsealed capabilities::
+When `CT=0`, the capability authorizes access to a region of memory as defined by the permissions and bounds.
+
+[#sealed_cap,reftext="sealed capability"]
+Sealed capabilities::
+Capabilities with `CT≠0` are sealed against modification and cannot be dereferenced to access memory.
+Instructions that operate on capabilities will produce a result with the {ctag} set to zero if the source capability is sealed and the operation would alter its address, bounds, or permissions.
+
+Unsealing::
+Deriving a `CT=0` capability from a `CT≠0` capability is termed _unsealing_.
+This is achieved using <<YSUNSEAL>>.
+
+Sealing::
+Given a capability with `CT=0`, deriving a capability with `CT≠0` is termed _sealing_.
+This is achieved using <<SENTRY>>.
+
+[#sentry_cap,reftext="secure entry point capability"]
+Control-flow Integrity::
+Sealed capabilities can be used as immutable function pointers, which can establish a form of control-flow integrity between mutually distrusting code.
+Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not in the elsewhere in a function.
+
+NOTE: Such function pointers are sometimes known as "sentries", a contraction of "sealed entries".
+
+A sealed capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
+The returned `{cd}` value is also _sealed_.
+
+NOTE: In addition to using sealed capabilities for secure entry points, they can also be useful to software as secure software tokens.
+ <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
+ A future extension may add an unseal instruction for performance.
+
+The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability encoding formats may add more types.
+
+[#table_capability_types]
+.Standard capability type mapping
+[width="100%",options=header,align=left,cols="2,1,4"]
+|===
+| Type Name         | Integer Value     | Description
+| Unsealed          | 0                 | _Unsealed_ capability granting access to memory
+| Sealed capability | 1                 | _Sealed_ capability which can be used as a secure entry point.
+|===
+
+NOTE: Future extensions may declare new <<CT-field>> values which place restrictions on their usage with <<JAL_CHERI>>/<<JALR_CHERI>> for improved CFI.
 
 endif::[]
 
@@ -937,6 +984,7 @@ Special instructions are provided to copy capabilities or derive a new capabilit
 |<<SCBNDSR>>  | {SCBNDSR_DESC}
 |<<YSUNSEAL>> | {YSUNSEAL_DESC}
 |<<CBLD>>     | {CBLD_DESC}
+|<<SENTRY>>   | {SENTRY_DESC}
 |=======================
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>
@@ -949,6 +997,7 @@ include::insns/scbnds_32bit.adoc[]
 include::insns/scbndsr_32bit.adoc[]
 include::insns/ysunseal_32bit.adoc[]
 include::insns/cbld_32bit.adoc[]
+include::insns/sentry_32bit.adoc[]
 
 <<<
 
@@ -1214,44 +1263,3 @@ include::rvy32-encoding.adoc[]
 endif::[]
 
 :leveloffset: -1
-
-[#section_rvy_sentry_insn_ext,reftext="{rvy_sentry_insn_ext_name}"]
-== "{rvy_sentry_insn_ext_name}" Extension for Creation of Sentry Capabilities
-
-The {rvy_sentry_insn_ext_name} extension:
-
-. Defines one <<sentry_cap>> type, the <<sentry_cap>> type for both _forward-edge_ and _backward-edge_ control-flow transitions, with a <<sec_cap_type>> value of `1`.
-. Adds the <<SENTRY>> instruction to allow <<sec_cap_type_ambient,ambient sealing >> of capabilities as sentries with <<sec_cap_type>> value of `1`.
-
-{rvy_sentry_insn_ext_name} is only compatible with capability encoding formats which can encode the <<sec_cap_type>> value of `1`.
-
-=== Interaction with <<JALR_CHERI>>
-
-{rvy_sentry_insn_ext_name} enables _sealing_ and _unsealing_ behavior in <<JALR_CHERI>> with the single <<sentry_cap>> of type `1` being available.
-
-Therefore the full operational description of <<JALR_CHERI>> is specialized to:
-
-. `{cs1}` is written to the target <<pcc>>.
-. The target address is obtained by adding the sign-extended 12-bit I-immediate to `{cs1}.address`, then setting the least-significant bit of the result to zero.
-. _Unseal_ the target <<pcc>> if it is _sealed_ as a _forward-edge_ <<sentry_cap>>^1^ and `{cs1}.address[0]` is zero and the I-immediate is zero.
-. Set the address of the target <<pcc>> to the target address using the semantics of the <<SCADDR>> instruction.
-. The <<pcc>> of the next instruction is _sealed_ as a <<sentry_cap>> of type `1` and written to `{cd}`.
-. Jump to the target <<pcc>>.
-
-^1^ type `1` defined by this extension is a _forward-edge_ <<sentry_cap>>, other compatible extensions may declare more _forward-edge_ types which <<JALR_CHERI>> will unseal.
-
-=== Interaction with <<JAL_CHERI>>
-
-{rvy_sentry_insn_ext_name} enables _sealing_ behavior in <<JAL_CHERI>> with the single <<sentry_cap>> of type `1` being available.
-
-Therefore the sealed type of `{cd}` is defined as follows:
-
-* The <<pcc>> of the next instruction is _sealed_ as a <<sentry_cap>> of type `1` and written to `{cd}`.
-
-=== Interaction with <<CBLD>>
-
-The <<sentry_cap>> type defined by this extension is <<sec_cap_type_ambient,ambient>> and so <<CBLD>> can output a sealed capability of this type.
-
-=== Added instructions
-
-include::insns/sentry_32bit.adoc[]

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -93,7 +93,6 @@ Known extension (in)compatibilities are listed in <<rv32y_cheriot_encoding1_ext_
 |==============================================================================
 | Extension                    | Comment
 | <<section_cheri_hybrid_ext>> | Not supported (<<p_bit>> not defined)
-| <<section_rvy_sentry_insn_ext>> | Not compatible without other extensions (no <<sec_cap_type_ambient,ambient>> <<sec_cap_type>> values defined herein)
 | <<section_zylevels1>>        | Compatible (recommended)
 ifndef::cheri_ratification_v1_only[]
 | <<section_zyseal>>           | Compatible (recommended)

--- a/src/cheri/rvy-cheriot-isa-unpriv.adoc
+++ b/src/cheri/rvy-cheriot-isa-unpriv.adoc
@@ -23,7 +23,7 @@ counterparts found in the {cheriot_priv_ext_name} extension.
 both the <<section_zylevels1>> and <<section_zyseal>> extensions.
 The present specification presumes the *absence*
 of both the <<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and
-<<section_rvy_sentry_insn_ext>> extensions.
+the <<SENTRY>> instruction.
 
 [NOTE]
 =====
@@ -36,7 +36,7 @@ we have not yet found a compelling reason to formally specify this composition.
 [NOTE]
 =====
 While {cheriot_unpriv_ext_name} is nominally compatible with
-<<section_rvy_sentry_insn_ext>>,
+<<SENTRY>>,
 the operating system written for link:https://cheriot.org[CHERIoT]
 has a security model that presumes the absence of ambient sealing,
 and so this specification does not

--- a/src/cheri/rvy-cheriot-isa-unpriv.adoc
+++ b/src/cheri/rvy-cheriot-isa-unpriv.adoc
@@ -23,7 +23,7 @@ counterparts found in the {cheriot_priv_ext_name} extension.
 both the <<section_zylevels1>> and <<section_zyseal>> extensions.
 The present specification presumes the *absence*
 of both the <<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and
-no support for <<CT-field>>=1 as an argument passed to the <<YSEAL>> instruction.
+no support for `{cs1}=x0` passed to the <<YSEAL>> instruction, which bypasses the authority.
 
 [NOTE]
 =====

--- a/src/cheri/rvy-cheriot-isa-unpriv.adoc
+++ b/src/cheri/rvy-cheriot-isa-unpriv.adoc
@@ -23,7 +23,7 @@ counterparts found in the {cheriot_priv_ext_name} extension.
 both the <<section_zylevels1>> and <<section_zyseal>> extensions.
 The present specification presumes the *absence*
 of both the <<section_cheri_hybrid_ext,{cheri_default_ext_name}>> and
-the <<SENTRY>> instruction.
+no support for <<CT-field>>=1 as an argument passed to the <<YSEAL>> instruction.
 
 [NOTE]
 =====
@@ -36,7 +36,7 @@ we have not yet found a compelling reason to formally specify this composition.
 [NOTE]
 =====
 While {cheriot_unpriv_ext_name} is nominally compatible with
-<<SENTRY>>,
+<<CT-field>>=1,
 the operating system written for link:https://cheriot.org[CHERIoT]
 has a security model that presumes the absence of ambient sealing,
 and so this specification does not

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -62,7 +62,6 @@ See xref:cap_perms_encoding32[xrefstyle=short].
 | Extension                    | Comment
 | <<section_cheri_hybrid_ext>> | Compatible
 | <<section_zylevels1>>        | Compatible
-| <<section_rvy_sentry_insn_ext>> | Compatible
 ifndef::cheri_ratification_v1_only[]
 | <<section_zyseal>>           | Will be compatible once new permissions are encoded
 endif::[]

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -55,7 +55,6 @@ This capability encoding has the following properties that affect the observable
 |==============================================================================
 | Extension                    | Comment
 | <<section_cheri_hybrid_ext>> | Compatible
-| <<section_rvy_sentry_insn_ext>> | Compatible
 | <<section_zylevels1>>        | Compatible
 ifndef::cheri_ratification_v1_only[]
 | <<section_zyseal>>           | Will be compatible once new permissions are encoded
@@ -118,9 +117,8 @@ The <<sec_cap_type>> field is as specified in <<table_capability_types>>.
 The capabilities of this chapter define a 1-bit field for <<sec_cap_type>> values;
 this field directly encodes the values `0` and `1`:
 
-* The encoded value `0` indicates an unsealed type.
-* If {rvy_sentry_insn_ext_name} is supported, then `1` encodes an unrestricted <<sentry_cap>>.
-* Otherwise, the value `1` is _reserved_.
+* The encoded value `0` indicates an _unsealed_ type.
+* The encoded value `1` indicates an _sealed_ type which can unsealed by <<JALR_CHERI>>.
 
 ifndef::cheri_ratification_v1_only[]
 ifdef::cheri_v9_annotations[]

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -123,7 +123,7 @@ this field directly encodes the values `0` and `1`:
 ifndef::cheri_ratification_v1_only[]
 ifdef::cheri_v9_annotations[]
 WARNING: *CHERI v9:* There is now a 1-bit otype (sentry or unsealed) and the old CHERI v9 otype no longer exists.
-The base CHERI-RISC-V standard does not have support for CHERI v9 CSEAL for sealed capabilities with object types and only has <<SENTRY>> for sealed entry (sentry) capabilities.
+The base CHERI-RISC-V standard does not have support for CHERI v9 CSEAL for sealed capabilities with object types and only has <<CT-field>>=1 for sealed entry (sentry) capabilities.
 endif::[]
 
 The capabilities of this chapter define a 1-bit field for <<sec_cap_type>> values;
@@ -132,8 +132,8 @@ The value `1` is...
 
 * considered <<sec_cap_type_ambient,ambiently available>> for <<CBLD>>,
 
-* used as the type for capabilities sealed by <<SENTRY>> instructions,
-  regardless of the input capability's permission.
+* used as the type for capabilities sealed by <<YSEAL>> instructions,
+  not requiring a specific sealing permission.
 
 Additionally, <<JALR_CHERI>> both
 

--- a/src/cheri/scripts/generate_tables.py
+++ b/src/cheri/scripts/generate_tables.py
@@ -586,11 +586,6 @@ if __name__ == "__main__":
                 header=header,
             ),
             InsnTable(
-                extension="{rvy_sentry_insn_ext_name}",
-                filename=output_file(args, "Zysentry_insns_table_body.adoc"),
-                header=header,
-            ),
-            InsnTable(
                 extension="{rvy_topr_insn_ext_name}",
                 filename=output_file(args, "Zytopr_insns_table_body.adoc"),
                 header=header,

--- a/src/cheri/scripts/rvy_instruction_encodings.py
+++ b/src/cheri/scripts/rvy_instruction_encodings.py
@@ -563,7 +563,7 @@ def get_custom3_insts():
         next_r2type("YTAGR", rs1="{cs1}", rd="rd"),
         next_r2type("YTYPER", rs1="{cs1}", rd="rd"),
         next_r2type("YAMASK", rs1="rs1", rd="rd"),
-        next_r2type("YSENTRY", rs1="{cs1}", rd="{cd}", ext="Zysentry"),
+        next_r2type("YUSEAL", rs1="{cs1}", rd="{cd}"),
         next_r2type("YMODER", rs1="{cs1}", rd="rd", ext="Zyhybrid"),
     ]
     # Sort by register selector bits (0:2) first and the the instruction index)

--- a/src/cheri/scripts/rvy_instruction_encodings.py
+++ b/src/cheri/scripts/rvy_instruction_encodings.py
@@ -518,7 +518,7 @@ def get_custom3_insts():
         next_rtype("YSS", rs1="{cs1}", rs2="{cs2}", rd="rd"),
         next_rtype("YSUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
         next_rtype("YBLD", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
-        next_rtype("YSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}", ext="Zyseal"),
+        next_rtype("YSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
         next_rtype("YUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}", ext="Zyseal"),
         next_rtype("YMODEW", rs1="{cs1}", rd=f"{{cd}}{NEQ}0", ext="Zyhybrid"),
         RVYRType3Op(
@@ -563,7 +563,6 @@ def get_custom3_insts():
         next_r2type("YTAGR", rs1="{cs1}", rd="rd"),
         next_r2type("YTYPER", rs1="{cs1}", rd="rd"),
         next_r2type("YAMASK", rs1="rs1", rd="rd"),
-        next_r2type("YUSEAL", rs1="{cs1}", rd="{cd}"),
         next_r2type("YMODER", rs1="{cs1}", rd="rd", ext="Zyhybrid"),
     ]
     # Sort by register selector bits (0:2) first and the the instruction index)

--- a/src/cheri/zyseal.adoc
+++ b/src/cheri/zyseal.adoc
@@ -7,8 +7,8 @@ IMPORTANT: {not_v1_ratification_package_freeze}
 === Explicit Sealing and Unsealing Operations
 
 The {cheri_base_ext_name} base architecture defines <<sealed_cap, sealed capabilities>>.
-The <<CBLD>>, <<JALR_CHERI>>, and <<YSUNSEAL>> instruction
-and the <<SENTRY>> instruction
+The <<CBLD>>, <<JALR_CHERI>>, and <<YSUNSEAL>> instructions
+and the <<YSEAL>> instruction with <<CT-field>>>1
 allow platforms to build and consume sealed capabilities in
 particular ways.
 This extension introduces a more general,
@@ -85,9 +85,9 @@ the <<acperm_bit_field,capability permissions bitfield>> (<<acperm_bit_field>>),
 used by <<CLRPERM>> and <<GCPERM>>,
 as shown in <<zyseal_acperm_bit_field>>.
 
-=== Added Instructions
+=== Extended and New Instructions
 
-<<YSEAL>>:: A `{YSEAL_LC} {cd}, {cs1}, {cs2}` instruction will use the provided
+<<YSEAL_ZYSEAL>>:: A `{YSEAL_LC} {cd}, {cs1}, {cs2}` instruction will use the provided
 sealing authority of `{cs1}` to copy the _unsealed_ capability
 in `{cs2}` into `{cd}` and seal it with type `{cs1}.address`,
 assuming `{cs1}` has a set {ctag}, is in bounds, and grants <<zyseal_se_perm>>.

--- a/src/cheri/zyseal.adoc
+++ b/src/cheri/zyseal.adoc
@@ -8,7 +8,7 @@ IMPORTANT: {not_v1_ratification_package_freeze}
 
 The {cheri_base_ext_name} base architecture defines <<sealed_cap, sealed capabilities>>.
 The <<CBLD>>, <<JALR_CHERI>>, and <<YSUNSEAL>> instruction
-and the <<section_rvy_sentry_insn_ext>> extension
+and the <<SENTRY>> instruction
 allow platforms to build and consume sealed capabilities in
 particular ways.
 This extension introduces a more general,

--- a/src/cheri_isa_tables.adoc
+++ b/src/cheri_isa_tables.adoc
@@ -52,18 +52,6 @@ Zcf and Zcd are incompatible with RVY.
 include::{generated_dir}/{rvy_zca_file_name}.adoc[]
 |==============================================================================
 
-[#rvy_sentry_insn_table, reftext="{rvy_sentry_insn_ext_name}"]
-=== {rvy_sentry_insn_ext_name}
-
-{rvy_sentry_insn_ext_name} adds the {SENTRY} instruction.
-
-.{rvy_sentry_insn_ext_name} instruction extension
-[#{rvy_sentry_insn_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_sentry_insn_file_name}.adoc[]
-|==============================================================================
-
 ifndef::cheri_ratification_v1_only[]
 
 [#rvy_bndsrdw_insn_table, reftext="{rvy_bndsrdw_insn_ext_name}"]


### PR DESCRIPTION
Addressing ARC feedback:

fix #1067 

We must put a sentry option into the base
The name sentry is very unpopular with ARC - so I've gone for "sealed entry point capability"

Therefore this PR:

1. Merges YSEAL and YSENTRY, calling the combined instruction YSEAL
2. YSEAL with rs1=x0 seals without authority and type 1 only if type 1 is available (Uni formats only - and will be disabled by S-mode CSR bit in future).
3. YSEAL with rs1 != x0 seals with authority as before (behaviour unchanged from CHERIoT if type 1 is not available)
4. Put the updated YSEAL into the base
5. Removes the word "sentry" except as a note. The usage in Zysentry is very simple anyway as it doesn't distinguish between any sentry types or any other sealed capabilities. I've gone for `YUSEAL` for Unauthorised SEAL. I didn't want to use `YSEAL` to avoid conflicting with Zyseal, which would have been confusing.

JALR behaviour is simplified to remove forwards/backwards sentries - the full text is still there ifdef'd out.
I confirmed that it's not a problem to add new JALR behaviour later when new sealed cap / sentry types are added later by CHERIoT.
