### PR TITLE
Describe C.ADDI16SP/C.ADDI4SPN by deferring to YADDI

### DIFF
--- a/src/cheri/insns/addi16sp_16bit.adoc
+++ b/src/cheri/insns/addi16sp_16bit.adoc
@@ -16,13 +16,9 @@ Encoding::
 include::wavedrom/c-int-reg-immed.adoc[]
 
 Description::
-Add the non-zero sign-extended 6-bit immediate to the value in the stack pointer (`{abi_creg}sp={creg}2`), where the immediate is scaled to represent multiples of 16 in the range (-512,496).
+Add the non-zero sign-extended 6-bit immediate to `{abi_creg}sp.address` (`{abi_creg}sp={creg}2`), where the immediate is scaled to represent multiples of 16 in the range (-512,496).
 +
-Set `{cd}.tag=0` if `{abi_creg}sp` is sealed.
-+
-include::rep_range_check.adoc[]
-+
-include::malformed_creg_sp_clear_tag.adoc[]
+All other details, including the conditions for clearing `{abi_creg}sp.tag`, are as defined by <<CADDI>> for the expansion shown above.
 
 Prerequisites::
 {c_cheri_base_ext_names}

--- a/src/cheri/insns/addi4spn_16bit.adoc
+++ b/src/cheri/insns/addi4spn_16bit.adoc
@@ -19,11 +19,7 @@ Description::
 
 Copy `{abi_creg}sp` to `{cd}'`. Add a zero-extended non-zero immediate, scaled by 4, to `{cd}'.address`.
 +
-Set `{cd}'.tag=0` if `{abi_creg}sp` is sealed.
-+
-Set `{cd}'.tag=0` if the resulting capability cannot be <<section_cap_representable_check,represented exactly>>.
-+
-Set `{cd}'.tag=0` if `{abi_creg}sp` 's bounds are <<section_cap_malformed,malformed>>, or if any of the reserved fields are set.
+All other details, including the conditions for clearing `{cd}'.tag`, are as defined by <<CADDI>> for the expansion shown above.
 
 Prerequisites::
 {c_cheri_base_ext_names}


### PR DESCRIPTION
C.ADDI16SP referred to a nonexistent rd operand (its destination is sp) and described the addition as acting on "the value in the stack pointer" rather than sp.address.  The two instructions also spelled their tag-clearing conditions differently even though both expand to YADDI.  State the address arithmetic and defer all tag-clearing conditions to the YADDI definition.