### PR TITLE
Improve wording for misa.Y writable check

### DIFF
--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -151,15 +151,12 @@ endif::[]
 When the base ISA is {cheri_base_ext_name}, the Y bit is one.
 
 `<<misa_y,misa>>.{CRE}` is a WARL field.
-If the implementation supports a writable <<misa_y,misa>>.{CRE}, the implementation must not allow setting it to zero if any register used for implicit CHERI checks is not currently configured as a root capability.
-Otherwise, the write to <<misa_y,misa>>.{CRE} is ignored.
+If any of <<pcc>>, `__x__tvec`, or `__x__epc` is not currently configured as a root capability then zero is not a legal value for <<misa_y,misa>>.{CRE}.
 
-These implicit check registers are <<pcc>>, `__x__tvec`, `__x__epc`.
-
-NOTE: The list includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemented.
+NOTE: The list also includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemented.
 
 NOTE: This restriction ensures M-mode software cannot drop CHERI checks by modifying <<misa_y,misa>> once they have been configured.
- A simpler conforming implementation could prevent setting <<misa_y,misa>>.{CRE} to zero if the capability metadata of any register used for implicit CHERI checks has ever been written to, rather than dynamically checking the current metadata.
+ A simpler conforming implementation could prevent setting <<misa_y,misa>>.{CRE} to zero if the capability metadata of any of these registers has ever been written to, rather than dynamically checking the current metadata.
 
 Either misa.I or misa.E is _also_ set to indicate whether 32 or 16 general purpose registers are present.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -151,7 +151,7 @@ endif::[]
 When the base ISA is {cheri_base_ext_name}, the Y bit is one.
 
 `<<misa_y,misa>>.{CRE}` is a WARL field.
-If the implementation supports a writable <<misa_y,misa>>.{CRE}, it can only be set to zero if all registers used for implicit CHERI checks are currently configured as root capabilities.
+If the implementation supports a writable <<misa_y,misa>>.{CRE}, the implementation must not allow setting it to zero if any register used for implicit CHERI checks is not currently configured as a root capability.
 Otherwise, the write to <<misa_y,misa>>.{CRE} is ignored.
 
 These implicit check registers are <<pcc>>, `__x__tvec`, `__x__epc`.
@@ -159,7 +159,7 @@ These implicit check registers are <<pcc>>, `__x__tvec`, `__x__epc`.
 NOTE: The list includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemented.
 
 NOTE: This restriction ensures M-mode software cannot drop CHERI checks by modifying <<misa_y,misa>> once they have been configured.
- The exact behavior of the restriction is implementation defined, and does not need to, for example, check that capability bounds have been narrowed and then reprogrammed _back_ to infinity. Detecting any bounds reduction is sufficient.
+ A simpler conforming implementation could prevent setting <<misa_y,misa>>.{CRE} to zero if the capability metadata of any register used for implicit CHERI checks has ever been written to, rather than dynamically checking the current metadata.
 
 Either misa.I or misa.E is _also_ set to indicate whether 32 or 16 general purpose registers are present.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -948,7 +948,7 @@ When using a system with {cheri_default_ext_name}, it may be desirable to config
 
 {cheri_default_ext_name} includes the ability to disable CHERI by making the {CRE} bit of <<menvcfg_y>> and <<senvcfg_y>> writable.
 
-{cheri_default_ext_name} adds <<ddc>>, which must be configured as a <<root-rw-cap>> for `<<misa_y,misa>>.{CRE}` to be programmed to zero.
+{cheri_default_ext_name} adds <<ddc>> to the registers which must be configured as root capabilities for `<<misa_y,misa>>.{CRE}` to be programmed to zero.
 
 The effective CHERI-enable for the current privilege is:
 


### PR DESCRIPTION
Using Jessica's suggested wording from PR #1144.
No functional change intended, just fix the wording to be correct.

Co-authored-by: Jessica Clarke <jrtc27@jrtc27.com>
