### PR TITLE
Expand funct12 encoding of zicbo ops

### DIFF
--- a/src/cheri/insns/cbo.clean.adoc
+++ b/src/cheri/insns/cbo.clean.adoc
@@ -17,7 +17,7 @@ Encoding::
   {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'rs1≠0',     attr: ['5','base'], type: 4},
-  {bits: 12, name: 'funct12',   attr: ['12','CBO.CLEAN=00.0001'],   type: 3},
+  {bits: 12, name: 'funct12',   attr: ['12','CBO.CLEAN=000000000001'],   type: 3},
 ]}
 ....
 

--- a/src/cheri/insns/cbo.flush.adoc
+++ b/src/cheri/insns/cbo.flush.adoc
@@ -17,7 +17,7 @@ Encoding::
   {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'rs1≠0',     attr: ['5','base'],     type: 4},
-  {bits: 12, name: 'funct12',   attr: ['12','CBO.FLUSH=00.0010'],   type: 3},
+  {bits: 12, name: 'funct12',   attr: ['12','CBO.FLUSH=000000000010'],   type: 3},
 ]}
 ....
 

--- a/src/cheri/insns/cbo.inval.adoc
+++ b/src/cheri/insns/cbo.inval.adoc
@@ -17,7 +17,7 @@ Encoding::
   {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'rs1{ne}0',  attr: ['5','base'],     type: 4},
-  {bits: 12, name: 'funct12',   attr: ['12','CBO.INVAL=00.0000'],   type: 3},
+  {bits: 12, name: 'funct12',   attr: ['12','CBO.INVAL=000000000000'],   type: 3},
 ]}
 ....
 

--- a/src/cheri/insns/cbo.zero.adoc
+++ b/src/cheri/insns/cbo.zero.adoc
@@ -17,7 +17,7 @@ Encoding::
   {bits: 5,  name: 'funct5',    attr: ['5','CBO=00000'],     type: 2},
   {bits: 3,  name: 'funct3',    attr: ['3','CBO=010'],  type: 8},
   {bits: 5,  name: 'rs1{ne}0',  attr: ['5','base'],     type: 4},
-  {bits: 12, name: 'funct12',   attr: ['12','CBO.ZERO=00.0100'],   type: 3},
+  {bits: 12, name: 'funct12',   attr: ['12','CBO.ZERO=000000000100'],   type: 3},
 ]}
 ....
 


### PR DESCRIPTION
Looks like a recent round of review fixed the bug I ran into here, but the format was also very confusing. Are those first two zeros in hex?