### PR TITLE
Include the CHERI Debug Specification in GitHub Pages and READMEs

### DIFF
--- a/.github/workflows/generate_gh_pages.py
+++ b/.github/workflows/generate_gh_pages.py
@@ -64,12 +64,13 @@ def get_repo_details() -> str:
 def stage_snapshot_local(build_dir: Path) -> None:
     """Stages snapshot from local build files (main branch workflow runs)."""
     print("Staging snapshot from local build...")
-    for spec in ["unprivileged", "privileged", "riscv-cheri", "riscv-cheri-full"]:
+    for spec in ["unprivileged", "privileged", "riscv-cheri", "riscv-cheri-debug", "riscv-cheri-full"]:
         (DIST_DIR / "snapshot" / spec).mkdir(parents=True, exist_ok=True)
 
     shutil.copy(build_dir / "riscv-unprivileged.html", DIST_DIR / "snapshot/unprivileged/index.html")
     shutil.copy(build_dir / "riscv-privileged.html", DIST_DIR / "snapshot/privileged/index.html")
     shutil.copy(build_dir / "riscv-cheri.html", DIST_DIR / "snapshot/riscv-cheri/index.html")
+    shutil.copy(build_dir / "riscv-cheri-debug.html", DIST_DIR / "snapshot/riscv-cheri-debug/index.html")
     shutil.copy(build_dir / "riscv-cheri-full.html", DIST_DIR / "snapshot/riscv-cheri-full/index.html")
 
     # Root index.html remains the latest active spec snapshot
@@ -89,7 +90,7 @@ def stage_snapshot_download(repo: str) -> None:
 
     if pages_url:
         print(f"Pages URL is {pages_url}")
-        for spec in ["unprivileged", "privileged", "riscv-cheri", "riscv-cheri-full"]:
+        for spec in ["unprivileged", "privileged", "riscv-cheri", "riscv-cheri-debug", "riscv-cheri-full"]:
             (DIST_DIR / "snapshot" / spec).mkdir(parents=True, exist_ok=True)
 
         def download_file(url_path: str, dest_path: str) -> None:
@@ -106,13 +107,14 @@ def stage_snapshot_download(repo: str) -> None:
         download_file("snapshot/unprivileged/index.html", "snapshot/unprivileged/index.html")
         download_file("snapshot/privileged/index.html", "snapshot/privileged/index.html")
         download_file("snapshot/riscv-cheri/index.html", "snapshot/riscv-cheri/index.html")
+        download_file("snapshot/riscv-cheri-debug/index.html", "snapshot/riscv-cheri-debug/index.html")
         download_file("snapshot/riscv-cheri-full/index.html", "snapshot/riscv-cheri-full/index.html")
 
         # Root index.html remains the latest active spec snapshot
         download_file("snapshot/riscv-cheri/index.html", "index.html")
     else:
         print("Warning: Creating placeholder snapshots.")
-        for spec in ["unprivileged", "privileged", "riscv-cheri", "riscv-cheri-full"]:
+        for spec in ["unprivileged", "privileged", "riscv-cheri", "riscv-cheri-debug", "riscv-cheri-full"]:
             (DIST_DIR / "snapshot" / spec).mkdir(parents=True, exist_ok=True)
             with open(DIST_DIR / "snapshot" / spec / "index.html", "w") as out_file:
                 out_file.write("Snapshot not available.")
@@ -214,6 +216,8 @@ def generate_snapshot_block() -> str:
                     label = "Unprivileged"
                 elif "privileged" in lower_d:
                     label = "Privileged"
+                elif "debug" in lower_d:
+                    label = "CHERI Debug Specification"
                 elif "cheri" in lower_d:
                     label = "CHERI Specification"
                 else:
@@ -296,6 +300,8 @@ def generate_releases_block(versions: List[str], version_assets: Dict[str, List[
                         label = "Unprivileged"
                     elif "privileged" in lower_spec:
                         label = "Privileged"
+                    elif "debug" in lower_spec:
+                        label = "CHERI Debug Specification"
                     else:
                         label = spec.replace("-", " ").replace("_", " ").title()
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The RISC-V Instruction Set Manual is organized into the following volumes:
 - **HTML snapshots of the latest commit** can be viewed at the following locations:
   - [Standalone CHERI specification](https://riscv.github.io/riscv-cheri/)
   - [Standalone CHERI specification with additional non-frozen chapters](https://riscv.github.io/riscv-cheri/snapshot/riscv-cheri-full/)
+  - [RISC-V Debug Specification for CHERI Extensions](https://riscv.github.io/riscv-cheri/snapshot/riscv-cheri-debug/)
   - [Unprivileged spec](https://riscv.github.io/riscv-cheri/snapshot/unprivileged/)
   - [Privileged spec](https://riscv.github.io/riscv-cheri/snapshot/privileged/)
 

--- a/readme.adoc
+++ b/readme.adoc
@@ -17,6 +17,10 @@ A snapshot of the latest standalone CHERI HTML include non-frozen sections can b
 
 * https://{gh_org}.github.io/{gh_repo}/snapshot/riscv-cheri-full/
 
+A snapshot of the latest RISC-V Debug Specification for CHERI HTML can be found here:
+
+* https://{gh_org}.github.io/{gh_repo}/snapshot/riscv-cheri-debug/
+
 == License
 
 This work is licensed under a Creative Commons Attribution 4.0 International License (CC-BY-4.0). For details, see the link:LICENSE[LICENSE] file.


### PR DESCRIPTION
riscv-cheri-debug was missing from the generated snapshot/versions
pages and from the repo READMEs alongside the other spec variants.
