### PR TITLE
Describe the menvcfg/senvcfg Y bit and link its definition

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -61,7 +61,8 @@ NOTE: The capability in <<mtvec_y>> is _not_ unsealed when it is written to <<pc
 [#menvcfg_y,reftext="menvcfg ({cheri_base_ext_name})"]
 ==== Machine Environment Configuration (`menvcfg`) Register
 
-<<section_cheri_hybrid_ext>> adds the {CRE} bit to *menvcfg*
+<<section_cheri_hybrid_ext>> adds the {CRE} bit to *menvcfg*.
+The {CRE} bit can be used to disable or enable {cheri_base_ext_name} for privilege modes below M-mode, as described in xref:section_cheri_disable[xrefstyle=full].
 
 [#menvcfgmodereg]
 include::img/menvcfgmodereg.edn[]
@@ -503,7 +504,8 @@ endif::[]
 [#senvcfg_y,reftext="senvcfg ({cheri_base_ext_name})"]
 ==== Supervisor environment configuration register (senvcfg)
 
-<<section_cheri_hybrid_ext>> adds the {CRE} bit to *senvcfg*
+<<section_cheri_hybrid_ext>> adds the {CRE} bit to *senvcfg*.
+The {CRE} bit can be used to disable or enable {cheri_base_ext_name} for U-mode, as described in xref:section_cheri_disable[xrefstyle=full].
 
 .Supervisor environment configuration register (*senvcfg*)
 include::img/senvcfgreg.edn[]


### PR DESCRIPTION
The sections only said the bit exists; state that it enables or disables RVY for lower privilege modes and reference the disabling-CHERI section.