### PR TITLE
Fix document titles

### DIFF
--- a/src/cheri/attributes-standalone.adoc
+++ b/src/cheri/attributes-standalone.adoc
@@ -1,5 +1,5 @@
 :docgroup: CHERI Task Group
-:description: RISC-V specification for CHERI extensions
+:description: RVY: RISC-V Base Architectures for CHERI
 :company: RISC-V.org
 :revdate: 1/2023
 :revnumber: 1.0

--- a/src/cheri/contributors.adoc
+++ b/src/cheri/contributors.adoc
@@ -19,6 +19,7 @@ This RISC-V specification has been contributed to directly or indirectly by:
 * Martin Kaiser <martin.kaiser@codasip.com>
 * Tariq Kurd <tariq.kurd@codasip.com>
 * Ben Laurie <benl@google.com>
+* Andrew Lindsay <andrew.lindsay@codasip.com>
 * Marno van der Maas <mvdmaas@lowrisc.org>
 * Maja Malenko <maja.malenko@codasip.com>
 * A. Theodore Markettos <theo.markettos@cl.cam.ac.uk>

--- a/src/cheri/riscv-cheri-debug.adoc
+++ b/src/cheri/riscv-cheri-debug.adoc
@@ -1,5 +1,5 @@
-= RISC-V Debug Specification for CHERI Extensions
-Authors: Thomas Aird, Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu, Robert Riglar, Florian Schmaus
+= RISC-V Debug Specification for RVY Base Achitectures
+Authors: Thomas Aird, Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Andrew Lindsay, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu, Robert Riglar, Florian Schmaus
 include::attributes-standalone.adoc[]
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/cheri/riscv-cheri.adoc
+++ b/src/cheri/riscv-cheri.adoc
@@ -1,5 +1,5 @@
 = RISC-V Specification for CHERI Extensions
-Authors: Thomas Aird, Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu, Robert Riglar, Florian Schmaus
+Authors: Thomas Aird, Hesham Almatary, Andres Amaya Garcia, John Baldwin, Paul Buxton, David Chisnall, Jessica Clarke, Brooks Davis, Nathaniel Wesley Filardo, Franz A. Fuchs, Timothy Hutt, Alexandre Joannou, Martin Kaiser, Tariq Kurd, Ben Laurie, Andrew Lindsay, Marno van der Maas, Maja Malenko, A. Theodore Markettos, David McKay, Jamie Melling, Stuart Menefy, Simon W. Moore, Peter G. Neumann, Robert Norton, Alexander Richardson, Michael Roe, Peter Rugg, Peter Sewell, Carl Shaw, Ricki Tura, Robert N. M. Watson, Toby Wenman, Jonathan Woodruff, Jason Zhijingcheng Yu, Robert Riglar, Florian Schmaus
 :cheri_standalone_spec: 1
 include::attributes-standalone.adoc[]
 


### PR DESCRIPTION
They aren't extensions, they are base architectures, as pointed out by Andrew Lindsay