### PR TITLE
Use "widens" instead of "extends to"

### DIFF
--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -93,7 +93,7 @@ apply.
 
 ==== Core Debug Registers
 
-{cheri_base_ext_name} extends debug CSRs that are designated to
+{cheri_base_ext_name} widens debug CSRs that are designated to
 hold addresses to be able to hold capabilities. The extended debug CSRs are
 listed in xref:dcsrnames-renamed[xrefstyle=short].
 
@@ -130,7 +130,7 @@ include::img/dscratch1reg.edn[]
 [#dpc_y,reftext="dpc ({cheri_base_ext_name})"]
 ==== Debug Program Counter Capability (dpc)
 
-The <<dpc>> register is extended to hold a capability.
+The <<dpc>> register is widened to hold a capability.
 
 {TAG_RESET_DCSR}
 
@@ -167,7 +167,7 @@ include::insns/dret.adoc[leveloffset=+1]
 [#dscratch0_y,reftext="dscratch0 ({cheri_base_ext_name})"]
 ==== Debug Scratch Register 0 (dscratch0)
 
-The <<dscratch0>> register is extended to hold a capability.
+The <<dscratch0>> register is widened to hold a capability.
 
 {TAG_RESET_DCSR}
 
@@ -177,7 +177,7 @@ include::img/dscratch0creg.edn[]
 [#dscratch1_y,reftext="dscratch1 ({cheri_base_ext_name})"]
 ==== Debug Scratch Register 1 (dscratch1)
 
-The <<dscratch1>> register is extended to hold a capability.
+The <<dscratch1>> register is widened to hold a capability.
 
 {TAG_RESET_DCSR}
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -93,9 +93,8 @@ apply.
 
 ==== Core Debug Registers
 
-{cheri_base_ext_name} widens debug CSRs that are designated to
-hold addresses to be able to hold capabilities. The extended debug CSRs are
-listed in xref:dcsrnames-renamed[xrefstyle=short].
+{cheri_base_ext_name} widens debug CSRs that are designated to hold addresses so that they can hold capabilities.
+These widened debug CSRs are listed in xref:dcsrnames-renamed[xrefstyle=short].
 
 The <<pcc>> must grant <<asr_perm>> to access debug CSRs. This permission is
 automatically provided when the hart enters debug mode as described
@@ -130,7 +129,7 @@ include::img/dscratch1reg.edn[]
 [#dpc_y,reftext="dpc ({cheri_base_ext_name})"]
 ==== Debug Program Counter Capability (dpc)
 
-The <<dpc>> register is widened to hold a capability.
+The <<dpc>> register is widened so that it can hold a capability.
 
 {TAG_RESET_DCSR}
 
@@ -167,7 +166,7 @@ include::insns/dret.adoc[leveloffset=+1]
 [#dscratch0_y,reftext="dscratch0 ({cheri_base_ext_name})"]
 ==== Debug Scratch Register 0 (dscratch0)
 
-The <<dscratch0>> register is widened to hold a capability.
+The <<dscratch0>> register is widened so that it can hold a capability.
 
 {TAG_RESET_DCSR}
 
@@ -177,7 +176,7 @@ include::img/dscratch0creg.edn[]
 [#dscratch1_y,reftext="dscratch1 ({cheri_base_ext_name})"]
 ==== Debug Scratch Register 1 (dscratch1)
 
-The <<dscratch1>> register is widened to hold a capability.
+The <<dscratch1>> register is widened so that it can hold a capability.
 
 {TAG_RESET_DCSR}
 

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -10,7 +10,7 @@ type-1 or type-2 hypervisor cite:[riscv-priv-spec].
 The hypervisor extension is
 generally orthogonal to CHERI; the main requirements, when integrating with
 {cheri_base_ext_name} and {cheri_default_ext_name}, are that address CSRs added
-for hypervisors are extended to YLEN size.
+for hypervisors are widened to YLEN size.
 The remainder of this chapter describes these changes in detail.
 
 [#hstatus,reftext="hstatus"]
@@ -76,7 +76,7 @@ xref:mstatus_y[xrefstyle=short] for mstatus.UXL.
 [#vstvec_y,reftext="vstvec ({cheri_base_ext_name})"]
 === Virtual Supervisor Trap Vector Base Address Capability Register (vstvec)
 
-The `vstvec` register is extended to hold a capability.
+The `vstvec` register is widened to hold a capability.
 
 .Virtual supervisor trap vector base address capability register
 include::img/vstveccreg.edn[]
@@ -87,7 +87,7 @@ virtual supervisor mode.
 [#vsscratch_y,reftext="vsscratch ({cheri_base_ext_name})"]
 === Virtual Supervisor Scratch Register (vsscratch)
 
-The `vsscratch` register is extended to hold a capability.
+The `vsscratch` register is widened to hold a capability.
 
 It is not WARL, all capability fields must be implemented.
 
@@ -97,7 +97,7 @@ include::img/vsscratchcreg.edn[]
 [#vsepc_y,reftext="vsepc ({cheri_base_ext_name})"]
 === Virtual Supervisor Exception Program Counter Capability (vsepc)
 
-The `vsepc` register is extended to hold a capability.
+The `vsepc` register is widened to hold a capability.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<vsepc_y>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
 Additionally, the capability in <<vsepc_y>> is unsealed when it is written to <<pcc>> on execution of an <<SRET_CHERI>> instruction when V=1.

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -10,7 +10,7 @@ type-1 or type-2 hypervisor cite:[riscv-priv-spec].
 The hypervisor extension is
 generally orthogonal to CHERI; the main requirements, when integrating with
 {cheri_base_ext_name} and {cheri_default_ext_name}, are that address CSRs added
-for hypervisors are widened to YLEN size.
+for hypervisors are widened so that they can hold capabilities.
 The remainder of this chapter describes these changes in detail.
 
 [#hstatus,reftext="hstatus"]

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -76,7 +76,7 @@ xref:mstatus_y[xrefstyle=short] for mstatus.UXL.
 [#vstvec_y,reftext="vstvec ({cheri_base_ext_name})"]
 === Virtual Supervisor Trap Vector Base Address Capability Register (vstvec)
 
-The `vstvec` register is widened to hold a capability.
+The `vstvec` register is widened so that it can hold a capability.
 
 .Virtual supervisor trap vector base address capability register
 include::img/vstveccreg.edn[]
@@ -87,7 +87,7 @@ virtual supervisor mode.
 [#vsscratch_y,reftext="vsscratch ({cheri_base_ext_name})"]
 === Virtual Supervisor Scratch Register (vsscratch)
 
-The `vsscratch` register is widened to hold a capability.
+The `vsscratch` register is widened so that it can hold a capability.
 
 It is not WARL, all capability fields must be implemented.
 
@@ -97,7 +97,7 @@ include::img/vsscratchcreg.edn[]
 [#vsepc_y,reftext="vsepc ({cheri_base_ext_name})"]
 === Virtual Supervisor Exception Program Counter Capability (vsepc)
 
-The `vsepc` register is widened to hold a capability.
+The `vsepc` register is widened so that it can hold a capability.
 
 As shown in xref:CSR_exevectors[xrefstyle=short], <<vsepc_y>> is a code capability, so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
 Additionally, the capability in <<vsepc_y>> is unsealed when it is written to <<pcc>> on execution of an <<SRET_CHERI>> instruction when V=1.

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -9,14 +9,14 @@ This chapter describes integration of {cheri_base_ext_name} with the RISC-V priv
 
 === Machine-Level CSRs added or extended by {cheri_base_ext_name}
 
-{cheri_base_ext_name} extends some M-mode CSRs to hold capabilities or
+{cheri_base_ext_name} widens some M-mode CSRs to hold capabilities or
 otherwise add new functions. <<asr_perm>> in the <<pcc>> is always required for access
 to privileged CSRs.
 
 [#mtvec_y,reftext="mtvec ({cheri_base_ext_name})"]
 ==== Machine Trap Vector Base Address Capability Register (mtvec)
 
-The <<mtvec>> register is extended to hold a code capability.
+The <<mtvec>> register is widened to hold a code capability.
 Its reset value is nominally a <<root-rx-cap>> capability.
 
 NOTE: <<mtvec_y>> exists in all CHERI implementations, and so may be used as a source of a <<root-rx-cap>> capability after reset.
@@ -60,7 +60,7 @@ NOTE: The capability in <<mtvec_y>> is _not_ unsealed when it is written to <<pc
 [#mscratch_y, reftext="mscratch ({cheri_base_ext_name})"]
 ==== Machine Scratch Capability Register (mscratch)
 
-The <<mscratch>> register is extended to hold a capability.
+The <<mscratch>> register is widened to hold a capability.
 
 {TAG_RESET_MCSR}
 
@@ -72,7 +72,7 @@ include::img/mscratchcreg.edn[]
 [#mepc_y,reftext="mepc ({cheri_base_ext_name})"]
 ==== Machine Exception Program Counter Capability (mepc)
 
-The <<mepc>> is extended to hold a capability.
+The <<mepc>> is widened to hold a capability.
 Its reset value is nominally a <<root-rx-cap>> capability.
 
 .Machine exception program counter capability register
@@ -250,13 +250,13 @@ endif::[]
 [#supervisor-level-csrs-section]
 === Supervisor-Level CSRs added or extended by {cheri_base_ext_name}
 
-{cheri_base_ext_name} extends some of the existing RISC-V CSRs to be able to
+{cheri_base_ext_name} widens some of the existing RISC-V CSRs to be able to
 hold capabilities or with other new functions. <<asr_perm>> in the <<pcc>> is required for access to all privileged CSRs.
 
 [#stvec_y,reftext="stvec ({cheri_base_ext_name})"]
 ==== Supervisor Trap Vector Base Address Capability Register (stvec)
 
-The <<stvec>> register is extended to hold a capability.
+The <<stvec>> register is widened to hold a capability.
 
 {ROOT_RX_RESET_SCSR}
 
@@ -268,7 +268,7 @@ The handling of <<stvec_y>> is otherwise identical to <<mtvec_y>>, but in superv
 [#sscratch_y, reftext="sscratch ({cheri_base_ext_name})"]
 ==== Supervisor Scratch Capability Register (sscratch)
 
-The <<sscratch>> register is extended to hold a capability.
+The <<sscratch>> register is widened to hold a capability.
 
 {TAG_RESET_SCSR}
 
@@ -280,7 +280,7 @@ include::img/sscratchcreg.edn[]
 [#sepc_y,reftext="sepc ({cheri_base_ext_name})"]
 ==== Supervisor Exception Program Counter Capability (sepc)
 
-The <<sepc>> register is extended to hold a capability.
+The <<sepc>> register is widened to hold a capability.
 
 {ROOT_RX_RESET_SCSR}
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -9,14 +9,13 @@ This chapter describes integration of {cheri_base_ext_name} with the RISC-V priv
 
 === Machine-Level CSRs added or extended by {cheri_base_ext_name}
 
-{cheri_base_ext_name} widens some M-mode CSRs to hold capabilities or
-otherwise add new functions. <<asr_perm>> in the <<pcc>> is always required for access
+{cheri_base_ext_name} widens some M-mode CSRs so that they can hold capabilities or otherwise add new functions. <<asr_perm>> in the <<pcc>> is always required for access
 to privileged CSRs.
 
 [#mtvec_y,reftext="mtvec ({cheri_base_ext_name})"]
 ==== Machine Trap Vector Base Address Capability Register (mtvec)
 
-The <<mtvec>> register is widened to hold a code capability.
+The <<mtvec>> register is widened so that it can hold a code capability.
 Its reset value is nominally a <<root-rx-cap>> capability.
 
 NOTE: <<mtvec_y>> exists in all CHERI implementations, and so may be used as a source of a <<root-rx-cap>> capability after reset.
@@ -60,7 +59,7 @@ NOTE: The capability in <<mtvec_y>> is _not_ unsealed when it is written to <<pc
 [#mscratch_y, reftext="mscratch ({cheri_base_ext_name})"]
 ==== Machine Scratch Capability Register (mscratch)
 
-The <<mscratch>> register is widened to hold a capability.
+The <<mscratch>> register is widened so that it can hold a capability.
 
 {TAG_RESET_MCSR}
 
@@ -72,7 +71,7 @@ include::img/mscratchcreg.edn[]
 [#mepc_y,reftext="mepc ({cheri_base_ext_name})"]
 ==== Machine Exception Program Counter Capability (mepc)
 
-The <<mepc>> is widened to hold a capability.
+The <<mepc>> is widened so that it can hold a capability.
 Its reset value is nominally a <<root-rx-cap>> capability.
 
 .Machine exception program counter capability register
@@ -250,13 +249,14 @@ endif::[]
 [#supervisor-level-csrs-section]
 === Supervisor-Level CSRs added or extended by {cheri_base_ext_name}
 
-{cheri_base_ext_name} widens some of the existing RISC-V CSRs to be able to
-hold capabilities or with other new functions. <<asr_perm>> in the <<pcc>> is required for access to all privileged CSRs.
+{cheri_base_ext_name} widens some of the existing RISC-V CSRs so that they can hold capabilities.
+Additionally, {cheri_base_ext_name} allocates some previously reserved bits in existing CSRs.
+<<asr_perm>> in the <<pcc>> is required for access to all privileged CSRs.
 
 [#stvec_y,reftext="stvec ({cheri_base_ext_name})"]
 ==== Supervisor Trap Vector Base Address Capability Register (stvec)
 
-The <<stvec>> register is widened to hold a capability.
+The <<stvec>> register is widened so that it can hold a capability.
 
 {ROOT_RX_RESET_SCSR}
 
@@ -268,7 +268,7 @@ The handling of <<stvec_y>> is otherwise identical to <<mtvec_y>>, but in superv
 [#sscratch_y, reftext="sscratch ({cheri_base_ext_name})"]
 ==== Supervisor Scratch Capability Register (sscratch)
 
-The <<sscratch>> register is widened to hold a capability.
+The <<sscratch>> register is widened so that it can hold a capability.
 
 {TAG_RESET_SCSR}
 
@@ -280,7 +280,7 @@ include::img/sscratchcreg.edn[]
 [#sepc_y,reftext="sepc ({cheri_base_ext_name})"]
 ==== Supervisor Exception Program Counter Capability (sepc)
 
-The <<sepc>> register is widened to hold a capability.
+The <<sepc>> register is widened so that it can hold a capability.
 
 {ROOT_RX_RESET_SCSR}
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -9,7 +9,9 @@ This chapter describes integration of {cheri_base_ext_name} with the RISC-V priv
 
 === Machine-Level CSRs added or extended by {cheri_base_ext_name}
 
-{cheri_base_ext_name} widens some M-mode CSRs so that they can hold capabilities or otherwise add new functions. <<asr_perm>> in the <<pcc>> is always required for access
+{cheri_base_ext_name} widens some M-mode CSRs so that they can hold capabilities.
+Additionally, {cheri_base_ext_name} allocates some previously reserved bits in existing CSRs.
+<<asr_perm>> in the <<pcc>> is always required for access
 to privileged CSRs.
 
 [#mtvec_y,reftext="mtvec ({cheri_base_ext_name})"]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -63,7 +63,7 @@ improve their security.
 [#sec_capability_registers]
 === Capability Registers and Format
 
-{cheri_base_ext_name} extends all registers that have to be able to hold addresses to `2*XLEN` bits (hereafter referred to as YLEN), adding metadata to protect its integrity, limit how it is manipulated, and control its use.
+{cheri_base_ext_name} widens all registers that can hold addresses from `XLEN` to `2*XLEN` bits (hereafter referred to as YLEN), adding metadata to protect its integrity, limit how it is manipulated, and control its use.
 In addition to widening to YLEN, each register also gains a one-bit {ctag} which is defined below.
 
 {cheri_base_ext_name} specifies the minimum required fields that the capability format must support, and their semantics.
@@ -652,8 +652,7 @@ As stated above, all state which can hold addresses are extended from XLEN to YL
 
 ==== General Purpose Registers
 
-The <<gprs,XLEN-wide integer registers>> (e.g., `x1`, `x2`) are all extended to YLEN bits
-and associated {ctag}s, as shown in <<base_cap_registers>>.
+The <<gprs,XLEN-wide integer registers>> (e.g., `x1`, `x2`) are all widened to YLEN bits, each gaining an associated {ctag}, as shown in <<base_cap_registers>>.
 
 .Extended registers in {cheri_base_ext_name}
 [#base_cap_registers]
@@ -682,8 +681,8 @@ The zero register (`x0`) is extended with zero metadata and a zero {ctag}: this 
 [#pcc,reftext="{pcc}"]
 ==== The Program Counter Capability (`{pcc}`)
 
-The `pc` is extended to be a capability.
-Extending the `pc` allows the range of branches, jumps and linear execution for currently executing code to be restricted.
+The `pc` register is widened to hold a capability (referred to as the Program Counter Capability, or `{pcc}`).
+Widening the `pc` register to `{pcc}` allows the range of branches, jumps and linear execution for currently executing code to be restricted.
 The <<pcc>> address field is the `pc` in the base RISC-V ISA so that the
 hardware automatically updates it as instructions are executed.
 
@@ -802,7 +801,7 @@ endif::[]
 [#rvy_csr_classes]
 ==== CSR Classes
 
-All CSRs that can hold addresses are extended to YLEN bits.
+All CSRs that can hold addresses are widened to YLEN bits.
 
 {cheri_base_ext_name} has three classes of CSRs:
 
@@ -810,7 +809,7 @@ All CSRs that can hold addresses are extended to YLEN bits.
 These do not contain pointers (e.g., _fcsr_ from the "F" extension).
 
 [[extended_csrs, extended CSRs]]Extended CSRs::
-These are XLEN-bit CSRs extended to YLEN bits, which are able to contain pointers
+These are XLEN-bit CSRs widened to YLEN bits, which are able to contain pointers
 // No unprivileged pointer-type CSRs in v1.0, so let's use mtvec here.
 ifdef::cheri_ratification_v1_only[]
 (e.g., _mtvec_ from the privileged specification).

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -681,8 +681,8 @@ The zero register (`x0`) is extended with zero metadata and a zero {ctag}: this 
 [#pcc,reftext="{pcc}"]
 ==== The Program Counter Capability (`{pcc}`)
 
-The `pc` register is widened to hold a capability (referred to as the Program Counter Capability, or `{pcc}`).
-Widening the `pc` register to `{pcc}` allows the range of branches, jumps and linear execution for currently executing code to be restricted.
+The `pc` register is widened to hold a capability.
+Widening the `pc` allows the range of branches, jumps and linear execution for currently executing code to be restricted.
 The <<pcc>> address field is the `pc` in the base RISC-V ISA so that the
 hardware automatically updates it as instructions are executed.
 


### PR DESCRIPTION
This should make the spec easier to parse (especially for non-native
English speakers) where some of the more complicated sentences could be
parsed as adding new wider registers.

Fixes: https://github.com/riscv/riscv-cheri/issues/1063
