### PR TITLE
Make misa.y=0 condition implementation defined

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -159,6 +159,7 @@ These implicit check registers are <<pcc>>, `__x__tvec`, `__x__epc`.
 NOTE: The list includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemented.
 
 NOTE: This restriction ensures M-mode software cannot drop CHERI checks by modifying <<misa_y,misa>> once they have been configured.
+ The exact behavior of the restriction is implementation defined, and can be as simple as detecting whether any CSR writes or <<pcc>> metadata updates have been executed in {cheri_cap_mode_name}.
 
 Either I or E is _also_ set to show how many registers are present.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -159,7 +159,7 @@ These implicit check registers are <<pcc>>, `__x__tvec`, `__x__epc`.
 NOTE: The list includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemented.
 
 NOTE: This restriction ensures M-mode software cannot drop CHERI checks by modifying <<misa_y,misa>> once they have been configured.
- The exact behavior of the restriction is implementation defined, and can be as simple as detecting whether any  metadata updates to the relevant CSRs, or the <<pcc>>, have been executed at all in {cheri_cap_mode_name}.
+ The exact behavior of the restriction is implementation defined, and does not need to, for example, check that capability bounds have been narrowed and then reprogrammed _back_ to infinity. Detecting any bounds reduction is sufficient.
 
 Either I or E is _also_ set to show how many registers are present.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -159,7 +159,7 @@ These implicit check registers are <<pcc>>, `__x__tvec`, `__x__epc`.
 NOTE: The list includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemented.
 
 NOTE: This restriction ensures M-mode software cannot drop CHERI checks by modifying <<misa_y,misa>> once they have been configured.
- The exact behavior of the restriction is implementation defined, and can be as simple as detecting whether any CSR writes or <<pcc>> metadata updates have been executed in {cheri_cap_mode_name}.
+ The exact behavior of the restriction is implementation defined, and can be as simple as detecting whether any  metadata updates to the relevant CSRs, or the <<pcc>>, have been executed at all in {cheri_cap_mode_name}.
 
 Either I or E is _also_ set to show how many registers are present.
 


### PR DESCRIPTION
This is to make the misa.y=0 detection simpler in the hardware.