### PR TITLE
JALR: Fix AsciiDoc formatting for the {cs1} placeholder

### DIFF
--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -23,7 +23,7 @@ NOTE: The description below is generic, and implementations which need control-f
 +
 . `{cs1}` is written to the target <<pcc>>.
 . If `{cd}`≠x0, `{cs1}` is _sealed_ and `{cs1}` is not a _forward-edge_ <<sentry_cap>>, then the behavior is _reserved_^1^.
-. If `{cd}=x0`, '{cs1}' is the link register , `{cs1}` is _sealed_ and `{cs1}` is not a _backward-edge_ <<sentry_cap>>, then the behavior is _reserved_^1^.
+. If `{cd}=x0`, `{cs1}` is the link register , `{cs1}` is _sealed_ and `{cs1}` is not a _backward-edge_ <<sentry_cap>>, then the behavior is _reserved_^1^.
 . The target address is obtained by adding the sign-extended 12-bit I-immediate to `{cs1}.address`, then setting the least-significant bit of the result to zero.
 . Unseal the target <<pcc>> if it is any <<sentry_cap>>, `{cs1}.address[0]` is zero, and the I-immediate is zero.
 . Set the address of the target <<pcc>> to the target address using the semantics of the <<SCADDR>> instruction.


### PR DESCRIPTION
Fix the formatting for the {cs1} placeholder by using backticks instead of single quotes.