### PR TITLE
Add multiple anchors into sections

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -127,9 +127,6 @@ endif::support_varxlen[]
 :c_cheri_base_ext_names:    Zca, {cheri_base_ext_name}
 :c_cheri_default_ext_names: Zca, {cheri_default_ext_name}
 
-:non-csrrw-or:  <<CSRRWI_CHERI>>, <<CSRRS_CHERI>>, <<CSRRSI_CHERI>>, <<CSRRC_CHERI>> or  <<CSRRCI_CHERI>>
-:non-csrrw-and: <<CSRRWI_CHERI>>, <<CSRRS_CHERI>>, <<CSRRSI_CHERI>>, <<CSRRC_CHERI>> and <<CSRRCI_CHERI>>
-
 :TAG_RESET_DCSR: The reset value of the {ctag} of this CSR is zero, the reset values of the metadata and address fields are UNSPECIFIED.
 :TAG_RESET_MCSR: The reset value of the {ctag} of this CSR is zero, the reset values of the metadata and address fields are UNSPECIFIED.
 :TAG_RESET_SCSR: At the start of the S-mode execution environment, the value of the {ctag} of this CSR is zero and the values of the metadata and address fields are UNSPECIFIED.

--- a/src/cheri/csv/CHERI_ISA.csv
+++ b/src/cheri/csv/CHERI_ISA.csv
@@ -47,12 +47,12 @@ C_JR_CHERI,C.CJR,{rvy_zca_mod_ext_name},✔,✔,,,,C2,,,{C_JR_CHERI_DESC},MODE==
 DRET_CHERI,same,DRET,✔,✔,,,SYSTEM,,,,"Return from debug mode, sets <<ddc>> from <<dddc>> and <<pcc>> from <<dpc_y>>",MODE<D,,,,,,,,v1
 MRET_CHERI,same,M,✔,✔,,,SYSTEM,,,,"Return from machine mode handler, sets <<pcc>> from <<mtvec_y>>","MODE<M,{pcc}.ASR==0",,,,,,,,v1
 SRET_CHERI,same,S,✔,✔,,,SYSTEM,,,,"Return from supervisor mode handler, sets <<pcc>> from <<stvec_y>>","MODE<S,{pcc}.ASR==0",mstatus.TSR==1 AND MODE==S,,,,,,,v1
-"CSRRW_CHERI,CSRRW ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write,CSR permission fault,,,,,,,,v1
-"CSRRS_CHERI,CSRRS ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set,CSR permission fault,,,,,,,,v1
-"CSRRC_CHERI,CSRRC ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear ,CSR permission fault,,,,,,,,v1
-"CSRRWI_CHERI,CSRRWI ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write (immediate form),CSR permission fault,,,,,,,,v1
-"CSRRSI_CHERI,CSRRSI ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set (immediate form),CSR permission fault,,,,,,,,v1
-"CSRRCI_CHERI,CSRRCI ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear (immediate form),CSR permission fault,,,,,,,,v1
+CSRRW_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write,CSR permission fault,,,,,,,,v1
+CSRRS_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set,CSR permission fault,,,,,,,,v1
+CSRRC_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear ,CSR permission fault,,,,,,,,v1
+CSRRWI_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write (immediate form),CSR permission fault,,,,,,,,v1
+CSRRSI_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set (immediate form),CSR permission fault,,,,,,,,v1
+CSRRCI_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear (immediate form),CSR permission fault,,,,,,,,v1
 CBO_INVAL_CHERI,same,{rvy_zicbom_mod_ext_name},✔,✔,,2,MISC-MEM,,,,Cache block invalidate (implemented as clean),MODE<M AND menvcfg.CBIE[0]==0,MODE<S AND senvcfg.CBIE[0]==0,{pcc}.ASR==0,,,,,,v1
 CBO_CLEAN_CHERI,same,{rvy_zicbom_mod_ext_name},✔,✔,,2,MISC-MEM,,,,Cache block clean,MODE<M AND menvcfg.CBIE[0]==0,MODE<S AND senvcfg.CBIE[0]==0,,,,,,,v1
 CBO_FLUSH_CHERI,same,{rvy_zicbom_mod_ext_name},✔,✔,,2,MISC-MEM,,,,Cache block flush,MODE<M AND menvcfg.CBIE[0]==0,MODE<S AND senvcfg.CBIE[0]==0,,,,,,,v1
@@ -71,14 +71,14 @@ CM_MVSA01_CHERI,same,Zcmp,✔,✔,,,,C2,,,Move two integer registers,,,,,,,,,v1
 CM_MVA01S_CHERI,same,Zcmp,✔,✔,,,,C2,,,Move two integer registers,,,,,,,,,v1
 CM_JALT_CHERI,same,Zcmt,✔,✔,,,,C2,,,Table jump and link,,,,,,,,,v1
 CM_JT_CHERI,same,Zcmt,✔,✔,,,,C2,,,Table jump,,,,,,,,,v1
-"SH1ADD_CHERI,{SH1ADD_CHERI}",N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-"SH2ADD_CHERI,{SH2ADD_CHERI}",N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-"SH3ADD_CHERI,{SH3ADD_CHERI}",N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-"SH4ADD_CHERI,{SH4ADD_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-"SH1ADD_UW_CHERI,{SH1ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
-"SH2ADD_UW_CHERI,{SH2ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
-"SH3ADD_UW_CHERI,{SH3ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
-"SH4ADD_UW_CHERI,{SH4ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+SH1ADD_CHERI,N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+SH2ADD_CHERI,N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+SH3ADD_CHERI,N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+SH4ADD_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+SH1ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+SH2ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+SH3ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+SH4ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
 HLV_CAP,HLV.C,{rvy_h_ext_name},✔,✔,,,SYSTEM,,,,Hypervisor virtual machine load capability,V=1,MODE==U AND hstatus.HU=0,,,,,,,post-v1
 HSV_CAP,HSV.C,{rvy_h_ext_name},✔,✔,,,SYSTEM,,,,Hypervisor virtual machine store capability,V=1,MODE==U AND hstatus.HU=0,,,,,,,post-v1
 {YSEAL},YSEAL,{cheri_seal_ext_name},✔,✔,,,OP,R-type,,,{YSEAL_DESC},,,,,,,,,v1

--- a/src/cheri/csv/CHERI_ISA.csv
+++ b/src/cheri/csv/CHERI_ISA.csv
@@ -47,12 +47,12 @@ C_JR_CHERI,C.CJR,{rvy_zca_mod_ext_name},✔,✔,,,,C2,,,{C_JR_CHERI_DESC},MODE==
 DRET_CHERI,same,DRET,✔,✔,,,SYSTEM,,,,"Return from debug mode, sets <<ddc>> from <<dddc>> and <<pcc>> from <<dpc_y>>",MODE<D,,,,,,,,v1
 MRET_CHERI,same,M,✔,✔,,,SYSTEM,,,,"Return from machine mode handler, sets <<pcc>> from <<mtvec_y>>","MODE<M,{pcc}.ASR==0",,,,,,,,v1
 SRET_CHERI,same,S,✔,✔,,,SYSTEM,,,,"Return from supervisor mode handler, sets <<pcc>> from <<stvec_y>>","MODE<S,{pcc}.ASR==0",mstatus.TSR==1 AND MODE==S,,,,,,,v1
-CSRRW_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write,CSR permission fault,,,,,,,,v1
-CSRRS_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set,CSR permission fault,,,,,,,,v1
-CSRRC_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear ,CSR permission fault,,,,,,,,v1
-CSRRWI_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write (immediate form),CSR permission fault,,,,,,,,v1
-CSRRSI_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set (immediate form),CSR permission fault,,,,,,,,v1
-CSRRCI_CHERI,same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear (immediate form),CSR permission fault,,,,,,,,v1
+"CSRRW_CHERI,CSRRW ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write,CSR permission fault,,,,,,,,v1
+"CSRRS_CHERI,CSRRS ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set,CSR permission fault,,,,,,,,v1
+"CSRRC_CHERI,CSRRC ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear ,CSR permission fault,,,,,,,,v1
+"CSRRWI_CHERI,CSRRWI ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR write (immediate form),CSR permission fault,,,,,,,,v1
+"CSRRSI_CHERI,CSRRSI ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR set (immediate form),CSR permission fault,,,,,,,,v1
+"CSRRCI_CHERI,CSRRCI ({cheri_base_ext_name})",same,{rvy_zicsr_mod_ext_name},✔,✔,,,SYSTEM,,,,CSR clear (immediate form),CSR permission fault,,,,,,,,v1
 CBO_INVAL_CHERI,same,{rvy_zicbom_mod_ext_name},✔,✔,,2,MISC-MEM,,,,Cache block invalidate (implemented as clean),MODE<M AND menvcfg.CBIE[0]==0,MODE<S AND senvcfg.CBIE[0]==0,{pcc}.ASR==0,,,,,,v1
 CBO_CLEAN_CHERI,same,{rvy_zicbom_mod_ext_name},✔,✔,,2,MISC-MEM,,,,Cache block clean,MODE<M AND menvcfg.CBIE[0]==0,MODE<S AND senvcfg.CBIE[0]==0,,,,,,,v1
 CBO_FLUSH_CHERI,same,{rvy_zicbom_mod_ext_name},✔,✔,,2,MISC-MEM,,,,Cache block flush,MODE<M AND menvcfg.CBIE[0]==0,MODE<S AND senvcfg.CBIE[0]==0,,,,,,,v1
@@ -71,14 +71,14 @@ CM_MVSA01_CHERI,same,Zcmp,✔,✔,,,,C2,,,Move two integer registers,,,,,,,,,v1
 CM_MVA01S_CHERI,same,Zcmp,✔,✔,,,,C2,,,Move two integer registers,,,,,,,,,v1
 CM_JALT_CHERI,same,Zcmt,✔,✔,,,,C2,,,Table jump and link,,,,,,,,,v1
 CM_JT_CHERI,same,Zcmt,✔,✔,,,,C2,,,Table jump,,,,,,,,,v1
-SH1ADD_CHERI,N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-SH2ADD_CHERI,N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-SH3ADD_CHERI,N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-SH4ADD_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
-SH1ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
-SH2ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
-SH3ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
-SH4ADD_UW_CHERI,N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+"SH1ADD_CHERI,{SH1ADD_CHERI}",N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+"SH2ADD_CHERI,{SH2ADD_CHERI}",N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+"SH3ADD_CHERI,{SH3ADD_CHERI}",N/A,{rvy_zba_ext_name},✔,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+"SH4ADD_CHERI,{SH4ADD_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add, representability check ",,,,,,,,,v1
+"SH1ADD_UW_CHERI,{SH1ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+"SH2ADD_UW_CHERI,{SH2ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+"SH3ADD_UW_CHERI,{SH3ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
+"SH4ADD_UW_CHERI,{SH4ADD_UW_CHERI} ({cheri_base64_ext_name})",N/A,{rvy_zba_ext_name},,✔,,,OP,,,,"shift and add unsigned word, representability check ",,,,,,,,,v1
 HLV_CAP,HLV.C,{rvy_h_ext_name},✔,✔,,,SYSTEM,,,,Hypervisor virtual machine load capability,V=1,MODE==U AND hstatus.HU=0,,,,,,,post-v1
 HSV_CAP,HSV.C,{rvy_h_ext_name},✔,✔,,,SYSTEM,,,,Hypervisor virtual machine store capability,V=1,MODE==U AND hstatus.HU=0,,,,,,,post-v1
 {YSEAL},YSEAL,{cheri_seal_ext_name},✔,✔,,,OP,R-type,,,{YSEAL_DESC},,,,,,,,,v1

--- a/src/cheri/insns/cadd_32bit.adoc
+++ b/src/cheri/insns/cadd_32bit.adoc
@@ -1,12 +1,8 @@
 <<<
 
-[#CADDI,reftext="{CADDI}"]
-==== {CADDI}
-
-See <<CADD>>.
-
-[#CADD,reftext="{CADD}"]
-==== {CADD}
+==== {CADD}, {CADDI}
+anchor:CADD[{CADD}]
+anchor:CADDI[{CADDI}]
 
 include::new_encoding_note.adoc[]
 

--- a/src/cheri/insns/csrr_32bit.adoc
+++ b/src/cheri/insns/csrr_32bit.adoc
@@ -1,23 +1,11 @@
 <<<
 
-[#CSRRWI_CHERI,reftext="CSRRWI ({cheri_base_ext_name})"]
-==== CSRRWI ({cheri_base_ext_name})
-See <<CSRRCI_CHERI>>.
-
-[#CSRRS_CHERI,reftext="CSRRS ({cheri_base_ext_name})"]
-==== CSRRS ({cheri_base_ext_name})
-See <<CSRRCI_CHERI>>.
-
-[#CSRRSI_CHERI,reftext="CSRRSI ({cheri_base_ext_name})"]
-==== CSRRSI ({cheri_base_ext_name})
-See <<CSRRCI_CHERI>>.
-
-[#CSRRC_CHERI,reftext="CSRRC ({cheri_base_ext_name})"]
-==== CSRRC ({cheri_base_ext_name})
-See <<CSRRCI_CHERI>>.
-
 [#CSRRCI_CHERI,reftext="CSRRCI ({cheri_base_ext_name})"]
-==== CSRRCI ({cheri_base_ext_name})
+==== CSRRWI, CSRRS, CSRRSI, CSRRC, CSRRCI ({cheri_base_ext_name})
+anchor:CSRRWI_CHERI[]
+anchor:CSRRS_CHERI[]
+anchor:CSRRSI_CHERI[]
+anchor:CSRRC_CHERI[]
 
 ifdef::cheri_v9_annotations[]
 NOTE: *CHERI v9 Note:* CSpecialRW is removed and this functionality replaces it

--- a/src/cheri/insns/csrr_32bit.adoc
+++ b/src/cheri/insns/csrr_32bit.adoc
@@ -1,11 +1,11 @@
 <<<
 
-[#CSRRCI_CHERI,reftext="CSRRCI ({cheri_base_ext_name})"]
 ==== CSRRWI, CSRRS, CSRRSI, CSRRC, CSRRCI ({cheri_base_ext_name})
-anchor:CSRRWI_CHERI[]
-anchor:CSRRS_CHERI[]
-anchor:CSRRSI_CHERI[]
-anchor:CSRRC_CHERI[]
+anchor:CSRRWI_CHERI[CSRRWI ({cheri_base_ext_name})]
+anchor:CSRRS_CHERI[CSRRS ({cheri_base_ext_name})]
+anchor:CSRRSI_CHERI[CSRRSI ({cheri_base_ext_name})]
+anchor:CSRRC_CHERI[CSRRC ({cheri_base_ext_name})]
+anchor:CSRRCI_CHERI[CSRRCI ({cheri_base_ext_name})]
 
 ifdef::cheri_v9_annotations[]
 NOTE: *CHERI v9 Note:* CSpecialRW is removed and this functionality replaces it

--- a/src/cheri/insns/modesw_32bit.adoc
+++ b/src/cheri/insns/modesw_32bit.adoc
@@ -1,11 +1,8 @@
 <<<
 
-[#MODESW_INT,reftext="{MODESW_INT}"]
-==== {MODESW_INT}
-See <<MODESW_CAP>>.
-
-[#MODESW_CAP,reftext="{MODESW_CAP}"]
-==== {MODESW_CAP}
+==== {MODESW_CAP}, {MODESW_INT}
+anchor:MODESW_CAP[{MODESW_CAP}]
+anchor:MODESW_INT[{MODESW_INT}]
 
 Synopsis::
 Switch execution mode to {cheri_cap_mode_name} ({MODESW_CAP}), or {cheri_int_mode_name} ({MODESW_INT}), 32-bit encodings

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -1,12 +1,8 @@
 <<<
 
-[#SCBNDSI,reftext="{SCBNDSI}"]
-==== {SCBNDSI}
-
-See <<SCBNDS>>.
-
-[#SCBNDS,reftext="{SCBNDS}"]
-==== {SCBNDS}
+==== {SCBNDS}, {SCBNDSI}
+anchor:SCBNDS[{SCBNDS}]
+anchor:SCBNDSI[{SCBNDSI}]
 
 ifdef::cheri_v9_annotations[]
 NOTE: *CHERI v9 Note:* {SCBNDS} was called CSETBOUNDSEXACT.

--- a/src/cheri/insns/sh1234add_32bit.adoc
+++ b/src/cheri/insns/sh1234add_32bit.adoc
@@ -1,19 +1,11 @@
 <<<
 
-[#SH1ADD_CHERI,reftext="{SH1ADD_CHERI}"]
-==== {SH1ADD_CHERI}
-See <<SH4ADD_CHERI>>.
+[#SH4ADD_CHERI]
+==== {SH1ADD_CHERI}, {SH2ADD_CHERI}, {SH3ADD_CHERI}, {SH4ADD_CHERI} ({cheri_base64_ext_name})
 
-[#SH2ADD_CHERI,reftext="{SH2ADD_CHERI}"]
-==== {SH2ADD_CHERI}
-See <<SH4ADD_CHERI>>.
-
-[#SH3ADD_CHERI,reftext="{SH3ADD_CHERI}"]
-==== {SH3ADD_CHERI}
-See <<SH4ADD_CHERI>>.
-
-[#SH4ADD_CHERI,reftext="{SH4ADD_CHERI} ({cheri_base64_ext_name})"]
-==== {SH4ADD_CHERI} ({cheri_base64_ext_name})
+anchor:SH1ADD_CHERI[]
+anchor:SH2ADD_CHERI[]
+anchor:SH3ADD_CHERI[]
 
 Synopsis::
 Shift by _n_ and add for address generation ({SH1ADD_CHERI}, {SH2ADD_CHERI}, {SH3ADD_CHERI}, {SH4ADD_CHERI})

--- a/src/cheri/insns/sh1234add_32bit.adoc
+++ b/src/cheri/insns/sh1234add_32bit.adoc
@@ -1,11 +1,11 @@
 <<<
 
-[#SH4ADD_CHERI]
 ==== {SH1ADD_CHERI}, {SH2ADD_CHERI}, {SH3ADD_CHERI}, {SH4ADD_CHERI} ({cheri_base64_ext_name})
 
-anchor:SH1ADD_CHERI[]
-anchor:SH2ADD_CHERI[]
-anchor:SH3ADD_CHERI[]
+anchor:SH1ADD_CHERI[{SH1ADD_CHERI}]
+anchor:SH2ADD_CHERI[{SH2ADD_CHERI}]
+anchor:SH3ADD_CHERI[{SH3ADD_CHERI}]
+anchor:SH4ADD_CHERI[{SH4ADD_CHERI}]
 
 Synopsis::
 Shift by _n_ and add for address generation ({SH1ADD_CHERI}, {SH2ADD_CHERI}, {SH3ADD_CHERI}, {SH4ADD_CHERI})

--- a/src/cheri/insns/sh1234add_uw_32bit.adoc
+++ b/src/cheri/insns/sh1234add_uw_32bit.adoc
@@ -1,19 +1,11 @@
 <<<
 
-[#SH1ADD_UW_CHERI,reftext="{SH1ADD_UW_CHERI} ({cheri_base64_ext_name})"]
-==== {SH1ADD_UW_CHERI} ({cheri_base64_ext_name})
-See <<SH4ADD_UW_CHERI>>.
+[#SH4ADD_UW_CHERI]
+==== {SH1ADD_UW_CHERI}, {SH2ADD_UW_CHERI}, {SH3ADD_UW_CHERI}, {SH4ADD_UW_CHERI}  ({cheri_base64_ext_name})
 
-[#SH2ADD_UW_CHERI,reftext="{SH2ADD_UW_CHERI} ({cheri_base64_ext_name})"]
-==== {SH2ADD_UW_CHERI} ({cheri_base64_ext_name})
-See <<SH4ADD_UW_CHERI>>.
-
-[#SH3ADD_UW_CHERI,reftext="{SH3ADD_UW_CHERI} ({cheri_base64_ext_name})"]
-==== {SH3ADD_UW_CHERI} ({cheri_base64_ext_name})
-See <<SH4ADD_UW_CHERI>>.
-
-[#SH4ADD_UW_CHERI,reftext="{SH4ADD_UW_CHERI} ({cheri_base64_ext_name})"]
-==== {SH4ADD_UW_CHERI} ({cheri_base64_ext_name})
+anchor:SH1ADD_UW_CHERI[]
+anchor:SH2ADD_UW_CHERI[]
+anchor:SH3ADD_UW_CHERI[]
 
 Synopsis::
 Shift by _n_ and add unsigned words for address generation ({SH1ADD_UW_CHERI}, {SH2ADD_UW_CHERI}, {SH3ADD_UW_CHERI}, {SH4ADD_UW_CHERI})

--- a/src/cheri/insns/sh1234add_uw_32bit.adoc
+++ b/src/cheri/insns/sh1234add_uw_32bit.adoc
@@ -1,11 +1,11 @@
 <<<
 
-[#SH4ADD_UW_CHERI]
 ==== {SH1ADD_UW_CHERI}, {SH2ADD_UW_CHERI}, {SH3ADD_UW_CHERI}, {SH4ADD_UW_CHERI}  ({cheri_base64_ext_name})
 
-anchor:SH1ADD_UW_CHERI[]
-anchor:SH2ADD_UW_CHERI[]
-anchor:SH3ADD_UW_CHERI[]
+anchor:SH1ADD_UW_CHERI[{SH1ADD_UW_CHERI}]
+anchor:SH2ADD_UW_CHERI[{SH2ADD_UW_CHERI}]
+anchor:SH3ADD_UW_CHERI[{SH3ADD_UW_CHERI}]
+anchor:SH4ADD_UW_CHERI[{SH4ADD_UW_CHERI}]
 
 Synopsis::
 Shift by _n_ and add unsigned words for address generation ({SH1ADD_UW_CHERI}, {SH2ADD_UW_CHERI}, {SH3ADD_UW_CHERI}, {SH4ADD_UW_CHERI})

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -1191,18 +1191,17 @@ These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_
 |<<AUIPC_CHERI>>            | {AUIPC_CHERI_DESC}
 |<<JAL_CHERI>>              | {JAL_CHERI_DESC}
 |<<JALR_CHERI>>             | {JALR_CHERI_DESC}
-|<<BEQ_CHERI, BEQ({cheri_base_ext_name})>> | {BEQ_CHERI_DESC}
-|<<BNE_CHERI, BNE({cheri_base_ext_name})>> | {BNE_CHERI_DESC}
+|<<BEQ_CHERI, BEQ ({cheri_base_ext_name})>> | {BEQ_CHERI_DESC}
+|<<BNE_CHERI, BNE ({cheri_base_ext_name})>> | {BNE_CHERI_DESC}
 |=======================
 
 include::insns/auipc_32bit.adoc[]
 include::insns/jal_32bit.adoc[]
 include::insns/jalr_32bit.adoc[]
 
-[#BEQ_CHERI]
 ==== BEQ, BNE ({cheri_base_ext_name})
-
-anchor:BNE_CHERI[]
+anchor:BEQ_CHERI[BEQ ({cheri_base_ext_name})]
+anchor:BNE_CHERI[BNE ({cheri_base_ext_name})]
 
 For `beq` and `bne` only, if `rs1≤rs2` then the encoding is _reserved_.
 This includes all encodings with `rs1=rs2`.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -1191,21 +1191,18 @@ These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_
 |<<AUIPC_CHERI>>            | {AUIPC_CHERI_DESC}
 |<<JAL_CHERI>>              | {JAL_CHERI_DESC}
 |<<JALR_CHERI>>             | {JALR_CHERI_DESC}
-|<<BEQ_CHERI>>              | {BEQ_CHERI_DESC}
-|<<BNE_CHERI>>              | {BNE_CHERI_DESC}
+|<<BEQ_CHERI, BEQ({cheri_base_ext_name})>> | {BEQ_CHERI_DESC}
+|<<BNE_CHERI, BNE({cheri_base_ext_name})>> | {BNE_CHERI_DESC}
 |=======================
 
 include::insns/auipc_32bit.adoc[]
 include::insns/jal_32bit.adoc[]
 include::insns/jalr_32bit.adoc[]
 
-[#BEQ_CHERI,reftext="BEQ ({cheri_base_ext_name})"]
-==== BEQ ({cheri_base_ext_name})
-
-See <<BNE_CHERI>>.
-
-[#BNE_CHERI,reftext="BNE ({cheri_base_ext_name})"]
+[#BEQ_CHERI]
 ==== BEQ, BNE ({cheri_base_ext_name})
+
+anchor:BNE_CHERI[]
 
 For `beq` and `bne` only, if `rs1≤rs2` then the encoding is _reserved_.
 This includes all encodings with `rs1=rs2`.


### PR DESCRIPTION
Allow multiple xrefs to a single section.
It looks like the asciidoc anchor:name[reflect] syntax.

Once all the names are finalised we can abolish all the mnemonic variables and just have hard coded names.
