### PR TITLE
Shrink the placeholder-references section

### DIFF
--- a/src/cheri/app-standalone-unpriv-refs.adoc
+++ b/src/cheri/app-standalone-unpriv-refs.adoc
@@ -6,33 +6,17 @@ WARNING: This chapter only exists for the standalone document to allow reference
 
 [[rv32]]RV32I::
 See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
-[[rv32e]]RV32E and RV64E::
-See Chapter _RV32E and RV64E Base Integer Instruction Sets_ in cite:[riscv-unpriv-spec].
 [[gprs]]General purpose registers::
 See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
 [[ldst]]Load and Store Instructions::
 See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
-[[int-comp-lui-aiupc]]Integer Register-Immediate Instructions::
-See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
-[[ct-insns]]Control Transfer Instructions::
-See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
-[[atomics]]Atomics::
-See Chapter _"A" Extension for Atomic Instructions_ in cite:[riscv-unpriv-spec].
-[[zba]]Zba::
-See Chapter _"B" Extension for Bit Manipulation_ in cite:[riscv-unpriv-spec].
-[[Zicbom]]Zicbom::
-See Chapter _"CMO" Extensions for Base Cache Management Operation ISA_ in cite:[riscv-unpriv-spec].
 [[Zcmt]]Zcmt::
 See Chapter _"Zc*" Extension for Code Size Reduction_ in cite:[riscv-unpriv-spec].
 [[Zcmp]]Zcmp::
 See Chapter _"Zc*" Extension for Code Size Reduction_ in cite:[riscv-unpriv-spec].
+ifndef::cheri_ratification_v1_only[]
 [[jvt]]jvt::
 See Chapter _"Zc*" Extension for Code Size Reduction_ in cite:[riscv-unpriv-spec].
-[[sec:amo]]Zaamo::
-See Chapter _"A" Extension for Atomic Instructions_ in cite:[riscv-unpriv-spec].
-[[zalrsc_cheri]]"Zalrsc" for {cheri_base_ext_name}::
-See Chapter _"A" Extension for Atomic Instructions_ in cite:[riscv-unpriv-spec].
-[[zaamo_cheri]]"Zaamo" for {cheri_base_ext_name}::
-See Chapter _"A" Extension for Atomic Instructions_ in cite:[riscv-unpriv-spec].
+endif::[]
 
 endif::[]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -1160,7 +1160,7 @@ These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_
 
 * Floating-point loads and stores.
 * <<section_cheri_vector_integration,Vector load and stores>>.
-* Atomic memory accesses, see <<zaamo_cheri>> and <<zalrsc_cheri>>.
+* Atomic memory accesses, see <<rvy_zaamo_insn_table>> and <<rvy_zalrsc_insn_table>>.
 
 .Changed RISC-V base ISA load/store instructions summary in {cheri_base_ext_name}
 [#tab_cap_base_ldst_summary,%autowidth,options=header,align="center",cols="2,4"]

--- a/src/cheri/zylevelsN.adoc
+++ b/src/cheri/zylevelsN.adoc
@@ -73,7 +73,7 @@ But unlike architectural permissions, the _Capability Level_ can be reduced even
 
 TODO
 
-=== Interaction with <<LOAD_CAP>> and <<zalrsc_cheri>>
+=== Interaction with <<LOAD_CAP>> and <<rvy_zalrsc_insn_table>>
 
 TODO
 
@@ -83,7 +83,7 @@ If `{cd}.tag=1`, `{cd}` is sealed and `{cs1}` does not grant <<zylevelsN_el_perm
 +
 NOTE: Missing <<zylevelsN_el_perm>> also affects the level of sealed capabilities since notionally the <<zylevelsN_cl_field>> of a capability is not a permission but rather a data flow label attached to the loaded value.
 
-=== Interaction with <<STORE_CAP>> and <<zalrsc_cheri>>
+=== Interaction with <<STORE_CAP>> and <<rvy_zalrsc_insn_table>>
 
 TODO
 


### PR DESCRIPTION
Delete the seven entries whose anchors are referenced nowhere, point
zalrsc_cheri/zaamo_cheri at the actual chapters in the standalone
build instead of redirecting readers to the upstream manual, and only
render the jvt entry when Zcmt content is included.  The v1.0 build
now renders five entries instead of fifteen.

Extracted from #1126
