### PR TITLE
Add back sail snippets

### DIFF
--- a/src/cheri/insns/acperm_32bit.adoc
+++ b/src/cheri/insns/acperm_32bit.adoc
@@ -48,6 +48,7 @@ Such dependent permissions must be allocated to the bits that are currently repo
 
 Operation::
 // Manual code here since the JSON one still has rs2 inverted.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cs1_val = C(cs1);

--- a/src/cheri/insns/acperm_32bit.adoc
+++ b/src/cheri/insns/acperm_32bit.adoc
@@ -47,7 +47,23 @@ This ensures software forward-compatibility: for example, a kernel that does not
 Such dependent permissions must be allocated to the bits that are currently reported as 1 to ensure forward-compatibility
 
 Operation::
+// Manual code here since the JSON one still has rs2 inverted.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cs1_val = C(cs1);
+let rs2_val = X(rs2);
+
+let cond = capIsSealed(cs1_val) | not(capReservedValid(cs1_val));
+let inCap = clearTagIf(cs1_val, cond);
+
+let old_perms = packPerms(getArchPermsLegalized(inCap), inCap.sd_perms).bits;
+
+let new_perms = old_perms & not(rs2_val);
+
+let (new_arch_perms, new_sd_perms) = unpackPerms(struct {bits = new_perms});
+let newCap = { setArchPerms(inCap, new_arch_perms) with sd_perms = new_sd_perms };
+
+C(cd) = newCap;
+RETIRE_SUCCESS
 ----
+//sail::execute[clause="ACPERM(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/addi16sp_16bit.adoc
+++ b/src/cheri/insns/addi16sp_16bit.adoc
@@ -24,8 +24,5 @@ Prerequisites::
 {c_cheri_base_ext_names}
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="C_ADDI16SP_capmode(_)",part=body,unindent]
++
+sail::execute[clause="C_ADDI16SP_capmode(_)",part=body,unindent]

--- a/src/cheri/insns/addi4spn_16bit.adoc
+++ b/src/cheri/insns/addi4spn_16bit.adoc
@@ -26,5 +26,4 @@ Prerequisites::
 
 Operation::
 +
-+
 sail::execute[clause="C_ADDI4SPN_capmode(_, _)",part=body,unindent]

--- a/src/cheri/insns/addi4spn_16bit.adoc
+++ b/src/cheri/insns/addi4spn_16bit.adoc
@@ -26,8 +26,5 @@ Prerequisites::
 
 Operation::
 +
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="C_ADDI4SPN_capmode(_, _)",part=body,unindent]
++
+sail::execute[clause="C_ADDI4SPN_capmode(_, _)",part=body,unindent]

--- a/src/cheri/insns/amoswap_32bit_cap.adoc
+++ b/src/cheri/insns/amoswap_32bit_cap.adoc
@@ -31,7 +31,5 @@ Prerequisites::
 {cheri_base_ext_name}, and Zaamo
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
++
+sail::execute[clause="AMOSwapCap(_, _, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/auipc_32bit.adoc
+++ b/src/cheri/insns/auipc_32bit.adoc
@@ -23,11 +23,8 @@ Take the value of the AUIPC instruction's <<pcc>>, increment its address by the 
 include::rep_range_check.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="AUIPC_capmode(_, _)",part=body,unindent]
++
+sail::execute[clause="AUIPC_capmode(_, _)",part=body,unindent]
 
 ifndef::cheri_ratification_v1_only[]
 

--- a/src/cheri/insns/cbld_32bit.adoc
+++ b/src/cheri/insns/cbld_32bit.adoc
@@ -53,8 +53,5 @@ However future extensions may add additional behavior to update currently reserv
 and so software should not assume `{cs1}=0` to be a pseudo-instruction for {ctag} clearing.
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="CBLD(_, _, _)",part=body,unindent]
++
+sail::execute[clause="CBLD(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/cbo.clean.adoc
+++ b/src/cheri/insns/cbo.clean.adoc
@@ -33,6 +33,7 @@ Zicbom, {cheri_base_ext_name}
 
 Operation::
 // Not bundled in the JSON due to build system, inserted manually for now.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cache_block_size = 2 ^ plat_cache_block_size_exp();

--- a/src/cheri/insns/cbo.clean.adoc
+++ b/src/cheri/insns/cbo.clean.adoc
@@ -32,7 +32,13 @@ Prerequisites::
 Zicbom, {cheri_base_ext_name}
 
 Operation::
+// Not bundled in the JSON due to build system, inserted manually for now.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cache_block_size = 2 ^ plat_cache_block_size_exp();
+let negative_offset = (X(cs1) & ~(zero_extend(ones(plat_cache_block_size_exp())))) - X(cs1);
+match ext_data_get_addr(cs1, negative_offset, Cache(CleanFlush), cache_block_size) {
+  Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+  Ext_DataAddr_OK(_)    => RETIRE_SUCCESS
+}
 ----

--- a/src/cheri/insns/cbo.flush.adoc
+++ b/src/cheri/insns/cbo.flush.adoc
@@ -33,6 +33,7 @@ Zicbom, {cheri_base_ext_name}
 
 Operation::
 // Not bundled in the JSON due to build system, inserted manually for now.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cache_block_size = 2 ^ plat_cache_block_size_exp();

--- a/src/cheri/insns/cbo.flush.adoc
+++ b/src/cheri/insns/cbo.flush.adoc
@@ -32,7 +32,13 @@ Prerequisites::
 Zicbom, {cheri_base_ext_name}
 
 Operation::
+// Not bundled in the JSON due to build system, inserted manually for now.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cache_block_size = 2 ^ plat_cache_block_size_exp();
+let negative_offset = (X(cs1) & ~(zero_extend(ones(plat_cache_block_size_exp())))) - X(cs1);
+match ext_data_get_addr(cs1, negative_offset, Cache(CleanFlush), cache_block_size) {
+  Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+  Ext_DataAddr_OK(_)    => RETIRE_SUCCESS
+}
 ----

--- a/src/cheri/insns/cbo.inval.adoc
+++ b/src/cheri/insns/cbo.inval.adoc
@@ -49,7 +49,13 @@ Prerequisites::
 Zicbom, {cheri_base_ext_name}
 
 Operation::
+// Not bundled in the JSON due to build system, inserted manually for now.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cache_block_size = 2 ^ plat_cache_block_size_exp();
+let negative_offset = (X(cs1) & ~(zero_extend(ones(plat_cache_block_size_exp())))) - X(cs1);
+match ext_data_get_addr(cs1, negative_offset, Cache(Inval), cache_block_size) {
+  Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+  Ext_DataAddr_OK(_)    => RETIRE_SUCCESS
+}
 ----

--- a/src/cheri/insns/cbo.inval.adoc
+++ b/src/cheri/insns/cbo.inval.adoc
@@ -50,6 +50,7 @@ Zicbom, {cheri_base_ext_name}
 
 Operation::
 // Not bundled in the JSON due to build system, inserted manually for now.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cache_block_size = 2 ^ plat_cache_block_size_exp();

--- a/src/cheri/insns/cbo.zero.adoc
+++ b/src/cheri/insns/cbo.zero.adoc
@@ -36,7 +36,21 @@ Prerequisites::
 Zicboz, {cheri_base_ext_name}
 
 Operation::
+// Not bundled in the JSON due to build system, inserted manually for now.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cache_block_size = 2 ^ plat_cache_block_size_exp();
+let negative_offset = (X(cs1) & ~(zero_extend(ones(plat_cache_block_size_exp())))) - X(cs1);
+match ext_data_get_addr(cs1, negative_offset, Cache(Zero), cache_block_size) {
+  Ext_DataAddr_Error(e) => { ext_handle_data_check_error(e); RETIRE_FAIL },
+  Ext_DataAddr_OK(vaddr) => match translateAddr(vaddr, Write(Data)) {
+    TR_Failure(e, ext_ptw) => { handle_translate_exception(vaddr - negative_offset, e, ext_ptw); RETIRE_FAIL },
+    TR_Address(paddr, pbmt, _) => {
+      let ep = effectivePrivilege(Cache(Zero), mstatus, cur_privilege());
+      let _ = mem_write_value_priv_meta(pbmt, paddr, cache_block_size, zeros(),
+                                        Cache(Zero), ep, default_meta, false, false, false);
+      RETIRE_SUCCESS
+    }
+  }
+}
 ----

--- a/src/cheri/insns/cbo.zero.adoc
+++ b/src/cheri/insns/cbo.zero.adoc
@@ -37,6 +37,7 @@ Zicboz, {cheri_base_ext_name}
 
 Operation::
 // Not bundled in the JSON due to build system, inserted manually for now.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cache_block_size = 2 ^ plat_cache_block_size_exp();

--- a/src/cheri/insns/cram_32bit.adoc
+++ b/src/cheri/insns/cram_32bit.adoc
@@ -20,8 +20,5 @@ See <<section_cap_bounds>> for the algorithm used to compute the next representa
 NOTE: This {cheri_base_ext_name} instruction only handles XLEN operands and produces an XLEN result.
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="CRAM(_, _)",part=body,unindent]
++
+sail::execute[clause="CRAM(_, _)",part=body,unindent]

--- a/src/cheri/insns/csrr_32bit.adoc
+++ b/src/cheri/insns/csrr_32bit.adoc
@@ -58,7 +58,5 @@ Prerequisites::
 {cheri_base_ext_name}, Zicsr, optional {cheri_default_ext_name}
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
++
+sail::execute[clause="CSR(_, _, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/csrrw_32bit.adoc
+++ b/src/cheri/insns/csrrw_32bit.adoc
@@ -43,7 +43,5 @@ Prerequisites::
 {cheri_base_ext_name}, Zicsr, optional {cheri_default_ext_name}
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
++
+sail::execute[clause="CSR(_, _, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/gcbase_32bit.adoc
+++ b/src/cheri/insns/gcbase_32bit.adoc
@@ -27,8 +27,5 @@ include::no_tag_affect.adoc[]
 
 Operation::
 +
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="GCBASE(_, _)",part=body,unindent]
++
+sail::execute[clause="GCBASE(_, _)",part=body,unindent]

--- a/src/cheri/insns/gcbase_32bit.adoc
+++ b/src/cheri/insns/gcbase_32bit.adoc
@@ -27,5 +27,4 @@ include::no_tag_affect.adoc[]
 
 Operation::
 +
-+
 sail::execute[clause="GCBASE(_, _)",part=body,unindent]

--- a/src/cheri/insns/gchi_32bit.adoc
+++ b/src/cheri/insns/gchi_32bit.adoc
@@ -53,8 +53,5 @@ Copy the metadata (bits [YLEN-1:XLEN]) of capability `{cs1}` into `rd`.
 include::no_tag_affect.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="GCHI(_, _)",part=body,unindent]
++
+sail::execute[clause="GCHI(_, _)",part=body,unindent]

--- a/src/cheri/insns/gchi_32bit.adoc
+++ b/src/cheri/insns/gchi_32bit.adoc
@@ -20,9 +20,12 @@ NOTE: The only valid shift amount is `XLEN` (as required by <<GCHI>>).
 A future extension may add an arbitrary shift distance.
 
 Operation::
+// SRLIY is not in the Sail model yet.
+// The only architecturally valid shamt is XLEN, i.e. this is equivalent to YHIR.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+X(rd) = truncate(capToBits(C(rs1)) >> shamt, xlen);
+RETIRE_SUCCESS
 ----
 
 <<<

--- a/src/cheri/insns/gchi_32bit.adoc
+++ b/src/cheri/insns/gchi_32bit.adoc
@@ -22,6 +22,7 @@ A future extension may add an arbitrary shift distance.
 Operation::
 // SRLIY is not in the Sail model yet.
 // The only architecturally valid shamt is XLEN, i.e. this is equivalent to YHIR.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 X(rd) = truncate(capToBits(C(rs1)) >> shamt, xlen);

--- a/src/cheri/insns/gclen_32bit.adoc
+++ b/src/cheri/insns/gclen_32bit.adoc
@@ -32,8 +32,5 @@ include::malformed_return_0.adoc[]
 include::no_tag_affect.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="GCLEN(_, _)",part=body,unindent]
++
+sail::execute[clause="GCLEN(_, _)",part=body,unindent]

--- a/src/cheri/insns/gcmode_32bit.adoc
+++ b/src/cheri/insns/gcmode_32bit.adoc
@@ -29,8 +29,5 @@ Otherwise set `rd` according to `{cs1}` 's {cheri_mode_name} (<<p_bit>>):
 include::no_tag_affect.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="GCMODE(_, _)",part=body,unindent]
++
+sail::execute[clause="GCMODE(_, _)",part=body,unindent]

--- a/src/cheri/insns/gcperm_32bit.adoc
+++ b/src/cheri/insns/gcperm_32bit.adoc
@@ -34,8 +34,5 @@ include::../img/acperm_bit_field.edn[]
 include::no_tag_affect.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="GCPERM(_, _)",part=body,unindent]
++
+sail::execute[clause="GCPERM(_, _)",part=body,unindent]

--- a/src/cheri/insns/gctag_32bit.adoc
+++ b/src/cheri/insns/gctag_32bit.adoc
@@ -21,8 +21,5 @@ Description::
 Zero extend the value of `{cs1}.tag` and write the result to `rd`.
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="GCTAG(_, _)",part=body,unindent]
++
+sail::execute[clause="GCTAG(_, _)",part=body,unindent]

--- a/src/cheri/insns/gctop_32bit.adoc
+++ b/src/cheri/insns/gctop_32bit.adoc
@@ -25,7 +25,16 @@ include::malformed_return_0.adoc[]
 include::no_tag_affect.adoc[]
 
 Operation::
+// GCTOP is not in the Sail model yet, use the same logic as YLENR.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let capVal = C(cs1);
+X(rd) = match getCapBoundsBits(capVal) {
+  None() => zeros(),
+  Some(_, top) => {
+    let top_val = unsigned(top);
+    to_bits(xlen, if top_val > cap_max_addr then cap_max_addr else top_val)
+  }
+};
+RETIRE_SUCCESS
 ----

--- a/src/cheri/insns/gctop_32bit.adoc
+++ b/src/cheri/insns/gctop_32bit.adoc
@@ -26,6 +26,7 @@ include::no_tag_affect.adoc[]
 
 Operation::
 // GCTOP is not in the Sail model yet, use the same logic as YLENR.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let capVal = C(cs1);

--- a/src/cheri/insns/gctype_32bit.adoc
+++ b/src/cheri/insns/gctype_32bit.adoc
@@ -24,7 +24,5 @@ Decode the architectural capability type (<<sec_cap_type>>) from `{cs1}`, zero e
 include::no_tag_affect.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
++
+sail::execute[clause="GCTYPE(_, _)",part=body,unindent]

--- a/src/cheri/insns/jal_32bit.adoc
+++ b/src/cheri/insns/jal_32bit.adoc
@@ -28,6 +28,7 @@ NOTE: A future extension may raise an exception on the branch instruction itself
 Operation::
 // Adapted from the Sail JAL_capmode clause with the address/bounds exception
 // checks removed (those are taken on fetch now).
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let off : xlenbits = sign_extend(imm);

--- a/src/cheri/insns/jal_32bit.adoc
+++ b/src/cheri/insns/jal_32bit.adoc
@@ -26,8 +26,15 @@ NOTE: A future extension may raise an exception on the branch instruction itself
   Performing the <<pcc>> bounds check at the branch source instead of on instruction fetch is helpful for debugging and can simplify the implementation of CPUs with very short pipelines.
 
 Operation::
+// Adapted from the Sail JAL_capmode clause with the address/bounds exception
+// checks removed (those are taken on fetch now).
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let off : xlenbits = sign_extend(imm);
+let newPC = PC + off;
+let (_, linkCap) = setCapAddr(PCC, nextPC); /* nextPC accounts for compressed instructions */
+C(cd) = sealCap(linkCap);
+set_next_pc(newPC);
+RETIRE_SUCCESS
 ----
 //sail::execute[clause="JAL_capmode(_, _)",part=body,unindent]

--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -63,8 +63,18 @@ endif::[]
 NOTE: A future extension may raise an exception on the <<JALR_CHERI>> instruction itself if the target <<pcc>> will raise a {cheri_excep_name_pc} at the target.
 
 Operation::
+// Adapted from the Sail JALR_capmode clause with the tag/seal/permission/bounds
+// checks removed (those are taken on fetch now).
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cs1_val = C(cs1);
+let off : xlenbits = sign_extend(imm);
+let newPC = [cs1_val.address + off with 0 = bitzero]; /* clear bit zero as for RISC-V JALR */
+let (_, linkCap) = setCapAddr(PCC, nextPC); /* nextPC accounts for compressed instructions */
+C(cd) = sealCap(linkCap);
+set_next_pc(newPC);
+let (_, newPCC) = setCapAddr(cs1_val, newPC);
+set_next_pcc(unsealCap(newPCC));
+RETIRE_SUCCESS
 ----
 //sail::execute[clause="JALR_capmode(_, _)",part=body,unindent]

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -48,8 +48,5 @@ When sending load data to a trace interface, implementations trace the final val
 include::load_exceptions.adoc[]
 +
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="LoadCapImm(_, _, _)",part=body,unindent]
++
+sail::execute[clause="LoadCapImm(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/load_res_cap_32bit.adoc
+++ b/src/cheri/insns/load_res_cap_32bit.adoc
@@ -34,7 +34,5 @@ Prerequisites::
 {cheri_base_ext_name}, and Zalrsc
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
++
+sail::execute[clause="LoadResCap(_, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/modesw_32bit.adoc
+++ b/src/cheri/insns/modesw_32bit.adoc
@@ -28,6 +28,7 @@ Operation::
 // instructions now. The Sail model additionally updates drootc (from the debug
 // specification) when in debug mode; that line is omitted here as this specification
 // does not include the debug extension.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let target : ExecutionMode = match op {

--- a/src/cheri/insns/modesw_32bit.adoc
+++ b/src/cheri/insns/modesw_32bit.adoc
@@ -24,8 +24,17 @@ Set the current {cheri_mode_name} in <<pcc>>.
 * {MODESW_INT}: If the current mode in <<pcc>> is {cheri_cap_mode_name} ({CAP_MODE_VALUE}), then the <<p_bit>> in <<pcc>> is set to {cheri_int_mode_name} ({INT_MODE_VALUE}). Otherwise no effect.
 
 Operation::
+// Manually updated for the current spec: MODESW.CAP and MODESW.INT are separate
+// instructions now. The Sail model additionally updates drootc (from the debug
+// specification) when in debug mode; that line is omitted here as this specification
+// does not include the debug extension.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let target : ExecutionMode = match op {
+  MODESW_CAP => CapPtrMode,
+  MODESW_INT => IntPtrMode,
+};
+set_next_pcc(setCapMode(PCC, target));
+RETIRE_SUCCESS
 ----
 //sail::execute[clause="MODESW()",part=body,unindent]

--- a/src/cheri/insns/mret_sret.adoc
+++ b/src/cheri/insns/mret_sret.adoc
@@ -41,3 +41,15 @@ Operation::
 ----
 SAIL TO BE UPDATED
 ----
+=======
+// TODO: Included in::
+// TODO: <<rvy_m_mod_insn_table>>
+// TODO: <<rvy_s_mod_insn_table>>
+
+Operation for MRET::
++
+sail::execute[clause="MRET()",part=body,unindent]
+
+Operation for SRET::
++
+sail::execute[clause="SRET()",part=body,unindent]

--- a/src/cheri/insns/mret_sret.adoc
+++ b/src/cheri/insns/mret_sret.adoc
@@ -36,12 +36,6 @@ Machine-Level ISA, {cheri_base_ext_name}
 Prerequisites (SRET)::
 Supervisor-Level ISA, {cheri_base_ext_name}
 
-Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-=======
 // TODO: Included in::
 // TODO: <<rvy_m_mod_insn_table>>
 // TODO: <<rvy_s_mod_insn_table>>

--- a/src/cheri/insns/prefetch.i.adoc
+++ b/src/cheri/insns/prefetch.i.adoc
@@ -58,7 +58,9 @@ Prerequisites::
 Zicbop, {cheri_base_ext_name}
 
 Operation::
-[source,sail]
+// Not in sail model since there are no architectural side effects
+[source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+// PREFETCH.I is a hint: it performs no architectural operation
+RETIRE_SUCCESS
 ----

--- a/src/cheri/insns/prefetch.r.adoc
+++ b/src/cheri/insns/prefetch.r.adoc
@@ -57,7 +57,9 @@ Prerequisites::
 Zicbop, {cheri_base_ext_name}
 
 Operation::
-[source,sail]
+// Not in sail model since there are no architectural side effects
+[source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+// PREFETCH.R is a hint: it performs no architectural operation
+RETIRE_SUCCESS
 ----

--- a/src/cheri/insns/prefetch.w.adoc
+++ b/src/cheri/insns/prefetch.w.adoc
@@ -57,7 +57,9 @@ Prerequisites::
 Zicbop, {cheri_base_ext_name}
 
 Operation::
-[source,sail]
+// Not in sail model since there are no architectural side effects
+[source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+// PREFETCH.R is a hint: it performs no architectural operation
+RETIRE_SUCCESS
 ----

--- a/src/cheri/insns/scaddr_32bit.adoc
+++ b/src/cheri/insns/scaddr_32bit.adoc
@@ -30,8 +30,5 @@ include::rep_range_check.adoc[]
 include::malformed_cs1_clear_tag.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCADDR(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCADDR(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -94,11 +94,8 @@ The hardware implementation is a simple bit-remapping: +
 ====
 
 Operation for {SCBNDS}::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCBNDS(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCBNDS(_, _, _)",part=body,unindent]
 
 Operation for {SCBNDSI}::
 [source,SAIL,subs="verbatim,quotes"]

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -98,7 +98,25 @@ Operation for {SCBNDS}::
 sail::execute[clause="SCBNDS(_, _, _)",part=body,unindent]
 
 Operation for {SCBNDSI}::
+// YBNDSWI in the JSON uses a different immediate, add it manually.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cs1_val = C(cs1);
+// Decode the requested length from the 9-bit immediate.
+let length : xlenbits =
+  if imm == 0b000000000 then to_bits(xlen, 4096)
+  else if imm[8] == bitzero then zero_extend(imm[7 .. 0])
+  else if imm[7 .. 5] == 0b000 then zero_extend(0b1 @ imm[3 .. 0] @ imm[4 .. 4] @ 0b000)
+  else zero_extend(imm[7 .. 0] @ 0b0000);
+let newBase = cs1_val.address;
+let newTop : CapLenBits = zero_extend(newBase) + zero_extend(length);
+// inCapBoundsNoWrap returns false if the input bounds are malformed.
+let inBounds = inCapBoundsNoWrap(cs1_val, newBase, unsigned(length));
+let (exact, newCap) : (bool, Capability) = setCapBounds(cs1_val, newBase, newTop);
+let cond = not(inBounds & exact) |
+           boundsMalformed(newCap) |
+           not(capReservedValid(newCap)) |
+           capIsSealed(newCap);
+C(cd) = clearTagIf(newCap, cond);
+RETIRE_SUCCESS
 ----

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -99,6 +99,7 @@ sail::execute[clause="SCBNDS(_, _, _)",part=body,unindent]
 
 Operation for {SCBNDSI}::
 // YBNDSWI in the JSON uses a different immediate, add it manually.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cs1_val = C(cs1);

--- a/src/cheri/insns/scbndsr_32bit.adoc
+++ b/src/cheri/insns/scbndsr_32bit.adoc
@@ -36,8 +36,5 @@ Set `{cd}.tag=0` if `{cd}` 's bounds exceed `{cs1}` 's bounds.
 include::malformed_cs1_clear_tag.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCBNDSR(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCBNDSR(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/sceq_32bit.adoc
+++ b/src/cheri/insns/sceq_32bit.adoc
@@ -23,8 +23,5 @@ Set `rd` to 1 if all bits (i.e., YLEN bits and the {ctag}) of capabilities `{cs1
 and `{cs2}`  are equal, otherwise set `rd` to 0.
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCEQ(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCEQ(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/schi_32bit.adoc
+++ b/src/cheri/insns/schi_32bit.adoc
@@ -41,8 +41,5 @@ Construct a YLEN-bit value in `{cd}` by setting the address from `rs1` and the m
 include::no_tag_affect.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCHI(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCHI(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/scmode_32bit.adoc
+++ b/src/cheri/insns/scmode_32bit.adoc
@@ -33,8 +33,5 @@ Otherwise, if `{cs1}` grants <<x_perm>> then update the <<p_bit>> of `{cd}` to:
 include::no_tag_affect.adoc[]
 
 Operation ::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCMODE(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCMODE(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/scss_32bit.adoc
+++ b/src/cheri/insns/scss_32bit.adoc
@@ -34,8 +34,5 @@ NOTE: The implementation of this instruction is similar to <<CBLD>>, although
 <<SCSS>> does not include the sealed bit in the check.
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
-//sail::execute[clause="SCSS(_, _, _)",part=body,unindent]
++
+sail::execute[clause="SCSS(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -31,7 +31,14 @@ NOTE: If the capability encoding format does not support a <<CT-field>> of type 
  Future capability encoding formats may redefine the behavior for <<CT-field>> values greater than 1.
 
 Operation::
+// The Sail SENTRY clause seals its cs1 operand; the current instruction seals
+// cs2 (cs1 is reserved for a future YSEAL) and also invalidates on a failed
+// integrity check.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cs2_val = C(cs2);
+let inCap = clearTagIf(cs2_val, capIsSealed(cs2_val) | not(capReservedValid(cs2_val)));
+C(cd) = sealCap(inCap);
+RETIRE_SUCCESS
 ----
+//sail::execute[clause="SENTRY(_, _)",part=body,unindent]

--- a/src/cheri/insns/sentry_32bit.adoc
+++ b/src/cheri/insns/sentry_32bit.adoc
@@ -34,6 +34,7 @@ Operation::
 // The Sail SENTRY clause seals its cs1 operand; the current instruction seals
 // cs2 (cs1 is reserved for a future YSEAL) and also invalidates on a failed
 // integrity check.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cs2_val = C(cs2);

--- a/src/cheri/insns/sh1234add_32bit.adoc
+++ b/src/cheri/insns/sh1234add_32bit.adoc
@@ -55,6 +55,7 @@ include::malformed_cs2_clear_tag.adoc[]
 
 Operation::
 // Manually updated for the current spec, sail JSON file omitted SH4ADD
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let rs1_val = X(rs1);

--- a/src/cheri/insns/sh1234add_32bit.adoc
+++ b/src/cheri/insns/sh1234add_32bit.adoc
@@ -54,8 +54,19 @@ include::rep_range_check.adoc[]
 include::malformed_cs2_clear_tag.adoc[]
 
 Operation::
+// Manually updated for the current spec, sail JSON file omitted SH4ADD
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let rs1_val = X(rs1);
+let cs2_val = C(cs2);
+let shamt : range(1,4) = match op {
+  RISCV_SH1ADD => 1,
+  RISCV_SH2ADD => 2,
+  RISCV_SH3ADD => 3,
+  RISCV_SH4ADD => 4,
+};
+let result = incCapAddrChecked(cs2_val, rs1_val << shamt);
+C(cd) = result;
+RETIRE_SUCCESS
 ----
 //sail::execute[clause="ZBA_RTYPE_capmode(_, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/sh1234add_uw_32bit.adoc
+++ b/src/cheri/insns/sh1234add_uw_32bit.adoc
@@ -52,8 +52,19 @@ include::rep_range_check.adoc[]
 include::malformed_cs2_clear_tag.adoc[]
 
 Operation::
+// Manually updated for the current spec, sail JSON file omitted SH4ADD.UW
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let rs1_val = X(rs1);
+let cs2_val = C(cs2);
+let shamt : range(1,4) = match op {
+  RISCV_SH1ADDUW => 1,
+  RISCV_SH2ADDUW => 2,
+  RISCV_SH3ADDUW => 3,
+  RISCV_SH4ADDUW => 4,
+};
+let result = incCapAddrChecked(cs2_val, zero_extend(rs1_val[31..0]) << shamt);
+C(cd) = result;
+RETIRE_SUCCESS
 ----
 //sail::execute[clause="ZBA_RTYPEUW_capmode(_, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/sh1234add_uw_32bit.adoc
+++ b/src/cheri/insns/sh1234add_uw_32bit.adoc
@@ -53,6 +53,7 @@ include::malformed_cs2_clear_tag.adoc[]
 
 Operation::
 // Manually updated for the current spec, sail JSON file omitted SH4ADD.UW
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let rs1_val = X(rs1);

--- a/src/cheri/insns/store_32bit_cap.adoc
+++ b/src/cheri/insns/store_32bit_cap.adoc
@@ -40,8 +40,5 @@ Raise a store/AMO access fault exception when the effective address is not align
 include::store_exceptions.adoc[]
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL to be updated
-----
-//sail::execute[clause="StoreCapImm(_, _, _)",part=body,unindent]
++
+sail::execute[clause="StoreCapImm(_, _, _)",part=body,unindent]

--- a/src/cheri/insns/store_cond_cap_32bit.adoc
+++ b/src/cheri/insns/store_cond_cap_32bit.adoc
@@ -36,7 +36,5 @@ Prerequisites::
 {cheri_base_ext_name}, and Zalrsc
 
 Operation::
-[source,SAIL,subs="verbatim,quotes"]
-----
-SAIL TO BE UPDATED
-----
++
+sail::execute[clause="StoreCondCap(_, _, _, _, _)",part=body,unindent]

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -86,7 +86,19 @@ it must use <<GCTYPE>> on the sealed capability.
 =====
 endif::[]
 Operation::
+// YSUNSEAL is not in the Sail model; it reuses the CBLD logic but additionally
+// requires cs2 to be tagged and sealed, and always unseals the result.
 [source,SAIL,subs="verbatim,quotes"]
 ----
-SAIL TO BE UPDATED
+let cs1_val = C(cs1);
+let cs2_val = C(cs2);
+
+let tag = cs1_val.tag &
+          not(capIsSealed(cs1_val)) &
+          cs2_val.tag &
+          capIsSealed(cs2_val) &
+          capIsSubset(cs2_val, cs1_val); /* subset checks for malformed bounds, perms, reserved bits */
+
+C(cd) = { unsealCap(cs2_val) with tag = tag };
+RETIRE_SUCCESS
 ----

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -88,6 +88,7 @@ endif::[]
 Operation::
 // YSUNSEAL is not in the Sail model; it reuses the CBLD logic but additionally
 // requires cs2 to be tagged and sealed, and always unseals the result.
+WARNING: Manually written code, to be replaced when updated SAIL is available.
 [source,SAIL,subs="verbatim,quotes"]
 ----
 let cs1_val = C(cs1);


### PR DESCRIPTION
Commit a72b38c64f06d4e32d23a21f39437067ac85c446 was too
aggressive in removing these, most instructions are still correct.

Some of them are not correct in the bundled JSON, so I've added a
fixed version here.