### PR TITLE
Fixes for the CMO chapter

### DIFF
--- a/src/cheri/insns/cbo.inval.adoc
+++ b/src/cheri/insns/cbo.inval.adoc
@@ -24,6 +24,9 @@ Encoding::
 Description::
 A CBO.INVAL instruction performs an invalidate operation on the cache block whose effective address is the base address specified in `{cs1}`.
 The authorizing capability for this instruction is `{cs1}`.
++
+Executing CBO.INVAL requires <<asr_perm>> in <<pcc>>, even when CSR state causes it to perform a flush operation instead of an invalidation.
+An illegal instruction exception is raised if <<asr_perm>> is not granted, matching the behavior of <<MRET_CHERI>>, <<SRET_CHERI>> and CSR accesses that require <<asr_perm>>.
 
 :cbo_inval:
 include::cbo_exceptions.adoc[]

--- a/src/cheri/insns/cbo.inval.adoc
+++ b/src/cheri/insns/cbo.inval.adoc
@@ -25,8 +25,9 @@ Description::
 A CBO.INVAL instruction performs an invalidate operation on the cache block whose effective address is the base address specified in `{cs1}`.
 The authorizing capability for this instruction is `{cs1}`.
 +
-Executing CBO.INVAL requires <<asr_perm>> in <<pcc>>, even when CSR state causes it to perform a flush operation instead of an invalidation.
-An illegal instruction exception is raised if <<asr_perm>> is not granted, matching the behavior of <<MRET_CHERI>>, <<SRET_CHERI>> and CSR accesses that require <<asr_perm>>.
+NOTE: Executing CBO.INVAL requires <<asr_perm>> in <<pcc>>, even when CSR state causes it to perform a flush operation instead of an invalidation.
++
+NOTE: An illegal instruction exception is raised if <<asr_perm>> is not granted, matching the behavior of `__x__RET` and CSR accesses that require <<asr_perm>>.
 
 :cbo_inval:
 include::cbo_exceptions.adoc[]

--- a/src/cheri/insns/cbo_exceptions.adoc
+++ b/src/cheri/insns/cbo_exceptions.adoc
@@ -29,5 +29,10 @@ endif::cbo_inval[]
 
 |==============================================================================
 
+ifdef::cbo_clean_flush[]
+NOTE: CBO.CLEAN and CBO.FLUSH only require one byte of the cache block to be within the authorizing capability's bounds because these operations do not reveal or modify any data, so performing them on a partially covered cache block is harmless.
+CBO.INVAL and CBO.ZERO destroy or overwrite the contents of the entire cache block and therefore require every byte of the cache block to be within bounds.
+endif::cbo_clean_flush[]
+
 :!cbo_clean_flush:
 :!cbo_inval:

--- a/src/cheri/insns/prefetch.i.adoc
+++ b/src/cheri/insns/prefetch.i.adoc
@@ -31,15 +31,19 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by an instruction fetch in the near future.
 +
 The authorizing capability is `{cs1}`.
-This instruction does not throw any exceptions.
+This instruction does not raise any exceptions.
 +
 The following authorization checks are performed:
 
 * `{cs1}.tag=1`
 * `{cs1}` is not sealed
-* Any bytes of the requested cache line requested are in `{cs1}` bounds
+* At least one byte of the requested cache block is within `{cs1}` 's bounds
 * `{cs1}` grants <<x_perm>>
 * `{cs1}` passes all <<section_cap_integrity, integrity>> checks
+
+If any of these checks fail, the instruction executes as a `nop` and no prefetch is performed.
+
+NOTE: Only one byte of the cache block is required to be within bounds because a hardware prefetcher is permitted to prefetch the same cache block in the background.
 
 [NOTE]
 ====

--- a/src/cheri/insns/prefetch.r.adoc
+++ b/src/cheri/insns/prefetch.r.adoc
@@ -30,15 +30,19 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by a data read (i.e., load) in the near future.
 +
 The authorizing capability is `{cs1}`.
-This instruction does not throw any exceptions.
+This instruction does not raise any exceptions.
 +
 The following authorization checks are performed:
 
 * `{cs1}.tag=1`
 * `{cs1}` is not sealed
-* Any bytes of the requested cache line requested are in `{cs1}` bounds
+* At least one byte of the requested cache block is within `{cs1}` 's bounds
 * `{cs1}` grants <<r_perm>>
 * `{cs1}` passes all <<section_cap_integrity, integrity>> checks
+
+If any of these checks fail, the instruction executes as a `nop` and no prefetch is performed.
+
+NOTE: Only one byte of the cache block is required to be within bounds because a hardware prefetcher is permitted to prefetch the same cache block in the background.
 
 [NOTE]
 ====

--- a/src/cheri/insns/prefetch.w.adoc
+++ b/src/cheri/insns/prefetch.w.adoc
@@ -30,15 +30,19 @@ sign-extended offset encoded in imm[11:0], where imm[4:0] equals 0b00000, is
 likely to be accessed by a data write (i.e., store) in the near future.
 +
 The authorizing capability is `{cs1}`.
-This instruction does not throw any exceptions.
+This instruction does not raise any exceptions.
 +
 The following authorization checks are performed:
 
 * `{cs1}.tag=1`
 * `{cs1}` is not sealed
-* Any bytes of the requested cache line requested are in `{cs1}` bounds
+* At least one byte of the requested cache block is within `{cs1}` 's bounds
 * `{cs1}` grants <<w_perm>>
 * `{cs1}` passes all <<section_cap_integrity, integrity>> checks
+
+If any of these checks fail, the instruction executes as a `nop` and no prefetch is performed.
+
+NOTE: Only one byte of the cache block is required to be within bounds because a hardware prefetcher is permitted to prefetch the same cache block in the background.
 
 [NOTE]
 ====


### PR DESCRIPTION
CBO.CLEAN/FLUSH fault only when no byte of the cache block is in
bounds, while CBO.INVAL/ZERO require the whole block in bounds.  This
is intentional (clean/flush are non-destructive) but looked like a
copy-paste error without a rationale note.

---

Specify CBO.INVAL ASR check applies even when executed as a flush

The ASR-permission requirement is on executing the instruction, not on
the operation it ends up performing.  Also note that the illegal
instruction exception matches MRET/SRET and ASR-gated CSR accesses.


---

Clarify PREFETCH.I/R/W authorization checks

- State what happens when a check fails: the instruction executes as a
  nop and no prefetch is performed (previously unstated).
- Fix the garbled bounds bullet ("Any bytes of the requested cache
  line requested") and make it explicit that only one byte of the
  cache block needs to be in bounds, with a rationale note (a hardware
  prefetcher could prefetch the same block in the background anyway).
- Use "cache block" (Zicbop terminology) and "raise" instead of
  "throw".