### PR TITLE
Fix mangled JALR Operation listing

### DIFF
--- a/src/cheri/insns/jalr_32bit.adoc
+++ b/src/cheri/insns/jalr_32bit.adoc
@@ -65,7 +65,9 @@ NOTE: A future extension may raise an exception on the <<JALR_CHERI>> instructio
 Operation::
 // Adapted from the Sail JALR_capmode clause with the tag/seal/permission/bounds
 // checks removed (those are taken on fetch now).
-[source,SAIL,subs="verbatim,quotes"]
+// Note: do not add the "quotes" substitution here - it corrupts the listing by
+// interpreting the underscores and comment markers as formatting pairs.
+[source,SAIL]
 ----
 let cs1_val = C(cs1);
 let off : xlenbits = sign_extend(imm);


### PR DESCRIPTION
The quotes substitution breaks the rendering of the sail semantics
