### PR TITLE
Drop stale suggested assembly syntax from YADD/YADDI

### DIFF
--- a/src/cheri/insns/cadd_32bit.adoc
+++ b/src/cheri/insns/cadd_32bit.adoc
@@ -20,10 +20,6 @@ Mnemonic::
 `{cadd}  {cd}, {cs1}, rs2` +
 `{caddi} {cd}, {cs1}, imm`
 
-Suggested assembly syntax::
-`ADD {cd}, {cs1}, rs2` +
-`ADDI {cd}, {cs1}, imm`
-
 Encoding::
 include::wavedrom/cadd.adoc[]
 


### PR DESCRIPTION
The ADD/ADDI aliases date back to when capability and integer registers
had separate names, so the operands disambiguated the encoding.  With
unified register names the alias would be ambiguous with integer
ADD/ADDI, which have separate encodings and different semantics.

Extracted from #1126
