### PR TITLE
Add G-stage translation note

### DIFF
--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -10,7 +10,9 @@ IMPORTANT: {not_v1_ratification_package_experimental}
 * The <<HLV_CAP>> and <<HSV_CAP>> encodings are added.
 
 [#hstatus_y,reftext="hstatus ({cheri_base_ext_name})"]
-=== Hypervisor Status Register (hstatus)
+
+NOTE: The {cheri_base_ext_name} field is not currently defined in G-stage PTEs and so remains reserved.
+ A future extension may define this field.
 
 VSXL and VSBE follow the same restrictions as <<mstatus_y>>.SXL and <<mstatus_y>>.SBE respectively.
 

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -12,7 +12,7 @@ IMPORTANT: {not_v1_ratification_package_experimental}
 [#hstatus_y,reftext="hstatus ({cheri_base_ext_name})"]
 
 NOTE: The {cheri_base_ext_name} field is not currently defined in G-stage PTEs and so remains reserved.
- A future extension may define this field.
+ A future extension may define this field to allow the hypervisor to control access to capabilities for guest OS translations.
 
 VSXL and VSBE follow the same restrictions as <<mstatus_y>>.SXL and <<mstatus_y>>.SBE respectively.
 


### PR DESCRIPTION
The note saying that G-stage translation tables don't have an RVY field seems to have been forgotten.
