### PR TITLE
Bump NEXT_VERSION to v0.9.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ DOCS := riscv-privileged riscv-unprivileged riscv-cheri riscv-cheri-debug riscv-
 
 RELEASE_TYPE ?= draft
 GIT_SHORT_HASH ?= -$(shell git rev-parse --short HEAD || true)
-NEXT_VERSION = v0.9.8.2
+NEXT_VERSION = v0.9.9
 ifeq ($(RELEASE_TYPE), draft)
 CHERI_SPEC_VERSION ?= $(NEXT_VERSION)-draft$(GIT_SHORT_HASH)
 else


### PR DESCRIPTION
This version addresses the ARC feedback on 0.9.8.2
