### PR TITLE
Remove outdated reference to a future unseal instruction

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -323,7 +323,6 @@ Sentry types may be restricted to _forward-edge_ only and _backward-edge_ only t
 
 NOTE: In addition to using sealed capabilities as sentries for secure entry points, sealed capabilities can also be useful to software as secure software tokens.
  <<YSUNSEAL>> can be used to convert such a token back to an unsealed capability.
- A future extension may add an unseal instruction for performance.
 
 [#sec_cap_type_ambient, reftext="Ambient sealing type"]
 Ambient sealing type::


### PR DESCRIPTION
The sentence about a speculative future unseal instruction is outdated since such an instruction exists with YSUNSEAL (mentioned directly before the removed sentence).