### PR TITLE
Remove redundant "Included in::" field from instruction listings

### DIFF
--- a/src/cheri/insns/acperm_32bit.adoc
+++ b/src/cheri/insns/acperm_32bit.adoc
@@ -46,9 +46,6 @@ NOTE: If a future extension adds a new permission that is dependent on an existi
 This ensures software forward-compatibility: for example, a kernel that does not know about finer-grained <<asr_perm, ASR permissions>> must still be able to prevent all access to privileged instructions and CSRs simply by clearing <<asr_perm>>.
 Such dependent permissions must be allocated to the bits that are currently reported as 1 to ensure forward-compatibility
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/addi16sp_16bit.adoc
+++ b/src/cheri/insns/addi16sp_16bit.adoc
@@ -27,9 +27,6 @@ include::malformed_creg_sp_clear_tag.adoc[]
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/addi4spn_16bit.adoc
+++ b/src/cheri/insns/addi4spn_16bit.adoc
@@ -28,9 +28,6 @@ Set `{cd}'.tag=0` if `{abi_creg}sp` 's bounds are <<section_cap_malformed,malfor
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_mod_insn_table>>
-
 Operation::
 +
 [source,SAIL,subs="verbatim,quotes"]

--- a/src/cheri/insns/amoswap_32bit_cap.adoc
+++ b/src/cheri/insns/amoswap_32bit_cap.adoc
@@ -30,9 +30,6 @@ include::atomic_exceptions.adoc[]
 Prerequisites::
 {cheri_base_ext_name}, and Zaamo
 
-Included in::
-<<rvy_zaamo_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/auipc_32bit.adoc
+++ b/src/cheri/insns/auipc_32bit.adoc
@@ -22,9 +22,6 @@ Take the value of the AUIPC instruction's <<pcc>>, increment its address by the 
 +
 include::rep_range_check.adoc[]
 
-Included in::
-<<rvy_i_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/cadd_32bit.adoc
+++ b/src/cheri/insns/cadd_32bit.adoc
@@ -45,9 +45,6 @@ include::rep_range_check.adoc[]
 +
 include::malformed_cs1_clear_tag.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation for {CADD}::
 +
 sail::execute[clause="CADD(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -52,9 +52,6 @@ NOTE: When `{cs1}` is `{creg}0` <<CBLD>> will copy `{cs2}` to `{cd}` and clear `
 However future extensions may add additional behavior to update currently reserved fields,
 and so software should not assume `{cs1}=0` to be a pseudo-instruction for {ctag} clearing.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/cbo.clean.adoc
+++ b/src/cheri/insns/cbo.clean.adoc
@@ -31,9 +31,6 @@ include::cbo_exceptions.adoc[]
 Prerequisites::
 Zicbom, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicbom_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/cbo.flush.adoc
+++ b/src/cheri/insns/cbo.flush.adoc
@@ -31,9 +31,6 @@ include::cbo_exceptions.adoc[]
 Prerequisites::
 Zicbom, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicbom_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/cbo.inval.adoc
+++ b/src/cheri/insns/cbo.inval.adoc
@@ -44,9 +44,6 @@ Untrusted software should use CBO.FLUSH instead as a minimum, and a sensible imp
 Prerequisites::
 Zicbom, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicbom_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/cbo.zero.adoc
+++ b/src/cheri/insns/cbo.zero.adoc
@@ -35,9 +35,6 @@ include::store_exceptions.adoc[]
 Prerequisites::
 Zicboz, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicboz_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/cmv_16bit.adoc
+++ b/src/cheri/insns/cmv_16bit.adoc
@@ -28,8 +28,5 @@ include::malformed_no_check.adoc[]
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_mod_insn_table>>
-
 Operation (after expansion to 32-bit encoding)::
  See <<CMV>>.

--- a/src/cheri/insns/cmv_32bit.adoc
+++ b/src/cheri/insns/cmv_32bit.adoc
@@ -25,9 +25,6 @@ Copy `{cs1}` to `{cd}`.
 +
 include::malformed_no_check.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 +
 sail::execute[clause="CMV(_, _)",part=body,unindent]

--- a/src/cheri/insns/cram_32bit.adoc
+++ b/src/cheri/insns/cram_32bit.adoc
@@ -19,9 +19,6 @@ See <<section_cap_bounds>> for the algorithm used to compute the next representa
 
 NOTE: This {cheri_base_ext_name} instruction only handles XLEN operands and produces an XLEN result.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/csrr_32bit.adoc
+++ b/src/cheri/insns/csrr_32bit.adoc
@@ -57,9 +57,6 @@ Accessing CSRs may require <<asr_perm>>.
 Prerequisites::
 {cheri_base_ext_name}, Zicsr, optional {cheri_default_ext_name}
 
-Included in::
-<<rvy_i_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/csrrw_32bit.adoc
+++ b/src/cheri/insns/csrrw_32bit.adoc
@@ -42,9 +42,6 @@ Accessing CSRs may require <<asr_perm>>.
 Prerequisites::
 {cheri_base_ext_name}, Zicsr, optional {cheri_default_ext_name}
 
-Included in::
-<<rvy_i_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/gcbase_32bit.adoc
+++ b/src/cheri/insns/gcbase_32bit.adoc
@@ -25,9 +25,6 @@ include::malformed_return_0.adoc[]
 +
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 +
 [source,SAIL,subs="verbatim,quotes"]

--- a/src/cheri/insns/gchi_32bit.adoc
+++ b/src/cheri/insns/gchi_32bit.adoc
@@ -19,9 +19,6 @@ Set `rd.tag=0`.
 NOTE: The only valid shift amount is `XLEN` (as required by <<GCHI>>).
 A future extension may add an arbitrary shift distance.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----
@@ -54,9 +51,6 @@ Description::
 Copy the metadata (bits [YLEN-1:XLEN]) of capability `{cs1}` into `rd`.
 +
 include::no_tag_affect.adoc[]
-
-Included in::
-<<rvy_insn_table>>
 
 Operation::
 [source,SAIL,subs="verbatim,quotes"]

--- a/src/cheri/insns/gclen_32bit.adoc
+++ b/src/cheri/insns/gclen_32bit.adoc
@@ -31,9 +31,6 @@ include::malformed_return_0.adoc[]
 +
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/gcmode_32bit.adoc
+++ b/src/cheri/insns/gcmode_32bit.adoc
@@ -28,9 +28,6 @@ Otherwise set `rd` according to `{cs1}` 's {cheri_mode_name} (<<p_bit>>):
 +
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_hybrid_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/gcperm_32bit.adoc
+++ b/src/cheri/insns/gcperm_32bit.adoc
@@ -33,9 +33,6 @@ include::../img/acperm_bit_field.edn[]
 
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/gctag_32bit.adoc
+++ b/src/cheri/insns/gctag_32bit.adoc
@@ -20,9 +20,6 @@ include::wavedrom/gctag.adoc[]
 Description::
 Zero extend the value of `{cs1}.tag` and write the result to `rd`.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/gctop_32bit.adoc
+++ b/src/cheri/insns/gctop_32bit.adoc
@@ -24,9 +24,6 @@ include::malformed_return_0.adoc[]
 +
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/gctype_32bit.adoc
+++ b/src/cheri/insns/gctype_32bit.adoc
@@ -23,9 +23,6 @@ Decode the architectural capability type (<<sec_cap_type>>) from `{cs1}`, zero e
 +
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/hypv-virt-load-cap.adoc
+++ b/src/cheri/insns/hypv-virt-load-cap.adoc
@@ -20,10 +20,6 @@ Execute <<LOAD_CAP>> as though V=1, following the same pattern as HLV.W but with
 Prerequisites::
 {cheri_base_ext_name}, H
 
-// TODO: Cross-document xref
-// Included in::
-// <<rvy_h_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/hypv-virt-store-cap.adoc
+++ b/src/cheri/insns/hypv-virt-store-cap.adoc
@@ -20,10 +20,6 @@ Execute <<STORE_CAP>> as though V=1; following the same pattern as HSV.W but wit
 Prerequisites for {cheri_cap_mode_name}::
 {cheri_base_ext_name}, H
 
-// TODO: Cross-document xref
-// Included in::
-// <<rvy_h_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/jal_16bit.adoc
+++ b/src/cheri/insns/jal_16bit.adoc
@@ -24,8 +24,5 @@ include::pcrel_debug_warning.adoc[]
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_mod_insn_table>>
-
 Operation (after expansion to 32-bit encodings)::
  See <<JAL_CHERI>>.

--- a/src/cheri/insns/jal_32bit.adoc
+++ b/src/cheri/insns/jal_32bit.adoc
@@ -25,9 +25,6 @@ Direct jump with an address offset.
 NOTE: A future extension may raise an exception on the branch instruction itself if fetching a minimum-sized instruction at the target <<pcc>> will raise a _{cheri_excep_name_pc}_.
   Performing the <<pcc>> bounds check at the branch source instead of on instruction fetch is helpful for debugging and can simplify the implementation of CPUs with very short pipelines.
 
-Included in::
-<<rvy_i_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/jalr_16bit.adoc
+++ b/src/cheri/insns/jalr_16bit.adoc
@@ -28,8 +28,5 @@ include::pcrel_debug_warning.adoc[]
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_mod_insn_table>>
-
 Operation (after expansion to 32-bit encodings)::
  See <<JALR_CHERI>>.

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -62,9 +62,6 @@ endif::[]
 +
 NOTE: A future extension may raise an exception on the <<JALR_CHERI>> instruction itself if the target <<pcc>> will raise a {cheri_excep_name_pc} at the target.
 
-Included in::
-<<rvy_i_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/jr_16bit.adoc
+++ b/src/cheri/insns/jr_16bit.adoc
@@ -25,8 +25,5 @@ include::pcrel_debug_warning.adoc[]
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_mod_insn_table>>
-
 Operation (after expansion to 32-bit encodings)::
  See <<JALR_CHERI>>.

--- a/src/cheri/insns/load_16bit_cap_sprel.adoc
+++ b/src/cheri/insns/load_16bit_cap_sprel.adoc
@@ -38,8 +38,5 @@ Load data from memory in the same manner as <<LOAD_CAP>>.
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_insn_table>>
-
 Operation (after expansion to 32-bit encodings)::
 See <<LOAD_CAP>>.

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -47,9 +47,6 @@ When sending load data to a trace interface, implementations trace the final val
 +
 include::load_exceptions.adoc[]
 +
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/load_res_32bit.adoc
+++ b/src/cheri/insns/load_res_32bit.adoc
@@ -19,9 +19,6 @@ include::wavedrom/load_res.adoc[]
 Description::
 Load reserved instructions, following the same semantics as LR.W.
 
-Included in::
-<<abhlrsc_ext,{lr_sc_bh_ext_name}>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/load_res_cap_32bit.adoc
+++ b/src/cheri/insns/load_res_cap_32bit.adoc
@@ -33,9 +33,6 @@ include::load_exceptions.adoc[]
 Prerequisites::
 {cheri_base_ext_name}, and A or Zalrsc
 
-Included in::
-<<rvy_zalrsc_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/modesw_32bit.adoc
+++ b/src/cheri/insns/modesw_32bit.adoc
@@ -23,9 +23,6 @@ Set the current {cheri_mode_name} in <<pcc>>.
 * {MODESW_CAP}: If the current mode in <<pcc>> is {cheri_int_mode_name} ({INT_MODE_VALUE}), then the <<p_bit>> in <<pcc>> is set to {cheri_cap_mode_name} ({CAP_MODE_VALUE}). Otherwise no effect.
 * {MODESW_INT}: If the current mode in <<pcc>> is {cheri_cap_mode_name} ({CAP_MODE_VALUE}), then the <<p_bit>> in <<pcc>> is set to {cheri_int_mode_name} ({INT_MODE_VALUE}). Otherwise no effect.
 
-Included in::
-<<rvy_hybrid_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/mret_sret.adoc
+++ b/src/cheri/insns/mret_sret.adoc
@@ -36,10 +36,6 @@ Machine-Level ISA, {cheri_base_ext_name}
 Prerequisites (SRET)::
 Supervisor-Level ISA, {cheri_base_ext_name}
 
-// TODO: Included in::
-// TODO: <<rvy_m_mod_insn_table>>
-// TODO: <<rvy_s_mod_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/prefetch.i.adoc
+++ b/src/cheri/insns/prefetch.i.adoc
@@ -53,9 +53,6 @@ NOTE: If `{cs1}=x0` this instruction executes as a `nop`.
 Prerequisites::
 Zicbop, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicbop_mod_insn_table>>
-
 Operation::
 [source,sail]
 ----

--- a/src/cheri/insns/prefetch.r.adoc
+++ b/src/cheri/insns/prefetch.r.adoc
@@ -52,9 +52,6 @@ NOTE: If `{cs1}=x0` this instruction executes as a `nop`.
 Prerequisites::
 Zicbop, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicbop_mod_insn_table>>
-
 Operation::
 [source,sail]
 ----

--- a/src/cheri/insns/prefetch.w.adoc
+++ b/src/cheri/insns/prefetch.w.adoc
@@ -52,9 +52,6 @@ NOTE: If `{cs1}=x0` this instruction executes as a `nop`.
 Prerequisites::
 Zicbop, {cheri_base_ext_name}
 
-Included in::
-<<rvy_zicbop_mod_insn_table>>
-
 Operation::
 [source,sail]
 ----

--- a/src/cheri/insns/scaddr_32bit.adoc
+++ b/src/cheri/insns/scaddr_32bit.adoc
@@ -29,9 +29,6 @@ include::rep_range_check.adoc[]
 +
 include::malformed_cs1_clear_tag.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -88,9 +88,6 @@ The hardware implementation is a simple bit-remapping: +
 `result[2:0] = imm[8] ? 0 : imm[2:0];`.
 ====
 
-Included in::
-<<rvy_insn_table>>
-
 Operation for {SCBNDS}::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/scbndsr_32bit.adoc
+++ b/src/cheri/insns/scbndsr_32bit.adoc
@@ -31,9 +31,6 @@ Set `{cd}.tag=0` if `{cs1}.tag=0`, `{cs1}` is sealed or if `{cd}` 's bounds exce
 +
 include::malformed_cs1_clear_tag.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/scbndsrd_32bit.adoc
+++ b/src/cheri/insns/scbndsrd_32bit.adoc
@@ -58,9 +58,6 @@ computing the length that is a maximal mantissa shifted left by that count
 (that is, using the number of trailing zeros in the base address as the value's exponent).
 =====
 
-Included in::
-<<rvy_bndsrdw_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/sceq_32bit.adoc
+++ b/src/cheri/insns/sceq_32bit.adoc
@@ -22,9 +22,6 @@ Description::
 Set `rd` to 1 if all bits (i.e., YLEN bits and the {ctag}) of capabilities `{cs1}`
 and `{cs2}`  are equal, otherwise set `rd` to 0.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/schi_32bit.adoc
+++ b/src/cheri/insns/schi_32bit.adoc
@@ -15,9 +15,6 @@ include::wavedrom/schi.adoc[]
 Description::
 The {SCHI_BASE} instruction copies `rs1[XLEN-1:0]` into `rd[XLEN-1:0]`, copies `rs2[XLEN-1:0]` into `rd[YLEN-1:XLEN]`, and sets `rd.tag=0`.
 
-Included in::
-<<rvy_insn_table>>
-
 <<<
 
 [#SCHI,reftext="{SCHI}"]
@@ -42,9 +39,6 @@ Description::
 Construct a YLEN-bit value in `{cd}` by setting the address from `rs1` and the metadata from `rs2`. Set `{cd}.tag` to 0.
 +
 include::no_tag_affect.adoc[]
-
-Included in::
-<<rvy_insn_table>>
 
 Operation::
 [source,SAIL,subs="verbatim,quotes"]

--- a/src/cheri/insns/scmode_32bit.adoc
+++ b/src/cheri/insns/scmode_32bit.adoc
@@ -32,9 +32,6 @@ Otherwise, if `{cs1}` grants <<x_perm>> then update the <<p_bit>> of `{cd}` to:
 +
 include::no_tag_affect.adoc[]
 
-Included in::
-<<rvy_hybrid_insn_table>>
-
 Operation ::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/scss_32bit.adoc
+++ b/src/cheri/insns/scss_32bit.adoc
@@ -33,9 +33,6 @@ Extensions may further impose constraints on when `rd` is set to 1.
 NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -30,9 +30,6 @@ NOTE: A future extension will allow YSEAL, which has `{cs1}` specifying an autho
 NOTE: If the capability encoding format does not support a <<CT-field>> of type 1, then this instruction is _reserved_.
  Future capability encoding formats may redefine the behavior for <<CT-field>> values greater than 1.
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/sh1234add_32bit.adoc
+++ b/src/cheri/insns/sh1234add_32bit.adoc
@@ -53,9 +53,6 @@ include::rep_range_check.adoc[]
 +
 include::malformed_cs2_clear_tag.adoc[]
 
-Included in::
-<<rvy_zba_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/sh1234add_uw_32bit.adoc
+++ b/src/cheri/insns/sh1234add_uw_32bit.adoc
@@ -51,9 +51,6 @@ include::rep_range_check.adoc[]
 +
 include::malformed_cs2_clear_tag.adoc[]
 
-Included in::
-<<rvy_zba_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/store_16bit_cap_sprel.adoc
+++ b/src/cheri/insns/store_16bit_cap_sprel.adoc
@@ -41,8 +41,5 @@ Store data to the memory in the same manner as <<STORE_CAP>>.
 Prerequisites::
 {c_cheri_base_ext_names}
 
-Included in::
-<<rvy_zca_insn_table>>
-
 Operation (after expansion to 32-bit encodings)::
  See <<STORE_CAP>>.

--- a/src/cheri/insns/store_32bit_cap.adoc
+++ b/src/cheri/insns/store_32bit_cap.adoc
@@ -39,9 +39,6 @@ Raise a store/AMO access fault exception when the effective address is not align
 +
 include::store_exceptions.adoc[]
 
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/store_cond_32bit.adoc
+++ b/src/cheri/insns/store_cond_32bit.adoc
@@ -19,9 +19,6 @@ include::wavedrom/store_cond.adoc[]
 Description::
 Store conditional instructions, following the semantics of SC.W.
 
-Included in::
-<<abhlrsc_ext,{lr_sc_bh_ext_name}>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/store_cond_cap_32bit.adoc
+++ b/src/cheri/insns/store_cond_cap_32bit.adoc
@@ -35,9 +35,6 @@ include::store_exceptions.adoc[]
 Prerequisites::
 {cheri_base_ext_name}, and A or Zalrsc
 
-Included in::
-<<rvy_zalrsc_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/yseal_32bit.adoc
+++ b/src/cheri/insns/yseal_32bit.adoc
@@ -54,9 +54,6 @@ even if some capabilities can be sealed with
 the type called for by the address of `{cs1}`.
 =====
 
-Included in::
-{cheri_base_ext_name}, extended in {cheri_seal_ext_name}
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -85,9 +85,6 @@ and software wishes to distinguish between them,
 it must use <<GCTYPE>> on the sealed capability.
 =====
 endif::[]
-Included in::
-<<rvy_insn_table>>
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----

--- a/src/cheri/insns/yunseal_32bit.adoc
+++ b/src/cheri/insns/yunseal_32bit.adoc
@@ -52,9 +52,6 @@ Future extensions may specify a fused "copy type" operation,
 as was present in the CHERI v9 ISA.
 =====
 
-Included in::
-{cheri_seal_ext_name}
-
 Operation::
 [source,SAIL,subs="verbatim,quotes"]
 ----


### PR DESCRIPTION
The extension summary tables already list every instruction, so this field just repeats that information. It also adds noise and sometimes pushes an instruction's listing over a page boundary, which is annoying for PDF formatting. Easy to bring back by reverting this commit if needed.