### PR TITLE
Update dco_check pointer to docs-resources

### DIFF
--- a/.github/workflows/dco_check.yml
+++ b/.github/workflows/dco_check.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   dco_check:
-    uses: riscv/riscv-isa-manual/.github/workflows/dco_check.yml@main
+    uses: riscv/docs-resources/.github/workflows/dco_check.yml@main
     permissions:
       pull-requests: write
       contents: read


### PR DESCRIPTION
Updates the pointer to docs-resources common repo for the dco_check workflow.

Signed-off-by: Bill Traynor wmat@riscv.org