### PR TITLE
Note why the YTYPER Sail reads the sealed boolean

### DIFF
--- a/src/cheri/insns/gctype_32bit.adoc
+++ b/src/cheri/insns/gctype_32bit.adoc
@@ -26,3 +26,6 @@ include::no_tag_affect.adoc[]
 Operation::
 +
 sail::execute[clause="GCTYPE(_, _)",part=body,unindent]
+
+NOTE: The Sail model stores the 1-bit <<sec_cap_type>> of <<rv64y_cap_description>> as the boolean `sealed`.
+Capability encoding formats with a wider <<sec_cap_type>> must return the full field value.


### PR DESCRIPTION
The model stores the 1-bit CT-field as the boolean sealed; wider
CT-field encodings must return the full field value.
