### PR TITLE
Separate out debug spec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #   docker pull ghcr.io/riscv/riscv-docs-base-container-image:latest
 #
 
-DOCS := riscv-privileged riscv-unprivileged riscv-cheri riscv-cheri-full
+DOCS := riscv-privileged riscv-unprivileged riscv-cheri riscv-cheri-debug riscv-cheri-full
 
 RELEASE_TYPE ?= draft
 GIT_SHORT_HASH ?= -$(shell git rev-parse --short HEAD || true)
@@ -155,6 +155,7 @@ SAIL_ASCIIDOC_JSON = $(CHERI_GEN_DIR)/riscv_RV64.json
 .PHONY: all build clean build-docs build-pdf build-html build-epub build-tags build-norm-rules docker-pull-latest generate generate-cheri-tables
 
 all: build
+html: build/riscv-privileged.html build/riscv-unprivileged.html build/riscv-cheri.html build/riscv-cheri-debug.html build/riscv-cheri-full.html
 
 $(CHERI_GEN_DIR):
 	mkdir -p "$@"

--- a/src/cheri/csv/CHERI_CSR.csv
+++ b/src/cheri/csv/CHERI_CSR.csv
@@ -1,9 +1,9 @@
 "RVY CSR","Extension","Width","Address","Alias","Mode","Permissions","Reset Value","Action on XLEN write","Action on YLEN write","Code Pointer","Data Pointer","Unseal On Execution","Prerequisites","Description","initial_ratification","","","","","","","","","","","","","","","","","","","",""
-"dpc_y","Sdext","YLEN","0x7b1","dpc","D","DRW","tag=0, otherwise specified by the platform","Apply <<section_invalid_addr_conv>>.
-Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
+"dpc_y","Sdext","YLEN","0x7b1","dpc","D","DRW","tag=0, otherwise specified by the platform","Apply invalid address conversion.
+Always update the CSR with `{SCADDR}` even if the address didn't change.","Apply invalid address conversion and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","✔","Sdext","Debug Program Counter Capability","v1","","","","","","","","","","","","","","","","","","","",""
-"dscratch0_y","Sdext","YLEN","0x7b2","dscratch0","D","DRW","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","Sdext","Debug Scratch Capability 0","v1","","","","","","","","","","","","","","","","","","","",""
-"dscratch1_y","Sdext","YLEN","0x7b3","dscratch1","D","DRW","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","Sdext","Debug Scratch Capability 1","v1","","","","","","","","","","","","","","","","","","","",""
+"dscratch0_y","Sdext","YLEN","0x7b2","dscratch0","D","DRW","tag=0, otherwise specified by the platform","Update the CSR using `{SCADDR}`.","Direct write","","","","Sdext","Debug Scratch Capability 0","v1","","","","","","","","","","","","","","","","","","","",""
+"dscratch1_y","Sdext","YLEN","0x7b3","dscratch1","D","DRW","tag=0, otherwise specified by the platform","Update the CSR using `{SCADDR}`.","Direct write","","","","Sdext","Debug Scratch Capability 1","v1","","","","","","","","","","","","","","","","","","","",""
 "mscratch_y","RVI","YLEN","0x340","mscratch","M","MRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","M-mode","Machine Scratch Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "sscratch_y","RVI","YLEN","0x140","sscratch","S","SRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","S-mode","Supervisor Scratch Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "vsscratch_y","H","YLEN","0x240","vsscratch","VS","HRW, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","H","Virtual Supervisor Scratch Capability","post-v1","","","","","","","","","","","","","","","","","","","",""
@@ -34,14 +34,14 @@ direct write if address didn't change","✔","","✔","H","Virtual Supervisor Ex
 "jvt_y","Zcmt","YLEN","0x017","jvt","U","URW","tag=0, otherwise specified by the platform","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","✔","","","Zcmt","Jump Vector Table Capability","post-v1","","","","","","","","","","","","","","","","","","","",""
-"dddc","Sdext","YLEN","0x7bc","","D","DRW","tag=0, otherwise specified by the platform","Apply <<section_invalid_addr_conv>>.
-Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
+"dddc","Sdext","YLEN","0x7bc","","D","DRW","tag=0, otherwise specified by the platform","Apply invalid address conversion.
+Always update the CSR with `{SCADDR}` even if the address didn't change.","Apply invalid address conversion and update the CSR with the result if the address changed,
 direct write if address didn't change","","✔","","{cheri_default_ext_name}, Sdext","Debug Default Data Capability (saved/restored on debug mode entry/exit)","v1","","","","","","","","","","","","","","","","","","","",""
 "ddc","{cheri_default_ext_name}","YLEN","0x416","","U","URW","nominally <<root-rw-cap>>","Apply <<section_invalid_addr_conv>>.
 Always update the CSR with <<SCADDR>> even if the address didn't change.","Apply <<section_invalid_addr_conv>> and update the CSR with the result if the address changed,
 direct write if address didn't change","","✔","","{cheri_default_ext_name}","User Default Data Capability","v1","","","","","","","","","","","","","","","","","","","",""
 "drootcsel","Sdext","DXLEN","0x7ba","","D","DRW","0","Ignore","Ignore","","","","Sdext","Multiplexing selector for <<drootc>>","v1","","","","","","","","","","","","","","","","","","","",""
-"drootc","Sdext","YLEN","0x7bd","","D","DRW","nominally <<root-rx-cap>>","Ignore","Ignore","","","","Sdext","Source of authority in debug mode, writes are ignored","v1","","","","","","","","","","","","","","","","","","","",""
+"drootc","Sdext","YLEN","0x7bd","","D","DRW","nominally Root Executable","Ignore","Ignore","","","","Sdext","Source of authority in debug mode, writes are ignored","v1","","","","","","","","","","","","","","","","","","","",""
 "mtidc","{cheri_base_ext_name}","YLEN","0x780","","M","Read: M, Write: M, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","{cheri_base_ext_name}","Machine Thread ID","v1","","","","","","","","","","","","","","","","","","","",""
 "vstidc","{cheri_base_ext_name}","YLEN","0xA80","","H","Read: VS, Write: VS, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","{cheri_base_ext_name}","Virtual supervisor Thread ID","post-v1","","","","","","","","","","","","","","","","","","","",""
 "stidc","{cheri_base_ext_name}","YLEN","0x580","","S","Read: S, Write: S, <<asr_perm>>","tag=0, otherwise specified by the platform","Update the CSR using <<SCADDR>>.","Direct write","","","","{cheri_base_ext_name}","Supervisor Thread ID","v1","","","","","","","","","","","","","","","","","","","",""

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -155,7 +155,7 @@ If `aamsize{ne}7` then {ctag}s are always read and written as zero.
 [#dpc_y,reftext="dpc ({cheri_base_ext_name})"]
 ===== Debug Program Counter Capability (dpc)
 
-The dpc register is widened so that it can hold a capability.
+The `dpc` register is widened to a capability.
 
 {TAG_RESET_DCSR}
 
@@ -190,7 +190,7 @@ One possible implementation choice for debug mode exit is DRET.
 [#dscratch0_y,reftext="dscratch0 ({cheri_base_ext_name})"]
 ===== Debug Scratch Register 0 (dscratch0)
 
-The `dscratch0` register is widened so that it can hold a capability.
+The `dscratch0` register is widened to a capability.
 
 {TAG_RESET_DCSR}
 
@@ -200,7 +200,7 @@ include::img/dscratch0creg.edn[]
 [#dscratch1_y,reftext="dscratch1 ({cheri_base_ext_name})"]
 ===== Debug Scratch Register 1 (dscratch1)
 
-The `dscratch1` register is widened so that it can hold a capability.
+The `dscratch1` register is widened to a capability.
 
 {TAG_RESET_DCSR}
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -1,4 +1,6 @@
-[appendix]
+include::attributes.adoc[]
+include::../symbols.adoc[]
+
 [#section_debug_integration_ext]
 == Integrating {cheri_base_ext_name} with Debug
 
@@ -130,7 +132,7 @@ Implementations can choose to also support accessing {ctag}s as part of the acce
 When a capability is written it must be derivable from the set of root capabilities available in <<drootc>>.
 If not then the destination {ctag} is set to zero.
 
-NOTE: If there is only a single root capability, then the derivable check is a <<cap_subset>> of the written capability against the capability in <<drootc>>.
+NOTE: If there is only a single root capability, then the derivable check is a capability subset check of the written capability against the capability in <<drootc>>.
  If there are multiple root capabilities then checks against multiple root capabilities may be required, as defined by the capability encoding format.
 
 If `aarsize{ne}7` then {ctag}s are always read and written as zero.
@@ -161,34 +163,34 @@ The dpc register is widened so that it can hold a capability.
 include::img/dpccreg.edn[]
 
 When the hart is in debug mode, the _RISC-V Debug Specification_ does not specify
-how the PC is updated, and says that PC-relative instructions may be illegal. This concept
-is extended to include any instruction which reads or updates <<pcc>>, which refers to
-all jumps, conditional branches and <<AUIPC_CHERI>>. The exceptions are <<MODESW_CAP>> and <<MODESW_INT>>,
+how the `pc` is updated, and says that PC-relative instructions may be illegal. This concept
+is extended to include any instruction which reads or updates PC, which refers to
+all jumps, conditional branches and `AUIPC`. The exceptions are `{MODESW_CAP}` and `{MODESW_INT}`,
 which _are_ supported if {cheri_default_ext_name} is implemented, see <<drootc>>
 for details.
 
-As a result, the value of <<pcc>> is UNSPECIFIED in debug mode according
-to this specification. The <<pcc>> metadata has no architectural effect in debug
-mode. Therefore, <<asr_perm>> is implicitly granted for access to all CSRs for
+As a result, the value of the `pc` is UNSPECIFIED in debug mode according
+to this specification. The `pc` metadata has no architectural effect in debug
+mode. Therefore, `ASR-permission` is implicitly granted for access to all CSRs for
 instruction execution.
 
 On debug mode entry, <<dpc_y>> is updated with the
-capability in <<pcc>>, whose address field equals to the address of the next
+capability in the `pc`, whose address field equals to the address of the next
 instruction to be executed upon debug mode exit as described in the _RISC-V Debug Specification_.
 
-When leaving debug mode, the value in <<dpc_y>> is unsealed if it is a <<sentry_cap>> and is written to <<pcc>>.
+When leaving debug mode, the value in <<dpc_y>> is unsealed if it is a {sentry_cap_uc} and is written to PC.
 
 NOTE: A debugger may write <<dpc_y>> to change where the hart resumes and its mode, permissions, sealing or bounds.
- The value saved from the <<pcc>> on debug mode entry cannot be sealed.
+ The value saved from the `pc` on debug mode entry cannot be sealed.
 
-The legalization of <<dpc_y>> follows the same rules described for <<mepc_y>>.
+The legalization of <<dpc_y>> follows the same rules described for `mepc`.
 
 One possible implementation choice for debug mode exit is DRET.
 
 [#dscratch0_y,reftext="dscratch0 ({cheri_base_ext_name})"]
 ===== Debug Scratch Register 0 (dscratch0)
 
-The dscratch0 register is widened so that it can hold a capability.
+The `dscratch0` register is widened so that it can hold a capability.
 
 {TAG_RESET_DCSR}
 
@@ -198,7 +200,7 @@ include::img/dscratch0creg.edn[]
 [#dscratch1_y,reftext="dscratch1 ({cheri_base_ext_name})"]
 ===== Debug Scratch Register 1 (dscratch1)
 
-The dscratch1 register is widened so that it can hold a capability.
+The `dscratch1` register is widened so that it can hold a capability.
 
 {TAG_RESET_DCSR}
 
@@ -211,9 +213,9 @@ include::img/dscratch1creg.edn[]
 <<drootcsel>> is a DXLEN-bit debug mode accessible integer CSR.  The address and access details are shown in
 xref:all_capability_CSRs_d[xrefstyle=short].
 
-It selects which <<root-cap>> capability is exposed through <<drootc>>.
+It selects which Root capability is exposed through <<drootc>>.
 The reset value is `0`, which must cause <<drootc>> to expose a
-<<root-rx-cap>> capability.
+Root Executable capability.
 
 Other capability values may be defined for exposure through <<drootc>>
 by the capability encoding,
@@ -231,17 +233,17 @@ xref:all_capability_CSRs_d[xrefstyle=short].
 It exposes the capability selected by <<drootcsel>>.
 
 If {cheri_default_ext_name} is implemented,
-the <<root-rx-cap>> exposed when <<drootcsel>> is `0` is further specified as follows:
+the Root Executable exposed when <<drootcsel>> is `0` is further specified as follows:
 
-* The <<p_bit>> is reset to {cheri_int_mode_name} ({INT_MODE_VALUE}).
-* The debugger can set the <<p_bit>> to {cheri_cap_mode_name} ({CAP_MODE_VALUE}) by executing <<MODESW_CAP>> from the program buffer.
-** Executing <<MODESW_CAP>> causes execution of subsequent instructions from the program buffer, starting from the next instruction, to be executed in {cheri_cap_mode_name}.
+* The `P-bit` is reset to {cheri_int_mode_name} ({INT_MODE_VALUE}).
+* The debugger can set the `P-bit` to {cheri_cap_mode_name} ({CAP_MODE_VALUE}) by executing `{MODESW_CAP}` from the program buffer.
+** Executing `{MODESW_CAP}` causes execution of subsequent instructions from the program buffer, starting from the next instruction, to be executed in {cheri_cap_mode_name}.
    It also sets the {cheri_mode_name} to {cheri_cap_mode_name} on future entry into debug mode.
-** Therefore, to enable use of a CHERI debugger, only a single <<MODESW_CAP>> needs to be executed once from the program buffer after resetting the core.
-** The debugger can also execute <<MODESW_INT>> to change the {cheri_mode_name} back to {cheri_int_mode_name}.
-   This affects the execution of the next instruction in the program buffer, updates the <<p_bit>> of <<drootc>>, and thereby controls which {cheri_mode_name} to use on the next entry into debug mode.
+** Therefore, to enable use of a CHERI debugger, only a single `{MODESW_CAP}` needs to be executed once from the program buffer after resetting the core.
+** The debugger can also execute `{MODESW_INT}` to change the {cheri_mode_name} back to {cheri_int_mode_name}.
+   This affects the execution of the next instruction in the program buffer, updates the `P-bit` of <<drootc>>, and thereby controls which {cheri_mode_name} to use on the next entry into debug mode.
 
-The <<p_bit>> of this capability is _only_ updated by executing <<MODESW_CAP>> or <<MODESW_INT>> from the program buffer.
+The `P-bit` of this capability is _only_ updated by executing `{MODESW_CAP}` or `{MODESW_INT}` from the program buffer.
 
 .Debug root capability register
 include::img/drootcreg.edn[]
@@ -252,12 +254,12 @@ include::insns/dret.adoc[leveloffset=+1]
 === Integrating {cheri_default_ext_name} with Sdext
 
 A new debug default data capability (<<dddc>>) CSR is added at the CSR number
-shown in xref:unpriv-csrnames-added[xrefstyle=short].
+shown in xref:all_capability_CSRs_d[xrefstyle=short].
 
-{cheri_default_ext_name} allows <<MODESW_CAP>> and <<MODESW_INT>> to execute in debug mode.
+{cheri_default_ext_name} allows `{MODESW_CAP}` and `{MODESW_INT}` to execute in debug mode.
 
 When entering debug mode, whether the core enters {cheri_int_mode_name} or
-{cheri_cap_mode_name} is controlled by the <<p_bit>> in the <<drootc>> capability selected by <<drootcsel>> value 0.
+{cheri_cap_mode_name} is controlled by the `P-bit` in the <<drootc>> capability selected by <<drootcsel>> value 0.
 
 The current mode can be read by setting <<drootcsel>> to `0` and then reading <<drootc>>.
 
@@ -269,10 +271,10 @@ csrr   {creg}1, drootc
 {gcmode_lc} x1, {creg}1
 ----
 
-NOTE: There is no <<section_cheri_disable,CHERI enable/disable bit>> for debug mode, so CHERI register and instruction access is always permitted in debug mode.
+NOTE: There is no CHERI enable/disable bit for debug mode, so CHERI register and instruction access is always permitted.
 
 ifdef::cheri_v9_annotations[]
-NOTE: *CHERI v9 Note:* The mode change instructions <<MODESW_CAP>> and <<MODESW_INT>> are new
+NOTE: *CHERI v9 Note:* The mode change instructions `{MODESW_CAP}` and `{MODESW_INT}` are new
 and the requirement to support them in debug mode is also new.
 endif::[]
 
@@ -280,7 +282,7 @@ endif::[]
 ==== Debug Default Data Capability CSR (dddc)
 
 <<dddc>> is a debug mode accessible capability CSR. The address is shown in
-xref:unpriv-csrnames-added[xrefstyle=short].
+xref:all_capability_CSRs_d[xrefstyle=short].
 
 {TAG_RESET_DCSR}
 
@@ -289,17 +291,17 @@ xref:unpriv-csrnames-added[xrefstyle=short].
 .Debug default data capability
 include::img/dddcreg.edn[]
 
-Upon entry to debug mode, <<ddc>> is saved in <<dddc>>. <<ddc>> is set to a
-<<root-rw-cap>> capability with an unchanged address.
+Upon entry to debug mode, `ddc` is saved in <<dddc>>. `ddc` is set to a
+Root Data capability with an unchanged address.
 
-NOTE: If the <<root-rw-cap>> capability does not cover all of memory then <<ddc>> must be updated using the semantics of <<SCADDR>>.
+NOTE: If the Root Data capability does not cover all of memory then `ddc` must be updated using the semantics of `{SCADDR}`.
 
-When debug mode is exited by executing <<DRET_CHERI>>, the hart's <<ddc>> is updated to the capability stored in <<dddc>>.
-When debug mode is exited the hart's <<ddc>> is updated to the capability stored in <<dddc>>, which may have been updated by the debugger.
+When debug mode is exited by executing <<DRET_CHERI>>, the hart's `ddc` is updated to the capability stored in <<dddc>>.
+When debug mode is exited the hart's `ddc` is updated to the capability stored in <<dddc>>, which may have been updated by the debugger.
 A debugger may write <<dddc>> to change the hart's context.
 
 As shown in xref:CSR_exevectors_d[xrefstyle=short], <<dddc>> is a data pointer,
-so it does not need to be able to hold all possible invalid addresses (see <<section_invalid_addr_conv>>).
+so it does not need to be able to hold all possible invalid addresses.
 
 === Debug Mode YLEN CSR Summary
 
@@ -312,7 +314,7 @@ The tables below show all debug mode CSRs added or modified by {cheri_base_ext_n
 include::{generated_dir}/csr_alias_action_d_table_body.adoc[]
 |==============================================================================
 
-Code pointers and data pointers in <<CSR_exevectors_d>> are WARL CSRs that do not need to store full 64-bit addresses on RV64, and so may be subject to <<section_invalid_addr_conv>> on writing.
+Code pointers and data pointers in <<CSR_exevectors_d>> are WARL CSRs that do not need to store full 64-bit addresses on RV64, and so may be subject to invalid address conversion on writing.
 
 .YLEN-wide Debug-Mode CSRs storing code pointers or data pointers
 [#CSR_exevectors_d]
@@ -325,10 +327,10 @@ include::{generated_dir}/csr_exevectors_d_table_body.adoc[]
 
 .All {cheri_base_ext_name} debug mode CSRs.
 [#all_capability_CSRs_d]
-[width="100%",options=header,cols="2,1,1,1,2,2,4"]
+[width="100%",options=header,cols="2,1,1,1,1,2,2,4"]
 |==============================================================================
 include::{generated_dir}/csr_permission_d_table_body.adoc[]
 |==============================================================================
 
-NOTE: Where reset values are specified as a <<root-rx-cap>> or <<root-rw-cap>> they are a maximum possible value.
+NOTE: Where reset values are specified as a Root Executable or Root Data Capability they are a maximum possible value.
 The platform may reset those CSRs to a smaller memory range, or to have fewer permissions.

--- a/src/cheri/insns/dret.adoc
+++ b/src/cheri/insns/dret.adoc
@@ -13,14 +13,14 @@ Encoding::
 include::wavedrom/dret.adoc[]
 
 Description::
-<<DRET_CHERI>> returns from debug mode.
-It unseals <<dpc_y>> if it is sealed as a <<sentry_cap>> and writes the result into <<pcc>>.
-It also restores <<ddc>> from <<dddc>>.
+`DRET` returns from debug mode.
+It unseals <<dpc_y>> if it is sealed as a {sentry_cap_uc} and writes the result into the `pc`.
+It also restores `ddc` from <<dddc>>.
 
-NOTE: The <<DRET_CHERI>> instruction is a documented method of exiting debug mode.
+NOTE: The `DRET` instruction is a documented method of exiting debug mode.
 However, it is a pseudoinstruction to return that technically does not execute
-from the program buffer or memory. It does not require the <<pcc>> to
-grant <<asr_perm>> so it never raises an exception.
+from the program buffer or memory. It does not require the `pc` to
+grant `ASR-permission` so it never raises an exception.
 
 NOTE: The definition of `DRET` is not part of Sdext, and is suggested as an implementation choice in the _RISC-V Debug Specification_.
 This specification assumes the recommended specification including the recommended encoding.

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -107,16 +107,7 @@ ifdef::support_varxlen[]
 |<<section_cheri_dyn_xlen,{cheri_priv_m_dyn_xlen_ext}>>     | Dynamic XLEN support
 endif::support_varxlen[]
 |<<section_priv_cheri_vmem,{cheri_priv_vmem_ext}>>          | Virtual Memory
-|<<section_debug_integration_trig,{cheri_priv_debug_trig}>> | Debug triggers
 |<<section_cheri_priv_crg_ext,    {cheri_priv_crg_ext}>>    | MMU-based capability data flow control and measurement
-|=============================================================================================================================================================
-
-.Debug stable extensions and specifications
-[#debug-extension-status,reftext="Extension Status and Summary"]
-[options=header,align=center,width="90%"]
-|=============================================================================================================================================================
-| Extension or Specification                                       | Description
-|<<section_debug_integration_ext,Sdext ({cheri_base_ext_name})>>   | External debug support
 |=============================================================================================================================================================
 
 ifndef::cheri_ratification_v1_only[]

--- a/src/cheri/riscv-cheri-debug.adoc
+++ b/src/cheri/riscv-cheri-debug.adoc
@@ -1,0 +1,21 @@
+= RISC-V Debug Specification for CHERI Extensions
+Authors: Thomas Aird, Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu, Robert Riglar, Florian Schmaus
+include::attributes-standalone.adoc[]
+
+///////////////////////////////////////////////////////////////////////////////
+// Preface
+///////////////////////////////////////////////////////////////////////////////
+
+ifdef::github_commit_sha[]
+[IMPORTANT]
+This document is a specification snapshot built from https://github.com/riscv/riscv-cheri/commit/{github_commit_sha} and is not a versioned release.
+The latest versioned PDF release can be downloaded from https://github.com/riscv/riscv-cheri/releases.
+endif::[]
+
+[WARNING]
+.This document is in the link:https://lf-riscv.atlassian.net/wiki/display/HOME/Specification+States[Stable state]
+====
+Assume anything could still change, but limited change should be expected.
+====
+
+include::debug-integration.adoc[]

--- a/src/cheri/riscv-cheri.adoc
+++ b/src/cheri/riscv-cheri.adoc
@@ -68,7 +68,6 @@ endif::[]
 include::app-rvy-encoding.adoc[leveloffset=+1]
 include::app-hybrid-usage.adoc[]
 include::system.adoc[leveloffset=+1]
-include::debug-integration.adoc[]
 
 ///////////////////////////////////////////////////////////////////////////////
 // Index and bibliography

--- a/src/cheri/trigger-integration.adoc
+++ b/src/cheri/trigger-integration.adoc
@@ -40,7 +40,7 @@ mcontrol/mcontrol6 after (on previous instruction) +
 3 +
 3 +
 | Illegal instruction +
-{cheri_excep_name_pc} due to {pcc} <<asr_perm>> clear +
+{cheri_excep_name_pc} due to {pcc} `ASR-permission` clear +
 Virtual instruction +
 Instruction address misaligned +
 Environment call +

--- a/src/riscv-cheri-debug.adoc
+++ b/src/riscv-cheri-debug.adoc
@@ -1,0 +1,1 @@
+include::cheri/riscv-cheri-debug.adoc[]


### PR DESCRIPTION
Debug won't be merged with the main RISC-V ISA manual, so needs to be a separate document.
This means we will track the version number separately (not yet implemented).
No spec changes.
Most of the edits are removing the xrefs with unpriv/priv.