### PR TITLE
Upload riscv-cheri-debug artifacts in CI and release workflows

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -91,6 +91,29 @@ jobs:
           path: ${{ github.workspace }}/build/riscv-cheri.epub
           retention-days: 7
 
+      # Upload the riscv-cheri-debug PDF file
+      - name: Upload riscv-cheri-debug.pdf
+        if: steps.build_files.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv-cheri-debug-${{ env.SHORT_SHA }}.pdf
+          path: ${{ github.workspace }}/build/riscv-cheri-debug.pdf
+          retention-days: 7
+      - name: Upload riscv-cheri-debug.html
+        if: steps.build_files.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv-cheri-debug-${{ env.SHORT_SHA }}.html
+          path: ${{ github.workspace }}/build/riscv-cheri-debug.html
+          retention-days: 7
+      - name: Upload riscv-cheri-debug.epub
+        if: steps.build_files.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv-cheri-debug-${{ env.SHORT_SHA }}.epub
+          path: ${{ github.workspace }}/build/riscv-cheri-debug.epub
+          retention-days: 7
+
       # Upload the riscv-cheri-full PDF file
       - name: Upload riscv-cheri-full.pdf
         if: steps.build_files.outcome == 'success'
@@ -175,7 +198,7 @@ jobs:
           echo "RELEASE_VERSION=${VERSION}" >> $GITHUB_ENV
 
           cd ${{ github.workspace }}/build
-          for base in riscv-cheri riscv-cheri-full riscv-privileged riscv-unprivileged; do
+          for base in riscv-cheri riscv-cheri-debug riscv-cheri-full riscv-privileged riscv-unprivileged; do
             for ext in pdf html epub; do
               cp "${base}.${ext}" "${base}-${VERSION}.${ext}"
             done

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -55,6 +55,26 @@ jobs:
           name: riscv-cheri-${{ env.SHORT_SHA }}.epub
           path: ${{ github.workspace }}/build/riscv-cheri.epub
 
+      # Upload the riscv-cheri-debug PDF file
+      - name: Upload riscv-cheri-debug.pdf
+        if: steps.build_files.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv-cheri-debug-${{ env.SHORT_SHA }}.pdf
+          path: ${{ github.workspace }}/build/riscv-cheri-debug.pdf
+      - name: Upload riscv-cheri-debug.html
+        if: steps.build_files.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv-cheri-debug-${{ env.SHORT_SHA }}.html
+          path: ${{ github.workspace }}/build/riscv-cheri-debug.html
+      - name: Upload riscv-cheri-debug.epub
+        if: steps.build_files.outcome == 'success'
+        uses: actions/upload-artifact@v7
+        with:
+          name: riscv-cheri-debug-${{ env.SHORT_SHA }}.epub
+          path: ${{ github.workspace }}/build/riscv-cheri-debug.epub
+
       # Upload the riscv-cheri-full PDF file
       - name: Upload riscv-cheri-full.pdf
         if: steps.build_files.outcome == 'success'
@@ -141,6 +161,9 @@ jobs:
             ${{ github.workspace }}/build/riscv-cheri.pdf
             ${{ github.workspace }}/build/riscv-cheri.html
             ${{ github.workspace }}/build/riscv-cheri.epub
+            ${{ github.workspace }}/build/riscv-cheri-debug.pdf
+            ${{ github.workspace }}/build/riscv-cheri-debug.html
+            ${{ github.workspace }}/build/riscv-cheri-debug.epub
             ${{ github.workspace }}/build/riscv-cheri-full.pdf
             ${{ github.workspace }}/build/riscv-cheri-full.html
             ${{ github.workspace }}/build/riscv-cheri-full.epub


### PR DESCRIPTION
The debug build variant was already produced by the Makefile but was
never uploaded as an artifact or included in releases.
