### PR TITLE
Specify that SRLIY encodings with shamt != XLEN are reserved

### DIFF
--- a/src/cheri/insns/gchi_32bit.adoc
+++ b/src/cheri/insns/gchi_32bit.adoc
@@ -15,9 +15,11 @@ include::wavedrom/srliy.adoc[]
 Description::
 Logical right shift of Y register `rs1` to `rd`, zero-filling the upper bits of the result.
 Set `rd.tag=0`.
++
+The only valid shift amount is `XLEN` (as required by <<GCHI>>).
+Encodings with any other shift amount are _reserved_.
 
-NOTE: The only valid shift amount is `XLEN` (as required by <<GCHI>>).
-A future extension may add an arbitrary shift distance.
+NOTE: A future extension may add an arbitrary shift distance.
 
 Operation::
 // SRLIY is not in the Sail model yet.


### PR DESCRIPTION
The behavior for other shift amounts was unstated; make the valid
shift amount normative text and mark all other encodings reserved,
leaving the future-extension remark as the non-normative note.

Extracted from #1126
