### PR TITLE
Consistent base/top bound address naming

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -246,11 +246,11 @@ endif::support_varxlen[]
 
 :GCBASE:       YBASER
 :GCBASE_LC:    ybaser
-:GCBASE_DESC:  Read capability base address
+:GCBASE_DESC:  Read capability base bound address
 
 :GCTOP:       YTOPR
 :GCTOP_LC:    ytopr
-:GCTOP_DESC:  Read capability top address
+:GCTOP_DESC:  Read capability top bound address
 
 :GCTYPE:       YTYPER
 :GCTYPE_LC:    ytyper

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -246,11 +246,11 @@ endif::support_varxlen[]
 
 :GCBASE:       YBASER
 :GCBASE_LC:    ybaser
-:GCBASE_DESC:  Read capability base bound address
+:GCBASE_DESC:  Read capability base address
 
 :GCTOP:       YTOPR
 :GCTOP_LC:    ytopr
-:GCTOP_DESC:  Read capability top bound address
+:GCTOP_DESC:  Read capability top address
 
 :GCTYPE:       YTYPER
 :GCTYPE_LC:    ytyper

--- a/src/cheri/insns/gclen_32bit.adoc
+++ b/src/cheri/insns/gclen_32bit.adoc
@@ -22,7 +22,7 @@ Description::
 Calculate the length of `{cs1}` 's bounds and write the result in `rd`.
 +
 The length
-is defined as the difference between the decoded bounds' top and base addresses,
+is defined as the difference between the decoded top and base bound addresses,
 i.e., `top - base`.
 +
 Return the maximum length, 2^XLEN^-1, if the length of `{cs1}` is 2^XLEN^.

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -31,7 +31,7 @@ include::wavedrom/scbnds_32bit.adoc[]
 
 Description::
 Copy the capability from register `{cs1}` to register `{cd}`.
-Set the base address of its bounds to the value of `{cs1}.address` and
+Set the base bound address to the value of `{cs1}.address` and
 set the length of its bounds to `rs2[XLEN-1:0]` for <<SCBNDS>>, or `imm` for <<SCBNDSI>>.
 +
 Set `{cd}.tag=0` if `{cs1}.tag=0`.

--- a/src/cheri/insns/scbnds_32bit.adoc
+++ b/src/cheri/insns/scbnds_32bit.adoc
@@ -31,7 +31,7 @@ include::wavedrom/scbnds_32bit.adoc[]
 
 Description::
 Copy the capability from register `{cs1}` to register `{cd}`.
-Set the base bound address to the value of `{cs1}.address` and
+Set the capability base address to the value of `{cs1}.address` and
 set the length of its bounds to `rs2[XLEN-1:0]` for <<SCBNDS>>, or `imm` for <<SCBNDSI>>.
 +
 Set `{cd}.tag=0` if `{cs1}.tag=0`.

--- a/src/cheri/insns/scbndsr_32bit.adoc
+++ b/src/cheri/insns/scbndsr_32bit.adoc
@@ -20,7 +20,7 @@ include::wavedrom/scbndsr_32bit.adoc[]
 
 Description::
 Copy the capability from register `{cs1}` to register `{cd}`.
-Set the base address of its bounds to the value of `{cs1}.address` and
+Set the base bound address to the value of `{cs1}.address` and
 set the length of its bounds to `rs2[XLEN-1:0]`.
 +
 The base is rounded down

--- a/src/cheri/insns/scbndsr_32bit.adoc
+++ b/src/cheri/insns/scbndsr_32bit.adoc
@@ -20,7 +20,7 @@ include::wavedrom/scbndsr_32bit.adoc[]
 
 Description::
 Copy the capability from register `{cs1}` to register `{cd}`.
-Set the base bound address to the value of `{cs1}.address` and
+Set the capability base address to the value of `{cs1}.address` and
 set the length of its bounds to `rs2[XLEN-1:0]`.
 +
 The base is rounded down

--- a/src/cheri/insns/scbndsrd_32bit.adoc
+++ b/src/cheri/insns/scbndsrd_32bit.adoc
@@ -16,10 +16,10 @@ include::wavedrom/scbndsrd_32bit.adoc[]
 
 Description::
 Copy the capability from register `{cs1}` to register `{cd}`.
-Set the base address of its bounds to the value of `{cs1}.address`.
+Set the base bound address to the value of `{cs1}.address`.
 +
 Round _down_ the requested length, in `rs2[XLEN-1:0]`, by the smallest amount necessary
-to guarantee that it is precisely representable given this base address.
+to guarantee that it is precisely representable given this base bound address.
 +
 Set `{cd}.tag=0` if `{cs1}.tag=0`, `{cs1}` is sealed or if `{cd}` 's bounds exceed `{cs1}` 's bounds.
 +
@@ -40,7 +40,7 @@ otherwise this threshold serves to guarantee a minimum length return from {SCBND
 =====
 {SCBNDSRD} finds the largest length `l` that is both
 less than or equal to the requested `rs2[XLEN-1:0]` and
-precisely representable given a particular base address, `b`.
+precisely representable given a particular base bound address, `b`.
 A length `l` is precisely representable given base `b` if a <<SCBNDS>> instruction...
 
 - whose `rs2` register holds `l` and
@@ -53,9 +53,9 @@ A length `l` is precisely representable given base `b` if a <<SCBNDS>> instructi
 
 produces a result in `{cd}` whose {ctag} is set to one.
 This value may be efficiently found, for most capability encoding schemes,
-by counting trailing zeros in the desired base address and
+by counting trailing zeros in the desired base bound address and
 computing the length that is a maximal mantissa shifted left by that count
-(that is, using the number of trailing zeros in the base address as the value's exponent).
+(that is, using the number of trailing zeros in the base bound address as the value's exponent).
 =====
 
 Operation::

--- a/src/cheri/insns/scbndsrd_32bit.adoc
+++ b/src/cheri/insns/scbndsrd_32bit.adoc
@@ -16,7 +16,7 @@ include::wavedrom/scbndsrd_32bit.adoc[]
 
 Description::
 Copy the capability from register `{cs1}` to register `{cd}`.
-Set the base bound address to the value of `{cs1}.address`.
+Set the capability base address to the value of `{cs1}.address`.
 +
 Round _down_ the requested length, in `rs2[XLEN-1:0]`, by the smallest amount necessary
 to guarantee that it is precisely representable given this base bound address.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -208,7 +208,7 @@ All capabilities with smaller bounds are derived from these.
 
 The bounds are reduced using the <<SCBNDS>>, <<SCBNDSI>> and <<SCBNDSR>> instructions.
 
-They all copy `{cs1}` to the output `{cd}`, set the _base_ bound of `{cd}` to `{cs1}.address`, subject to encoding granularity constraints, and set the _length_ of `{cd}` from `rs2` or the immediate field depending on the instruction.
+They all copy `{cs1}` to the output `{cd}`, set the _base_ bound address of `{cd}` to `{cs1}.address`, subject to encoding granularity constraints, and set the _length_ of `{cd}` from `rs2` or the immediate field depending on the instruction.
 
 * <<SCBNDS>> sets the _base_ to `{cs1}.address`, and the _length_ to `rs2`.
 ** The {ctag} is set to zero if the bounds cannot be encoded exactly.
@@ -243,7 +243,7 @@ The maximum range of address values that the pointer can take without changing t
 NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
-Since the upper bits of the address are used to calculate the top and base bounds, deriving a new capability with a different address could change the resulting bounds.
+Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with a different address could change the resulting bounds.
 All instructions that derive a capability with a new address must check that the new address does not change the bounds.
 If the bounds _do_ change then the {ctag} of the derived capability is set to zero, so that the capability becomes invalid.
 
@@ -943,8 +943,8 @@ Some instructions use the concept of `cap2` being a _capability subset_ of `cap1
 The definition is:
 +
 . All permissions granted by the <<AP-field>> and the <<SDP-field>> of `cap2` are also granted by those of `cap1`, and
-. `cap2` 's top bound is less than or equal to `cap1` 's top bound, and
-. `cap2` 's base bound is greater than or equal to `cap1` 's base bound, and
+. `cap2` 's top bound address is less than or equal to `cap1` 's top bound address, and
+. `cap2` 's base bound address is greater than or equal to `cap1` 's base bound address, and
 . `cap1` and `cap2` pass all <<section_cap_integrity,integrity>> checks
 
 NOTE: A capability whose {ctag} is set is assumed to satisfy the <<section_cap_integrity,integrity>> checks, so this rule can only affect the result for an operand whose {ctag} is zero.

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -329,8 +329,8 @@ that it is unsealed, has no permissions and its exponent, base and top are 0.
 | P        | zeros  | Grants no permissions
 | CT       | zeros  | Unsealed
 | E        | zeros  | Exponent
-| T        | zeros  | Top address bits
-| B        | zeros  | Base address bits
+| T        | zeros  | Top bound address bits
+| B        | zeros  | Base bound address bits
 | Address  | zeros  | Capability address
 |==============================================================================
 

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -29,11 +29,11 @@ The bit ranges in <<cap_encoding_xlen32_field_table>> are relative to the XLEN-b
 | GL         | 24        | <<zylevels1_gl_flag, Global (GL) flag>> (<<section_zylevels1>> only).
 | CT         | 20        | <<CT-field, Capability Type field>>.
 | EF         | 19        | Exponent format for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| L8         | 18        | Exponent or top bound MSB for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| T[7:2]     | 17:12     | Top address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| TE         | 11:10     | Top address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| B[9:2]     | 9:2       | Base address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| BE         | 1:0       | Base address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| L8         | 18        | Exponent or top bound address MSB for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| T[7:2]     | 17:12     | Top bound address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| TE         | 11:10     | Top bound address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| B[9:2]     | 9:2       | Base bound address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| BE         | 1:0       | Base bound address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
 3+| All other fields are _reserved_
 |==============================================================================
 

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -39,10 +39,10 @@ The bit ranges in <<cap_encoding_xlen64_field_table>> are relative to the XLEN-b
 | GL         | 43        | <<zylevels1_gl_flag, Global (GL) flag>> (<<section_zylevels1>> only).
 | CT         | 27        | <<CT-field, Capability Type field>>.
 | EF         | 26        | Exponent format for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| T[11:3]    | 25:17     | Top address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| TE         | 16:14     | Top address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| B[13:3]    | 13:3      | Base address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
-| BE         | 2:0       | Base address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| T[11:3]    | 25:17     | Top bound address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| TE         | 16:14     | Top bound address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| B[13:3]    | 13:3      | Base bound address field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
+| BE         | 2:0       | Base bound address or exponent field for the <<section_cap_bounds,capability bounds>> decoding, see <<rvy64_uni_base_name_bndsenc_param_summary>>.
 3+| All other fields are _reserved_
 |==============================================================================
 
@@ -195,12 +195,12 @@ The variables related to the bounds decoding are shown in <<rvy64_uni_base_name_
 [#rvy64_uni_base_name_bndsenc_param_summary,width="100%",options=header,cols="1,4"]
 |==============================================================================
 | Variable  | Description
-| T         | Value substituted into the capability's address to decode the _top_ bound.
-| TE        | Value either substituted into the exponent or the _top_ bound depending on EF.
-| B         | Value substituted into the capability's address to decode the _base_ bound.
-| BE        | Value either substituted into the exponent or the _base_ bound depending on EF.
+| T         | Value substituted into the capability's address to decode the _top_ bound address.
+| TE        | Value either substituted into the exponent or the _top_ bound address depending on EF.
+| B         | Value substituted into the capability's address to decode the _base_ bound address.
+| BE        | Value either substituted into the exponent or the _base_ bound address depending on EF.
 | E         | Exponent that determines the position at which T and B are substituted into the capability's address.
-| L~8~^1^   | Value used to form either the MSB of the exponent or the MSB of the _top_ bound.
+| L~8~^1^   | Value used to form either the MSB of the exponent or the MSB of the _top_ bound address.
 | EF        | Exponent format flag indicating the encoding for T, B and E: +
 EF=0: The exponent is calculated from TE and BE, and conditionally L8, so it is 'internal'. +
 EF=1: The exponent is zero; TE, BE and L8 form part of the address bounds.
@@ -249,14 +249,14 @@ NOTE: *CHERI v9 Note:* The IE bit from CHERI v9 is renamed EF and its value is
 inverted to ensure that the <<null-cap>> capability is encoded as zero without the
 need for CHERI v9's in-memory format. +
 When EF=1, the exponent E=0, so the address bits a[MW - 1:0] are replaced
-with T and B to form the top and base addresses respectively. +
+with T and B to form the top and base bound addresses respectively. +
 When EF=0, the exponent `E=CAP_MAX_E - ( enableL8 ? { L~8~, TE, BE } : { TE, BE } )`,
 so the address bits a[E + MW - 1:E] are replaced with T and B to form the top
-and base addresses respectively. E is computed by subtracting from the maximum
+and base bound addresses respectively. E is computed by subtracting from the maximum
 possible exponent CAP_MAX_E which can be efficiently implemented in hardware
 assuming that T and B are at bit CAP_MAX_E and performing a logical bitwise
 shift right by E. In contrast, CHERI v9 implementations computed the top and
-base addresses by assuming that T and B are at bit 0 and performing a logical
+base bound addresses by assuming that T and B are at bit 0 and performing a logical
 bitwise shift left by E.
 endif::[]
 
@@ -313,7 +313,7 @@ T[MW - 1:MW - 2] = B[MW - 1:MW - 2] + LCout + LMSB
 This derivation relies on the equality `T = B + L`, where `L` is the encoded length of the capability.
 `LMSB` is the value of `L[MW - 2]`, which is known from the values of `EF` and `E` (as well as L~8~ when `enableL8=1`).
 `LCout` is the carry out from the lower bits, which is implied by `T[MW - 3:0] < B[MW - 3:0]` since it is
-guaranteed that the _top_ bound is larger than the _base_ bound.
+guaranteed that the _top_ bound address is larger than the _base_ bound address.
 
 [#section_cap_bounds_format]
 ===== Format of the Bounds
@@ -327,13 +327,13 @@ xref:base_bound_dec[xrefstyle=short].
 
 NOTE: XLEN and MW are constant parameters, but E is decoded from the capability metadata, and so the bit positions of the boundaries between the sections vary.
 
-NOTE: The _top_ bound has an additional bit so that the bounds can include the topmost byte of memory.
+NOTE: The _top_ bound address has an additional bit so that the bounds can include the topmost byte of memory.
 
-.Decoding of the XLEN+1 wide _top_ bound
+.Decoding of the XLEN+1 wide _top_ bound address
 [#top_bound_dec]
 include::img/top-bound-dec.edn[]
 
-.Decoding of the XLEN wide _base_ bound
+.Decoding of the XLEN wide _base_ bound address
 [#base_bound_dec]
 include::img/base-bound-dec.edn[]
 
@@ -342,31 +342,31 @@ include ranges which may not be present when the bounds are decoded:
 
 * If `E = 0` the lower section does not exist.
 * If `E+MW=XLEN` then the top section is only the least significant bit of
- _c~t~_ for the _top_ bound, and top section does not exist for the _base_ bound.
+ _c~t~_ for the _top_ bound address, and the top section does not exist for the _base_ bound address.
 * If `E+MW>XLEN` then neither top section exists, and so the bounds are calculated
  with no dependency on the address field _a_.
 
 The compressed bounds encoding allows the address to roam over the _representable range_, (`space~R~` in <<cap_bounds_map>> and <<capformat_correction_illustration>>), while maintaining the original bounds.
-The overall effect is that the address can roam at least `2^E+MW^/4` bytes below the _base_ bound and at least `2^E+MW^/4` bytes above the _top_ bound while still allowing the bounds to be correctly decoded.
+The overall effect is that the address can roam at least `2^E+MW^/4` bytes below the _base_ bound address and at least `2^E+MW^/4` bytes above the _top_ bound address while still allowing the bounds to be correctly decoded.
 
 [#section_cap_bounds_correction_factors, reftext="Correction Factors"]
 ===== Correction Factors
 
-Substituting `B`/`T` into the capability address, as described in xref:section_cap_bounds_format[xrefstyle=short] above, only decodes to the correct _base_ or _top_ bound if `B`/`T` and the capability address both lie in the _same_ _s_=2^E+MW^-aligned block.
+Substituting `B`/`T` into the capability address, as described in xref:section_cap_bounds_format[xrefstyle=short] above, only decodes to the correct _base_ or _top_ bound address if `B`/`T` and the capability address both lie in the _same_ _s_=2^E+MW^-aligned block.
 In this case no correction is required.
 
 If `B`/`T` and the capability address lie in _different_ _s_-aligned blocks then _correction factors_ are applied to move the computed bounds between the _s_-aligned blocks.
 
-The _correction factors_ are _c~b~_ for the _base_ bound and _c~t~_ for the _top_ bound.
+The _correction factors_ are _c~b~_ for the _base_ bound address and _c~t~_ for the _top_ bound address.
 
-In the example shown in <<capformat_correction_illustration>>, the _top_ bound and the capability address lie in the same _s_-aligned block, but the _base_ bound doesn't, it is in the block below.
-Therefore _c~t~_ is zero, but _c~b~_ is set to -1 to move the _base_ bound down into the _s_-aligned block below (i.e. from space~U~ to space~L~).
+In the example shown in <<capformat_correction_illustration>>, the _top_ bound address and the capability address lie in the same _s_-aligned block, but the _base_ bound address doesn't, it is in the block below.
+Therefore _c~t~_ is zero, but _c~b~_ is set to -1 to move the _base_ bound address down into the _s_-aligned block below (i.e. from space~U~ to space~L~).
 
 Therefore adding the _correction factor_ moves the computed bound into the correct _s_-aligned block.
 Each _correction factor_ can have values of -1, 0 or +1, so that it is possible to move computed bound up or down by one _s_-aligned block.
 
 [#capformat_correction_illustration]
-.Example capability bounds that use the correction. The _base_ is an s-aligned block below the address, meaning the upper bits (above the mantissa) of the _base_ are smaller than the upper bits of the address. Therefore _c~b~_=-1. The address and _top_ are in the same region, so _c~t~_=0.
+.Example capability bounds that use the correction. The _base_ bound address is an s-aligned block below the address, meaning the upper bits (above the mantissa) of the _base_ bound address are smaller than the upper bits of the address. Therefore _c~b~_=-1. The address and _top_ are in the same region, so _c~t~_=0.
 image::../cheri/img/capformat-correction-illustration.png[width=80%,align=center]
 
 ====== Correction Factor Calculations
@@ -389,7 +389,7 @@ The correction factors _c~b~_ and _c~t~_ are calculated as follows.
 
 NOTE: Mathematically, `B < R` requires `B[MW-1:MW-2] = 0`.
 
-.Calculation of the _top_ and _base_ bound corrections
+.Calculation of the _top_ and _base_ bound address corrections
 [#cap_encoding_corrections,options=header,cols="^1,^1,^1,^2",width="60%",align="center"]
 |==============================================================================
 | A < R      | T < R | B < R | Correction factors
@@ -422,7 +422,7 @@ In summary, for either bound:
 * If the bound is above the _s_-aligned boundary and the capability address is below the _s_-aligned boundary, then set the correction factor to +1 to correct the bound upwards.
 
 [#t_bound_msb_inversion]
-===== Top bound MSB correction
+===== Top bound address MSB correction
 
 A capability has _infinite_ bounds if its bounds cover the entire address space
 such that _base_=0 and _top_{ge}2^XLEN^,
@@ -465,7 +465,7 @@ NOTE: The above includes a special case for encodings where `enableL8=1`.
 
 Capabilities with malformed bounds:
 
-. Return both _base_ and _top_ bounds as zero, which affects instructions like <<GCBASE>>.
+. Return both _base_ and _top_ bound addresses as zero, which affects instructions like <<GCBASE>>.
 . Cause certain manipulation instructions like <<CADDI>> to always set the {ctag} of the result to zero.
 
 [#section_cap_representable_check, reftext="Representable Range"]
@@ -500,7 +500,7 @@ The _top_ and _base_ capability bounds are formed of two or three sections:
 * Lower bits are set to zero
 ** This is only if there is an internal exponent (`EF=0`)
 
-.Composition of the decoded _top_ bound
+.Composition of the decoded _top_ bound address
 [#comp_addr_bounds,options=header,align="center",cols="2,4,2,2"]
 |==============================================================================
 | Configuration   | Upper Section (if E + MW < XLEN) | Middle Section | Lower Section
@@ -521,16 +521,16 @@ destination capabilities.  Therefore, the Middle and Lower sections
 of the bounds calculation are also unchanged for source and
 destination capabilities.
 
-When E > CAP_MAX_E - 2, the calculation of the _top_ bound is entirely derived
+When E > CAP_MAX_E - 2, the calculation of the _top_ bound address is entirely derived
 from `T` and `E`, which will be identical for both the source and destination
 capabilities, thus guaranteeing that `top == top'`.  Likewise, with such values of E, the
-_base_ bound is entirely derived from `B` and `E` and therefore `base == base'`.
+_base_ bound address is entirely derived from `B` and `E` and therefore `base == base'`.
 
-The calculation of the MSB of the _top_ bound may be inverted as specified
+The calculation of the MSB of the _top_ bound address may be inverted as specified
 in xref:t_bound_msb_inversion[xrefstyle=short].
 Assuming `(E < (CAP_MAX_E - 1))`, the truth-table for this inversion is as follows:
 
-.Top bound MSB inversion truth table
+.Top bound address MSB inversion truth table
 [#t_bound_msb_inversion_truth_table]
 [options=header,align=center,width="100%"]
 |==============================================================================
@@ -606,10 +606,10 @@ The exponent value causes its bounds to cover the entire address space, but no p
 | <<AP-field,AP>>          | zeros  | Grants no permissions
 | CT       | zero   | Unsealed
 | EF       | zero   | Internal exponent format
-| L~8~^1^  | zero   | Top address reconstruction bit
-| T        | zeros  | Top address bits
+| L~8~^1^  | zero   | Top bound address reconstruction bit
+| T        | zeros  | Top bound address bits
 | T~E~     | zeros  | Exponent bits
-| B        | zeros  | Base address bits
+| B        | zeros  | Base bound address bits
 | B~E~     | zeros  | Exponent bits
 | Address  | zeros  | Capability address
 | Reserved | zeros  | All reserved fields
@@ -636,10 +636,10 @@ This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capabil
 | <<AP-field,AP>>     | AP_MAX | Grants all permissions
 | CT            | zero  | Unsealed
 | EF            | zero  | Internal exponent format
-| L~8~^1^       | zero  | Top address reconstruction bit
-| T             | zeros | Top address bits
+| L~8~^1^       | zero  | Top bound address reconstruction bit
+| T             | zeros | Top bound address bits
 | T~E~          | zeros | Exponent bits
-| B             | zeros | Base address bits
+| B             | zeros | Base bound address bits
 | B~E~          | zeros | Exponent bits
 | Address       | any^2^ | Capability address
 | Reserved      | zeros | All reserved fields


### PR DESCRIPTION
We still had a combination of "top address" and "top bound" so I've gone for "top bound address" everywhere.
Similarly for "base address bound"