### PR TITLE
Avoid undefined mode terminology in the Zca chapter opening

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -1241,7 +1241,8 @@ ifdef::cheri_standalone_spec[]
 [#rvy_zca_insn_table, reftext="{rvy_zca_ext_name}"]
 == Zca ({cheri_base_ext_name} added and modified instructions)
 
-Zcf (RV32) and Zcd (RV64) are incompatible with {cheri_base_ext_name} harts executing in {cheri_cap_mode_name}.
+Zcf (RV32) and Zcd (RV64) are incompatible with the {cheri_base_ext_name} base ISA, as their encodings are reused for the capability loads and stores below.
+On harts that also implement {cheri_default_ext_name}, these encodings revert to Zcf/Zcd when executing in {cheri_int_mode_name} (see xref:cheri_execution_mode[xrefstyle=full]).
 
 .{rvy_zca_ext_name} instruction extension
 [#{rvy_zca_file_name}]


### PR DESCRIPTION
The chapter referred to Capability Pointer Mode ten chapters before the
CHERI Pointer Modes are defined, and a pure RVY hart has no modes at
all.  State the incompatibility in terms of the base ISA and add a
forward reference for the Zyhybrid mode behavior.

Extracted from #1126
