### PR TITLE
Remove stale two-register phrasing from mtvec

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -35,10 +35,9 @@ NOTE: Examples of WARL behavior include always setting <<x_perm>> to 1 and setti
 
 NOTE: Care must be taken however that suitable root capabilities are available to software after reset if this CSR does not represent one.
 
-When traps are taken into machine mode, the `pc` is updated following the standard `mtvec` behavior.
-The {ctag} and metadata from <<mtvec_y>> are also written to the <<pcc>>.
+When a trap is taken into machine mode, the capability in <<mtvec_y>> is installed in the <<pcc>>, with the address determined by the standard `mtvec` behavior.
 
-As with the standard `mtvec` register, the address observed through <<mtvec_y>> is not simply the stored base address:
+As in the standard `mtvec` definition, the address observed through <<mtvec_y>> is not simply the stored base address:
 
 . `mtvec.address[1:0]` holds the MODE field, which selects the trap-vector mode and does not form part of the trap-vector base address.
 . When MODE=Vectored, the effective trap-vector address is the base address plus four times the interrupt cause.
@@ -56,7 +55,7 @@ This has two consequences:
 
 NOTE: The capability in <<mtvec_y>> is _not_ unsealed when it is written to <<pcc>>, unlike other CSRs such as <<mepc_y>>.
 
-<<mtvec_y>> follows the rule from `mtvec` about not needing to be able to hold all possible <<section_invalid_addr_conv, invalid addresses>>.
+Following the standard `mtvec` rules, <<mtvec_y>> need not be able to hold all possible <<section_invalid_addr_conv, invalid addresses>>.
 
 [#menvcfg_y,reftext="menvcfg ({cheri_base_ext_name})"]
 ==== Machine Environment Configuration (`menvcfg`) Register


### PR DESCRIPTION
The text still described the capability CSR and the classic CSR as two
separate registers, dating back to the dropped mepcc/mtvecc naming scheme.
Describe a single widened register whose address field follows the standard
rules, and simplify the unreadable representability paragraph.
