### PR TITLE
Debug integration review

### DIFF
--- a/src/cheri/contributors.adoc
+++ b/src/cheri/contributors.adoc
@@ -23,6 +23,7 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Maja Malenko <maja.malenko@codasip.com>
 * A. Theodore Markettos <theo.markettos@cl.cam.ac.uk>
 * Alfredo Mazzinghi <alfredo.mazzinghi@cl.cam.ac.uk>
+* Jan Matyas <jan.matyas@codasip.com>
 * Dave McEwan <dave.mcewan@codasip.com>
 * David McKay <david.mckay@codasip.com>
 * Jamie Melling <jamie.melling@codasip.com>

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -121,7 +121,7 @@ All other bits in that `data` register are UNSPECIFIED.
 When a capability is written it must be a <<cap_subset>> of the capability in <<drootc>>.
 If not then the destination {ctag} is set to zero.
 
-NOTE: For the capability subset: `cap2` is the capability being written and `cap` 1 is the value of <<drootc>>.
+NOTE: For the capability subset: `cap2` is the capability being written and `cap1` is the value of <<drootc>>.
 
 NOTE: It is valid for root capabilities not to cover the entire possible address space.
  In this case the debugger cannot claim access to more memory than is permitted by <<drootc>>.

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -8,7 +8,7 @@ include::trigger-integration.adoc[]
 
 {cheri_base_ext_name} harts must provide a means for accessing capabilities in registers and in memory via the external debugger.
 
-This can be achieved by at least one of:
+This is achieved by supporting at least one of:
 
 . Implementing a program buffer configured as specified below.
 . Supporting full capability access for both Access Register and Access Memory abstract commands (`aarsize=7` and `aamsize=7`).

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -93,9 +93,13 @@ no way to discover the former property.
 
 ==== Access Register Command
 
-The _Access Register_ abstract command has optional support for accessing YLEN registers.
+When an YLEN-wide register is accessible via _Access Register_ abstract command, then:
 
-If `aarsize` matches YLEN then all YLEN-bits should be accessible via the command.
+- Reads of YLEN bits or any smaller amounts of bits must be supported.
+- Writes of YLEN bits must be supported.
+- Writes of smaller amounts of bits than YLEN may optionally be supported but it is UNSPECIFIED what happens to the higher bits.
+
+NOTE: The debugger can change the low XLEN bits of a YLEN wide register by performing a read-modify-write sequence.
 This requires enough `data<n>` registers to be supported to cover the entire data width (2 for {cheri_base32_ext_name} or 4 for {cheri_base64_ext_name}).
 
 Implementations can choose to also support accessing {ctag}s as part of the access register command.

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -111,6 +111,8 @@ The `data<n>` register mapping for full capability accesses is as shown in <<deb
 ^1^ arg1 represents an address so never needs to exceed DXLEN.
  Each `data<n>` register is 32-bit so a maximum of 2 are required.
 
+^2^ arg2 is not used for abstract commands, and is included for consistency with the equivalent table in the _RISC-V Debug Specification_
+
 Bit 0 of `data5` or `data10` contain the {ctag} which is either written to, or read from, the target register.
 All other bits in that `data` register are UNSPECIFIED.
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -6,7 +6,7 @@ include::trigger-integration.adoc[]
 
 === Integrating {cheri_base_ext_name} with Sdext
 
-{cheri_base_ext_name} harts should be able to access capabilities in registers and in memory via the external debugger.
+{cheri_base_ext_name} harts must provide a means for accessing capabilities in registers and in memory via the external debugger.
 
 This can be achieved by at least one of:
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -91,24 +91,15 @@ no way to discover the former property.
   setting `transfer` to 1 and `write` to 0).
 ====
 
-==== Access Register Command
+==== Abstract Commands
 
-When an YLEN-wide register is accessible via _Access Register_ abstract command, then:
+Abstract commands are optionally extended to access full capabilities.
 
-- Reads of YLEN bits or any smaller amounts of bits must be supported.
-- Writes of YLEN bits must be supported.
-- Writes of smaller amounts of bits than YLEN may optionally be supported but it is UNSPECIFIED what happens to the higher bits.
+`aarsize/aarmsize=7` represent full capability access.
 
-NOTE: The debugger can change the low XLEN bits of a YLEN wide register by performing a read-modify-write sequence.
-This requires enough `data<n>` registers to be supported to cover the entire data width (2 for {cheri_base32_ext_name} or 4 for {cheri_base64_ext_name}).
+The `data<n>` register mapping for full capability accesses is as shown in <<debug_data_aarsize_7>>.
 
-Implementations can choose to also support accessing {ctag}s as part of the access register command.
-
-`aarsize=7` is defined to represent full capability access.
-
-The `data<n>` register mapping is as shown in <<debug_data_aarsize_7>>.
-
-.Data register mapping when `aarsize=7`
+.Data register mapping when `aarsize/aamsize=7`
 [#debug_data_aarsize_7]
 [width="100%",options=header,cols="1,1,1,1,1"]
 |=====
@@ -123,21 +114,34 @@ The `data<n>` register mapping is as shown in <<debug_data_aarsize_7>>.
 Bit 0 of `data5` or `data10` contain the {ctag} which is either written to, or read from, the target register.
 All other bits in that `data` register are UNSPECIFIED.
 
+==== Access Register Command
+
+When a YLEN-wide register is accessible via an _Access Register_ abstract command, then:
+
+- Reads of YLEN bits or any smaller amounts of bits must be supported.
+- Writes of YLEN bits must be supported.
+- Writes of smaller amounts of bits than YLEN may optionally be supported but it is UNSPECIFIED what happens to the higher bits.
+
+NOTE: The debugger can change the low XLEN bits of a YLEN wide register by performing a read-modify-write sequence.
+This requires enough `data<n>` registers to be supported to cover the entire data width (2 for {cheri_base32_ext_name} or 4 for {cheri_base64_ext_name}).
+
+Implementations can choose to also support accessing {ctag}s as part of the access register command by supporting `aarsize=7`.
+
 When a capability is written it must be a <<cap_subset>> of the capability in <<drootc>>.
 If not then the destination {ctag} is set to zero.
+
+If `aarsize{ne}7` then {ctag}s are always read and written as zero.
 
 NOTE: For the capability subset: `cap2` is the capability being written and `cap1` is the value of <<drootc>>.
 
 NOTE: It is valid for root capabilities not to cover the entire possible address space.
- In this case the debugger cannot claim access to more memory than is permitted by <<drootc>>.
-
-NOTE: If `aarsize{ne}7` then {ctag}s are always read and written as zero.
+ In this case the debugger cannot claim access to more memory than is permitted by the current value of <<drootc>>.
 
 ==== Access Memory Command
 
-Implementations can choose to support accessing full capabilities, including the {ctag}s, via the the _Access Memory_ abstract command. Full capability access is denoted by `aamsize=7` and uses the `data<n>` register assignments specified in <<debug_data_aarsize_7>>.
+Implementations can choose to support accessing full capabilities, including the {ctag}s, via the _Access Memory_ abstract command. Full capability access is denoted by `aamsize=7` and uses the `data<n>` register assignments specified in <<debug_data_aarsize_7>>.
 
-NOTE: If `aamsize{ne}7` then {ctag}s are always read and written as zero.
+If `aamsize{ne}7` then {ctag}s are always read and written as zero.
 
 ==== Core Debug Registers
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -85,6 +85,48 @@ no way to discover the former property.
   setting `transfer` to 1 and `write` to 0).
 ====
 
+==== Access Register Command
+
+The _Access Register_ abstract command has optional support for accessing YLEN registers.
+
+If `aarsize` matches YLEN then all YLEN-bits should be accessible via the command.
+This requires enough `data<n>` registers to be supported to cover the entire data width (2 for {cheri_base32_ext_name} or 4 for {cheri_base64_ext_name}).
+
+Implementations can choose to also support accessing {ctag}s as part of the access register command.
+
+`aarsize=7` is defined to represent full capability access.
+
+The `data<n>` register mapping is as shown in <<debug_data_aarsize_7>>.
+
+.Data register mapping when `aarsize=7`
+[#debug_data_aarsize_7]
+[width="100%",options=header,cols="1,1,1,1,1"]
+|=====
+|ISA                    | arg0/return value| arg1^1^     | arg2        | {ctag}
+|{cheri_base32_ext_name}| data0,data1      | data2       | data3,data4 | data5
+|{cheri_base64_ext_name}| data0-data3      | data4,data5 | data6-data9 | data10
+|=====
+
+^1^ arg1 represents an address so never needs to exceed DXLEN.
+ Each `data<n>` register is 32-bit so a maximum of 2 is required.
+
+Bit 0 of `data5` or `data10` contain the {ctag} which is either written to, or read from, the target register.
+All other bits in that `data` register are UNSPECIFIED.
+
+When a capability is written it must be a <<cap_subset>> of the capability in <<drootc>>.
+If not then the destination {ctag} is set to zero.
+
+NOTE: For the capability subset: `cap2` is the capability being written and `cap` 1 is the value of <<drootc>>.
+
+NOTE: It is valid for root capabilities not to cover the entire possible address space.
+ In this case the debugger cannot claim access to more memory than is permitted by <<drootc>>.
+
+==== Access Memory Command
+
+The _Access Memory_ abstract command does not support accessing {ctag}s.
+
+NOTE: A future version of this specification may supporting accessing {ctag}s in memory by permitted `aarsize=7`.
+
 ==== Core Debug Registers
 
 {cheri_base_ext_name} widens debug CSRs that are designated to hold addresses so that they can hold capabilities.

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -122,7 +122,8 @@ When a YLEN-wide register is accessible via an _Access Register_ abstract comman
 - Writes of smaller amounts of bits than YLEN may optionally be supported but it is UNSPECIFIED what happens to the higher bits.
 
 NOTE: The debugger can change the low XLEN bits of a YLEN wide register by performing a read-modify-write sequence.
-This requires enough `data<n>` registers to be supported to cover the entire data width (2 for {cheri_base32_ext_name} or 4 for {cheri_base64_ext_name}).
+
+The requirement to support YLEN-wide access mandates that enough `data<n>` registers are implemented to cover the entire YLEN bit-width (at least 2 for {cheri_base32_ext_name} or at least 4 for {cheri_base64_ext_name}).
 
 Implementations can choose to also support accessing {ctag}s as part of the access register command by supporting `aarsize=7`.
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -114,7 +114,7 @@ The `data<n>` register mapping is as shown in <<debug_data_aarsize_7>>.
 |=====
 
 ^1^ arg1 represents an address so never needs to exceed DXLEN.
- Each `data<n>` register is 32-bit so a maximum of 2 is required.
+ Each `data<n>` register is 32-bit so a maximum of 2 are required.
 
 Bit 0 of `data5` or `data10` contain the {ctag} which is either written to, or read from, the target register.
 All other bits in that `data` register are UNSPECIFIED.
@@ -127,13 +127,13 @@ NOTE: For the capability subset: `cap2` is the capability being written and `cap
 NOTE: It is valid for root capabilities not to cover the entire possible address space.
  In this case the debugger cannot claim access to more memory than is permitted by <<drootc>>.
 
-NOTE: Any register write with `aarsize{ne}7` causes the {ctag} (if present) to be set to zero.
+NOTE: If `aarsize{ne}7` then {ctag}s are always read and written as zero.
 
 ==== Access Memory Command
 
 Implementations can choose to support accessing full capabilities, including the {ctag}s, via the the _Access Memory_ abstract command. Full capability access is denoted by `aamsize=7` and uses the `data<n>` register assignments specified in <<debug_data_aarsize_7>>.
 
-NOTE: If `aarsize{ne}7` then {ctag}s are always read and written as zero.
+NOTE: If `aamsize{ne}7` then {ctag}s are always read and written as zero.
 
 ==== Core Debug Registers
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -8,6 +8,11 @@ include::trigger-integration.adoc[]
 
 {cheri_base_ext_name} harts should be able to access capabilities in registers and in memory via the external debugger.
 
+This can be achieved by at least one of:
+
+. Implementing a program buffer configured as specified below.
+. Supporting `aarsize=7` for abstract commands which access registers and memory, or both.
+
 ==== Program Buffer
 
 If a Program Buffer is implemented, this section shows how it can be configured and used to access capabilities.
@@ -121,11 +126,13 @@ NOTE: For the capability subset: `cap2` is the capability being written and `cap
 NOTE: It is valid for root capabilities not to cover the entire possible address space.
  In this case the debugger cannot claim access to more memory than is permitted by <<drootc>>.
 
+NOTE: Any register write with `aarsize{ne}7` causes the {ctag} (if present) to be set to zero.
+
 ==== Access Memory Command
 
-The _Access Memory_ abstract command does not support accessing {ctag}s.
+The _Access Memory_ abstract command supports accessing {ctag}s when `aarsize=7`, using the `data<n>` register format specified in <<debug_data_aarsize_7>>.
 
-NOTE: A future version of this specification may supporting accessing {ctag}s in memory by permitted `aarsize=7`.
+NOTE: If `aarsize{ne}7` then {ctag}s are always read and written as zero.
 
 ==== Core Debug Registers
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -11,7 +11,7 @@ include::trigger-integration.adoc[]
 This can be achieved by at least one of:
 
 . Implementing a program buffer configured as specified below.
-. Supporting `aarsize=7` for abstract commands which access registers and memory, or both.
+. Supporting full capability access for both Access Register and Access Memory abstract commands (`aarsize=7` and `aamsize=7`).
 
 ==== Program Buffer
 
@@ -19,15 +19,16 @@ If a Program Buffer is implemented, this section shows how it can be configured 
 
 * `hartinfo` must be implemented.
 * `hartinfo.nscratch` is at least 1 and the <<dscratch0_y>> register is implemented.
-* `hartinfo.datasize` is at least 1 and `hartinfo.dataaccess` of 0.
-* `abstractcs.progbufsize` of at least 4 if `dmstatus.impebreak` is 1, or at least 5 if `dmstatus.impebreak` is 0.
+* `hartinfo.datasize` is at least 1 and `hartinfo.dataaccess` is 0.
+* `abstractcs.progbufsize` is at least 4 if `dmstatus.impebreak` is 1, or at least 5 if `dmstatus.impebreak` is 0.
 
 [NOTE]
 ====
 These requirements allow a debugger to read and write capabilities in integer
 registers without disturbing other registers.  These requirements may be
 relaxed if some other means of accessing capabilities in integer registers,
-such as an extension of the Access Register abstract command, is added.
+These requirements allow a debugger to read and write capabilities in integer
+registers without disturbing other registers.
 
 The sequences below demonstrate how a debugger can read and write a capability in `{creg}1` using the program buffer if:
 
@@ -130,7 +131,7 @@ NOTE: Any register write with `aarsize{ne}7` causes the {ctag} (if present) to b
 
 ==== Access Memory Command
 
-The _Access Memory_ abstract command supports accessing {ctag}s when `aarsize=7`, using the `data<n>` register format specified in <<debug_data_aarsize_7>>.
+Implementations can choose to support accessing full capabilities, including the {ctag}s, via the the _Access Memory_ abstract command. Full capability access is denoted by `aamsize=7` and uses the `data<n>` register assignments specified in <<debug_data_aarsize_7>>.
 
 NOTE: If `aarsize{ne}7` then {ctag}s are always read and written as zero.
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -24,11 +24,8 @@ If a Program Buffer is implemented, this section shows how it can be configured 
 
 [NOTE]
 ====
-These requirements allow a debugger to read and write capabilities in integer
-registers without disturbing other registers.  These requirements may be
-relaxed if some other means of accessing capabilities in integer registers,
-These requirements allow a debugger to read and write capabilities in integer
-registers without disturbing other registers.
+These requirements allow a debugger to read and write capabilities in integer registers without disturbing other registers.
+These requirements may be relaxed if abstract commands support full capability access.
 
 The sequences below demonstrate how a debugger can read and write a capability in `{creg}1` using the program buffer if:
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -155,7 +155,7 @@ endif::[]
 {cheri_base_ext_name} sets the Y bit to be 1.
 Either I or E is _also_ set to show how many registers are present.
 
-NOTE: Implementations which allow misa.C to be writable need to legalize <`__x__epc`>
+NOTE: Implementations which allow misa.C to be writable need to legalize <<mtvec_y>>/<<stvec_y>>
  on _reading_ if the misa.C value has changed since the value was written as this
  can cause the read value of bit [1] to change state.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -888,4 +888,6 @@ Sealed Entry Point Capability.
 Hybrid mode.
 [#STORE_COND_CAP,reftext="SC{LD_ST_DOT_CAP}"]
 SC{LD_ST_DOT_CAP}.
+[#cap_subset,reftext="Capability Subset"]
+See the unprivileged manual for details of the Capability Subset.
 endif::[]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -556,13 +556,13 @@ NOTE: Implementations are not required to provide access to the entire address s
 
 [#root-rx-cap,reftext="Root Executable"]
 Root Executable Capability::
-An unsealed capability that has bounds covering all addresses
+An unsealed capability that has bounds nominally covering all addresses
 and grants at least all of <<x_perm>>, <<r_perm>>, <<c_perm>>, <<lm_perm>>, and <<asr_perm>>.
 Extensions introducing new permissions may require these to be provided by root executable capabilities.
 
 [#root-rw-cap,reftext="Root Data"]
 Root Data Capability::
-An unsealed capability that has bounds covering all addresses
+An unsealed capability that has bounds nominally covering all addresses
 and grants at least all of <<r_perm>>, <<w_perm>>, <<c_perm>>, and <<lm_perm>>.
 Extensions introducing new permissions may require these to be provided by root data capabilities.
 
@@ -928,13 +928,13 @@ Special instructions are provided to copy capabilities or derive a new capabilit
 
 [#cap_subset,reftext="capability subset"]
 Capability subset::
-Some instructions use the concept of `{cs2}` being a _capability subset_ of `{cs1}`.
+Some instructions use the concept of `cap2` being a _capability subset_ of `cap1`.
 The definition is:
 +
-. All permissions granted by the <<AP-field>> and the <<SDP-field>> of `{cs2}` are also granted by those of `{cs1}`, and
-. `{cs2}` 's top bound is less than or equal to `{cs1}` 's top bound, and
-. `{cs2}` 's base bound is greater than or equal to `{cs1}` 's base bound, and
-. `{cs1}` and `{cs2}` pass all <<section_cap_integrity,integrity>> checks
+. All permissions granted by the <<AP-field>> and the <<SDP-field>> of `cap2` are also granted by those of `cap1`, and
+. `cap2` 's top bound is less than or equal to `cap1` 's top bound, and
+. `cap2` 's base bound is greater than or equal to `cap1` 's base bound, and
+. `cap1` and `cap2` pass all <<section_cap_integrity,integrity>> checks
 
 .Summary of {cheri_base_ext_name} instructions that create a modified capability
 [#tab_cap_manip_summary,%autowidth,options=header,align="center",cols="1,4"]


### PR DESCRIPTION

1) <del>Specify that Access Memory abstract commands clear the capability tags, as discussed in
https://github.com/riscv/riscv-cheri/issues/1068.</del>

2) <del>Prepare a placeholder section for Access Register abstract commands, which should be filled in after we clarify this issue: https://github.com/riscv/riscv-cheri/issues/1039</del>

Overall review of the debug integration chapter.
