### PR TITLE
Explain why YBNDSRW sail checks rs1 instead of rounded bounds

### DIFF
--- a/src/cheri/insns/scbndsr_32bit.adoc
+++ b/src/cheri/insns/scbndsr_32bit.adoc
@@ -38,3 +38,5 @@ include::malformed_cs1_clear_tag.adoc[]
 Operation::
 +
 sail::execute[clause="SCBNDSR(_, _, _)",part=body,unindent]
+
+NOTE: Checking only the _requested_ region with `inCapBoundsNoWrap` is sufficient, since the rounding performed by `setCapBounds` can never grow the bounds beyond those of `{cs1}`.

--- a/src/cheri/insns/ysunseal_32bit.adoc
+++ b/src/cheri/insns/ysunseal_32bit.adoc
@@ -1,3 +1,4 @@
+
 <<<
 
 [#YSUNSEAL,reftext="{YSUNSEAL}"]


### PR DESCRIPTION
The Sail only checks the requested region against rs1's bounds; state
the bounds-rounding containment guarantee that makes this sufficient
so the tag-clearing bullet is not misread as a separate dynamic
check.

Also add a separating blank line before ysunseal page break. The <<< on
the first line was glued onto the trailing paragraph of the preceding
YBNDSRW page and rendered literally.
