### PR TITLE
Fix tag note on YMODEW

### DIFF
--- a/src/cheri/insns/scmode_32bit.adoc
+++ b/src/cheri/insns/scmode_32bit.adoc
@@ -30,7 +30,7 @@ Otherwise, if `{cs1}` grants <<x_perm>> then update the <<p_bit>> of `{cd}` to:
 +
 2. {cheri_int_mode_name} if the least significant bit of `rs2` is {INT_MODE_VALUE}.
 +
-include::no_tag_affect.adoc[]
+NOTE: The value of `{cs1}.tag` is not checked and is propagated unchanged to `{cd}`.
 
 Operation ::
 +


### PR DESCRIPTION
YMODEW copies rs1 including its tag to rd, so "does not affect the
result" was wrong; the tag is not checked but is propagated.

Extracted from #1126
