### PR TITLE
Remove stale branch-execution wording from capability checks

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -881,7 +881,7 @@ Instruction fetches and data memory accesses raise an exception if the access is
 * All store instructions require <<w_perm>> and are authorized by the capability in `{cs1}`
 * All instruction fetches require <<x_perm>> in <<pcc>>
 
-Instruction fetch and branch execution are authorized by the program counter capability which extends the PC.
+Instruction fetches are authorized by the program counter capability (<<pcc>>) which extends the *pc*.
 
 NOTE: This allows code fetch to be bounded, preventing a wide range of attacks that subvert control flow with non-capability data.
 


### PR DESCRIPTION
Branches are no longer checked at the branch source (the check happens
on fetching the target), so only instruction fetches are authorized by
the program counter capability.  Also link pcc and use consistent pc
capitalization.

Extracted from #1126
