### PR TITLE
Clarify Load Capability Fault conditions

### DIFF
--- a/src/cheri/cheri-pte-ext.adoc
+++ b/src/cheri/cheri-pte-ext.adoc
@@ -18,9 +18,10 @@ endif::[]
 
 {cheri_priv_crg_ext} implies Sv39.
 
-The {cheri_priv_crg_ext} extension is enabled when the `{pte_cap_fc_enable}` bit is set.
+The {cheri_priv_crg_ext} extension is enabled when the `sstatus.{pte_cap_fc_enable}` bit is set.
 
-NOTE: `sstatus.{pte_cap_fc_enable}` affects the interpretation of the _pte_._rvy_ field.
+When `sstatus.{pte_cap_fc_enable}`=0, only _pte_._{rv64y_pte4_field_name_lc}[3]_ (_pte_._{pte_cap_rw_name_lc}_) has meaning: it completely enables or disables storing capabilities to the page, as defined in xref:section_pte_rvy[xrefstyle=full].
+When `sstatus.{pte_cap_fc_enable}`=1, the entire _pte_._{rv64y_pte4_field_name_lc}_ field is redefined as described in this chapter.
 
 The extension adds the ability for supervisor-mode software to quickly enable trapping loads of capabilities from all pages of memory, incrementally allow loads of capabilities from such pages, and track stores of capabilities to all pages of memory.
 Applied to userspace pages, this has been shown to allow the operating system to implement capability revocation schemes, which allow userspace memory allocators to deterministically guard against use-after-reallocation cite:[cornucopia-reloaded].
@@ -51,12 +52,10 @@ NOTE: It may make sense to subdivide this into two extensions as _Capability Dir
 
 === {cheri_excep_name_pte_ld}s
 
-_pte_._{pte_cap_r_name_lc}_ and _pte_._{pte_cap_crg_pte_name_lc}_ are used to enable capability loads or AMOs to write a {ctag} to `{cd}`.
+_pte_._{pte_cap_r_name_lc}_ and _pte_._{pte_cap_crg_pte_name_lc}_ control whether capability loads or AMOs write the loaded {ctag} to `{cd}`.
 
-When _pte_._{pte_cap_r_name_lc}_ is clear, _pte_._{pte_cap_crg_pte_name_lc}_ controls whether capabilities can write a {ctag} to `{cd}`:
-
-* When it is clear, {ctag}s cannot be written to `{cd}`.
-* When it is set, they can.
+When _pte_._{pte_cap_r_name_lc}_ is clear, _pte_._{pte_cap_crg_pte_name_lc}_ selects the behavior of capability loads:
+if _pte_._{pte_cap_crg_pte_name_lc}_ is clear, the loaded {ctag} is written to `{cd}` as zero; if _pte_._{pte_cap_crg_pte_name_lc}_ is set, the load operates as normal.
 
 When _pte_._{pte_cap_r_name_lc}_ is set, _pte_._{pte_cap_crg_pte_name_lc}_ can be used to trap on capability loads or AMOs when it does not match the Capability Read Generation value that is represented by the value of `sstatus.U{pte_cap_crg_pte_name}` for userspace pages (_pte_._u=1_) or `sstatus.S{pte_cap_crg_pte_name}` for kernel pages (_pte_._u=0_).
 
@@ -66,13 +65,15 @@ The implementation raises a {cheri_excep_name_pte_ld} when, in addition to the r
 . _pte_._{pte_cap_r_name_lc}_ is set.
 . if _pte_._u=1_, _pte_._{pte_cap_crg_pte_name_lc}_ does not equal `sstatus.U{pte_cap_crg_pte_name}`.
 . if _pte_._u=0_, _pte_._{pte_cap_crg_pte_name_lc}_ does not equal `sstatus.S{pte_cap_crg_pte_name}`.
-. Optionally, the loaded {ctag} is set^1^.
+. The loaded {ctag} is set, unless the implementation traps conservatively^1^.
 . Any other platform specific rules have not forced the loaded {ctag} to be clear.
+
+^1^ Implementations that trap conservatively may raise the fault regardless of the value of the loaded {ctag}, as shown in <<pte_rvy_load_summary>>.
 
 [NOTE]
 ====
 
-^1^Checking the value of the {ctag} requires taking data dependent exceptions on loaded capabilities for loads or AMOs.
+Checking the value of the {ctag} requires taking data dependent exceptions on loaded capabilities for loads or AMOs.
 Ideally all implementations would trap precisely (taking the {ctag} into account in all cases) rather than conservatively (trapping more often, potentially on every loaded capability).
 However, the loaded {ctag} may not be available in all implementations when determining whether to raise the exception, and therefore flexibility is permitted.
 As a result, the software is required to be tolerant of raising the trap when the {ctag} is not set, potentially resulting in spurious traps from pages that have _pte_._{pte_cap_r_name_lc}=1_, and so are likely to store valid capabilities.
@@ -103,6 +104,7 @@ NOTE: {cheri_excep_name_pte_ld}s may be used to implement the load-barrier primi
 NOTE: In the case of AMOs that could trigger both a {cheri_excep_name_pte_st}, due to storing a valid {ctag}, and a {cheri_excep_name_pte_ld}, the {cheri_excep_name_pte_st} takes priority as shown in <<exception-priority-cheri>>.
 
 
+[#sec_cap_dirty_tracking,reftext="Capability Dirty Tracking"]
 === Capability Dirty Tracking
 
 When _pte_._{pte_cap_w_name_lc}_ is clear, capability stores or AMOs where the to-be-stored {ctag} is set will raise a {cheri_excep_name_pte_st}.

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -701,6 +701,7 @@ Such sharing through virtual memory is on the page granularity, so preventing ca
 
 ====
 
+[#section_pte_rvy,reftext="_pte_._rvy_ field"]
 === The _pte_._{cheri_base_ext_name_lc}_ field for capability flow control
 
 [NOTE]
@@ -732,7 +733,8 @@ If _pte_._{pte_cap_rw_name_lc}_=1 then:
 
 * All capability loads and capability stores operate as normal.
 
-NOTE: rvy[2:0] follow the standard reserved behavior for PTE bits.
+NOTE: The reserved bits _pte_._{rv64y_pte4_field_name_lc}[2:0]_ follow the standard reserved behavior for PTE bits.
+They are allocated by <<section_cheri_priv_crg_ext,{cheri_priv_crg_ext}>>, which redefines the entire _pte_._{rv64y_pte4_field_name_lc}_ field when enabled.
 
 [#section_invalid_addr_conv,reftext="Invalid address conversion"]
 === Invalid Virtual Address Handling


### PR DESCRIPTION
Rewrite the description of pte.yr/pte.yrg for loads and replace the confusing "Optionally, the loaded tag is set" list item with a plain statement of the conservative-trapping allowance.

Also note in the base definition that the reserved bits are allocated by Svyrg, which redefines the whole field when enabled, and state in the Svyrg chapter that with YRGE=0 only pte.rvy[3] (pte.y) has meaning.

Extracted from #1126