### PR TITLE
Align the PMA SC.Y tag-store-fault rule with dirty tracking

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -429,7 +429,8 @@ There are three levels of support:
 |=========================================================================================
 
 ^1^ The access fault is triggered on all capability stores or atomics such as <<STORE_CAP>> or <<AMOSWAP_CAP>> when <<c_perm>> and <<w_perm>> are granted and the to-be-stored {ctag} is set to one.
- For <<STORE_COND_CAP>>, the access fault is raised if the to-be-stored {ctag} is set in {cs2} even when the store fails.
+ For <<STORE_COND_CAP>>, the access fault is raised if the to-be-stored {ctag} is set in {cs2}, independent of the reservation outcome.
+ This matches the semantics of SC.* with regard to _pte_._d_ (see also xref:sec_cap_dirty_tracking[xrefstyle=short]).
 
 Only memory regions that have the _CHERI {ctag_title}_ PMA require storage for {ctag}s.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -429,7 +429,7 @@ There are three levels of support:
 |=========================================================================================
 
 ^1^ The access fault is triggered on all capability stores or atomics such as <<STORE_CAP>> or <<AMOSWAP_CAP>> when <<c_perm>> and <<w_perm>> are granted and the to-be-stored {ctag} is set to one.
- For <<STORE_COND_CAP>>, the access fault is raised if the to-be-stored {ctag} is set in {cs2}, independent of the reservation outcome.
+ For <<STORE_COND_CAP>>, the access fault is raised if the to-be-stored {ctag} is set in `{cs2}`, independent of the reservation outcome.
  This matches the semantics of SC.* with regard to _pte_._d_ (see also xref:sec_cap_dirty_tracking[xrefstyle=short]).
 
 Only memory regions that have the _CHERI {ctag_title}_ PMA require storage for {ctag}s.


### PR DESCRIPTION
Say the fault is raised independent of the reservation outcome and
cross-reference the Capability Dirty Tracking section, which already
explains that this matches SC.* semantics for pte.d.
