### PR TITLE
Convert leftover editorial notes into ARC-NOTEs

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -402,7 +402,7 @@ NOTE: In the table below `auth_cap` is `{cs1}`, unless {cheri_default_ext_name} 
 [#CHERI_SPEC,reftext="CHERI Exceptions and speculative execution"]
 === CHERI Exceptions and speculative execution
 
-NOTE: Not sure where this small section should go, or even if it should be expanded and paced in a supporting document.
+NOTE: #ARC-NOTE: Please advise whether this section should remain in this chapter, or whether it should be expanded and placed in a supporting document.#
 
 NOTE: CHERI adds architectural guarantees that can prove to be micro-architecturally useful for reducing side-channels caused by speculative-execution.
  +

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -2,7 +2,7 @@
 == CHERI System Implications
 
 ifdef::cheri_standalone_spec[]
-WARNING: It's unclear where this section should go, probably in supporting documentation.
+NOTE: #ARC-NOTE: Please advise whether this appendix should remain in this specification or move to supporting documentation.#
 endif::[]
 
 CHERI processors need memory systems that support the {ctag}s in memory.


### PR DESCRIPTION
The speculative-execution section and the system-implications appendix
still contained informal author notes.  Turn them into explicit
ARC-NOTE questions (matching the existing ARC-NOTE style) so ARC can
answer them during review.  Also fixes the "paced" typo.
