### PR TITLE
Reword AP-field encoding legality statement

### DIFF
--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -59,7 +59,7 @@ endif::[]
 ==== Architectural Permissions (AP) Encoding
 
 The permissions field is {cap_rv64_perms_width} bits wide and is encoded using one bit per architectural permission as shown in xref:cap_perms_encoding64[xrefstyle=short].
-It is only legal to encode a subset of all combinations, but this capability encoding does not make use of this redundancy as there are sufficient reserved bits.
+Some bit patterns are _reserved_ because they encode illegal combinations of permissions (see xref:sec_permission_transitions[xrefstyle=short]).
 
 .Encoding of architectural permissions for {rv64y_uni_base_name}
 [#cap_perms_encoding64,align="center",options=header,cols="^10%,90%",width="75%"]
@@ -86,7 +86,7 @@ There are 9 bits in total allocated to the <<AP-field>> and the <<p_bit>>.
 * The total valid combinations of X, ASR and P are 5.
 * The two groups are fully orthogonal.
 
-Therefore there are 90 valid combinations encoded in 9-bits, which is inefficient.
+Therefore there are 90 valid combinations encoded in 9-bits.
 
 Future extensions or capability encoding formats may address this by implementing a more compact joint <<AP-field>> and <<p_bit>> encoding that is fully _compatible for all software_ to increase the number of reserved bits.
 


### PR DESCRIPTION
Say directly that some bit patterns are reserved because they encode
illegal permission combinations, with a link to the permission
transition rules, and drop the editorializing "which is inefficient".

Extracted from #1126
