### PR TITLE
Fix SC.Y success/failure value in description

### DIFF
--- a/src/cheri/insns/store_cond_cap_32bit.adoc
+++ b/src/cheri/insns/store_cond_cap_32bit.adoc
@@ -21,7 +21,7 @@ Authorize the memory access with the capability in `{cs1}`.
 +
 Conditionally store the YLEN-bit value in `{cs2}`, together with its {ctag}, to the naturally aligned memory location, following the same rules as SC.W.
 +
-Set rd to 1 for success or 0 for failure.
+Set rd to 0 for success or 1 for failure.
 +
 The written {ctag} may be cleared following the same modification rules as <<STORE_CAP>>.
 +


### PR DESCRIPTION
The RISC-V convention (and the Sail operation shown for this instruction) is that store-conditional writes zero to rd on success and a non-zero value on failure.  The prose had it backwards.