### PR TITLE
representable region -> representable range everywhere

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -220,24 +220,24 @@ The number of shared bits depends on the exponent, see xref:section_cap_bounds[x
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
 Because the CHERI Concentrate cite:[woodruff2019cheri] encoding scheme for memory bounds shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
-This range is known as the *representable region*.
-The relationship between the bounds and the representable region is illustrated in <<cap_bounds_map>>.
+This range is known as the *representable range*.
+The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>>.
 
 NOTE: While the C standard only requires one-past-the-end pointers to be valid, real-world software has been observed to (temporarily) create pointers that point multiple bytes past the end or even before the start.
   To maximize software compatibility, the bounds representation was designed to allow for out-of-bounds pointers.
 
 [#cap_bounds_map]
-.Memory address bounds and representable region encoded within a capability
+.Memory address bounds and representable range encoded within a capability
 image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 
 E, MW and R in the figure are all introduced in xref:section_cap_bounds_decoding[xrefstyle=short] along with the bounds decoding.
 
-The maximum range of address values that the pointer can take without changing the interpretation of bounds is defined by the <<section_cap_representable_check,representable region>>.
+The maximum range of address values that the pointer can take without changing the interpretation of bounds is defined by the <<section_cap_representable_check,representable range>>.
 
 NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding had separate 64-bit values for the base and top memory bounds, and another for metadata fields.
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
-Since deriving a new capability with a different address could change the meaning of the bounds, all such derived capabilities (e.g., deriving the next <<pcc>> capability from the existing <<pcc>> via control-flow instructions or sequential execution) and instructions that return valid derived capabilities, must check that the new address is within the representable region defined by the source capability.
+Since deriving a new capability with a different address could change the meaning of the bounds, all such derived capabilities (e.g., deriving the next <<pcc>> capability from the existing <<pcc>> via control-flow instructions or sequential execution) and instructions that return valid derived capabilities, must check that the new address is within the representable range defined by the source capability.
 If the interpretation of bounds _has_ changed, then the {ctag} of the derived capability is set to zero, so that it is invalid for use.
 
 Software can derive a capability with a new address using instructions such as <<SCADDR>>, <<CADD>> and <<CADDI>>.
@@ -246,7 +246,7 @@ NOTE: <<SCADDR>> writes back a derived capability with a new address field and, 
 
 NOTE: Existing software sometimes temporarily moves pointers outside of arrays, and then only comes back into the valid range on dereference, so the encoding was designed to allow valid capabilities to be out-of-bounds.
 
-NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable region check, and may never allow the address to be out of bounds.
+NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check, and may never allow the address to be out of bounds.
 Therefore, the rest of the specification uses the phrase *represented exactly* for this check.
 
 ==== Memory space

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -83,7 +83,7 @@ Known extension (in)compatibilities are listed in <<rv32y_cheriot_encoding1_ext_
 | Parameter | Value                  | Comment
 | mw        | {cap_cheriot_mw_width} | Mantissa width
 | e         | 14                     | Exponent limit before jumping to maximum exponent
-| rc        | 0                      | Representable region between base and top only
+| rc        | 0                      | Representable range between base and top only
 | p         | pc                     | Compressed permission encoding
 | enc       | Cheriot1               | Encoding variant
 |==============================================================================
@@ -107,7 +107,7 @@ endif::[]
 [#rv32y_cheriot_encoding1_feature_summary,width="100%",options=header,]
 |==============================================================================
 | Feature                      | Comment
-| Representable region         | Between base and top only (inclusive)
+| Representable range         | Between base and top only (inclusive)
 | Permission encodings         | Not all combinations can be represented
 |==============================================================================
 
@@ -253,7 +253,7 @@ c_t = A_hi - T_hi
 ----
 
 These corrections work by assuming that the base is in the lower of two 2^e+9^ aligned regions, and that the top and address are always greater than or equal to the base but may be in the higher region provided they are within 2^e+9^ of base.
-These assumptions lead to the representable region being given by:
+These assumptions lead to the representable range being given by:
 
 [source]
 ----

--- a/src/cheri/rvy-cheriot-enc2.adoc
+++ b/src/cheri/rvy-cheriot-enc2.adoc
@@ -77,7 +77,7 @@ whose parametric requirements are no stronger than those given in <<rv32y_cherio
 | Parameter | Value                | Comment
 | mw        | {cap_cheriot_mw_width}  | Mantissa width
 | e         | a                    | All exponents are supported
-| rc        | 0                    | Representable region between base and top only
+| rc        | 0                    | Representable range between base and top only
 | p         | pc                   | Compressed permission encoding
 | enc       | Cheriot2             | Encoding variant
 |==============================================================================

--- a/src/cheri/rvy-cheriot-enc3.adoc
+++ b/src/cheri/rvy-cheriot-enc3.adoc
@@ -47,7 +47,7 @@ These are identical to those of {rv32y_cheriot_encoding2_name} except for the en
 | Parameter | Value                  | Comment
 | mw        | {cap_cheriot_mw_width} | Mantissa width
 | e         | a                      | All exponents are supported
-| rc        | 0                      | Representable region between base and top only
+| rc        | 0                      | Representable range between base and top only
 | p         | pc                     | Compressed permission encoding
 | enc       | Cheriot3               | Encoding variant
 |==============================================================================

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -33,7 +33,7 @@ This capability encoding has the following properties that affect the observable
 
 * **Mantissa width (mw{cap_rv64_mw_width})**: The mantissa width for the bounds encoding uses {cap_rv64_mw_width} bits
 * **Maximum exponent (e{cap_rv64_exp_max})**: The maximum value for the exponent in a valid capability is {cap_rv64_exp_max}.
-* **Representable region (rc1)**: The encoding uses one additional bit to ensure a _centered_ region of at least 1/4 of the capability size remains representable when creating out-of-bounds derived capabilities.
+* **Representable range (rc1)**: The encoding uses one additional bit to ensure a _centered_ region of at least 1/4 of the capability size remains representable when creating out-of-bounds derived capabilities.
 * **Permission encoding (ps)**: The permissions are encoded using a simple representation of one bit per architectural permission.
 
 ==== Capability Encoding Summary
@@ -67,7 +67,7 @@ endif::[]
 [#rvy64_uni_base_name_feature_summary,width="100%",options=header,]
 |==============================================================================
 | Feature                      | Comment
-| Representable region         | At least 1/4 of the capability size
+| Representable range         | At least 1/4 of the capability size
 | Permission encodings         | All combinations can be represented, some combinations are reserved
 |==============================================================================
 


### PR DESCRIPTION
the naming was inconsistent