### PR TITLE
Arc review feedback 20260902 - Non-normative changes only

### DIFF
--- a/src/cheri/app-hybrid-usage.adoc
+++ b/src/cheri/app-hybrid-usage.adoc
@@ -229,8 +229,7 @@ This allows a kernel to run non-CHERI-aware code in a strict integer environment
 Transitions between modes are performed using specific instructions:
 
 <<MODESW_INT>> and <<MODESW_CAP>>::
-These instructions are used to switch between modes without changing the control flow.
-They are typically used when entering or leaving a section of code that requires a different mode.
+These instructions are used to switch between modes without changing the control flow and are typically used when entering or leaving a section of code that requires a different mode.
 <<JALR_CHERI>>::
 When jumping to a target capability with the <<p_bit>> set differently from the current mode, the jump performs a mode switch.
 This is commonly used for function calls between compartments or libraries in different modes.

--- a/src/cheri/app-rvy-encoding.adoc
+++ b/src/cheri/app-rvy-encoding.adoc
@@ -3,7 +3,7 @@
 
 [IMPORTANT]
 ====
-#ARC-NOTE: The instruction encoding listings below are presented in three different formats (bytefield, wavedrom and AsciiDoc tables).#
+#ARC-NOTE: The instruction encoding listings below are presented in three different formats (bytefield, wavedrom, and AsciiDoc tables).#
 #Please choose which of these formats you would like to see in the final specification.#
 ====
 

--- a/src/cheri/app-standalone-unpriv-refs.adoc
+++ b/src/cheri/app-standalone-unpriv-refs.adoc
@@ -6,7 +6,7 @@ WARNING: This chapter only exists for the standalone document to allow reference
 
 [[rv32]]RV32I::
 See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
-[[gprs]]General purpose registers::
+[[gprs]]General-purpose registers::
 See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].
 [[ldst]]Load and Store Instructions::
 See Chapter _RV32I Base Integer Instruction Set_ in cite:[riscv-unpriv-spec].

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -187,7 +187,7 @@ endif::support_varxlen[]
 :cheri_excep_name_pte_ld:    CHERI Load Capability Fault
 :cheri_excep_name_pte_st:    CHERI Store/AMO Page Fault
 
-:cheri_excep_desc_ytag:      Authorizing {ctag} is set to 0.
+:cheri_excep_desc_ytag:      Authorizing {ctag} is set to zero.
 :cheri_excep_desc_seal:      Authorizing capability is sealed.
 :cheri_excep_desc_perm:      Authorizing capability does not grant the necessary permissions.
 :cheri_excep_desc_bnds:      At least one byte accessed is outside the authorizing capability bounds, or the bounds could not be decoded.

--- a/src/cheri/cheri-pte-ext.adoc
+++ b/src/cheri/cheri-pte-ext.adoc
@@ -2,7 +2,7 @@
 [#section_cheri_priv_crg_ext]
 == "{cheri_priv_crg_ext}" Extension, Version 1.0 for {cheri_base64_ext_name}
 
-This extension specifies use of the {rv64y_pte4_field_name} field in the Sv39, Sv48 and Sv57 PTE formats (e.g., see <<sv39pte>>).
+This extension specifies use of the {rv64y_pte4_field_name} field in the Sv39, Sv48, and Sv57 PTE formats (e.g., see <<sv39pte>>).
 
 ifdef::cheri_standalone_spec[]
 
@@ -70,7 +70,7 @@ Therefore `sstatus.{pte_cap_fc_enable}` is not required to change dynamically an
 When all of the following are true, {cheri_priv_crg_ext} adds two related architectural features, {cheri_excep_name_pte_ld}s and Capability Dirty Tracking:
 
 . `sstatus.{pte_cap_fc_enable}` is set.
-. The authorizing capability has <<c_perm>>.
+. The authorizing capability grants <<c_perm>>.
 . The PMA is set to _CHERI {ctag_title}_.
 
 NOTE: It may make sense to subdivide this into two extensions as _Capability Dirty Tracking_ is more generally useful than _{cheri_excep_name_pte_ld}s_.
@@ -196,7 +196,7 @@ Checking the stored {ctag} is less of a burden to the implementation than checki
 
 NOTE: Capability dirty tracking may be used to implement the store-barrier primitive from cite:[cornucopia-reloaded].
 
-NOTE: The minimum level of PTE support is to set _pte_._{pte_cap_r_name_lc}_=1, _pte_._{pte_cap_dirty_name_lc}_=1, _pte_._{pte_cap_w_name_lc}_=1 and _pte_._{pte_cap_crg_pte_name_lc}_=0 in all PTEs intended for storing capabilities (e.g., private anonymous mappings) and set `sstatus.U{pte_cap_crg_pte_name}`=0 and `sstatus.S{pte_cap_crg_pte_name}`=0 on all harts, which will enable capabilities to be loaded and stored successfully.
+NOTE: The minimum level of PTE support is to set _pte_._{pte_cap_r_name_lc}_=1, _pte_._{pte_cap_dirty_name_lc}_=1, _pte_._{pte_cap_w_name_lc}_=1, and _pte_._{pte_cap_crg_pte_name_lc}_=0 in all PTEs intended for storing capabilities (e.g., private anonymous mappings) and set `sstatus.U{pte_cap_crg_pte_name}`=0 and `sstatus.S{pte_cap_crg_pte_name}`=0 on all harts, which will enable capabilities to be loaded and stored successfully.
 
 [[sv32algorithm_rvy]]
 === Virtual Address Translation Process

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -83,7 +83,7 @@ If `write=1` and `aamsize{ne}7` then {ctag}s are always written as zero.
 
 If a Program Buffer is implemented, this section shows how it can be configured and used to access the {ctag}s.
 
-The minimum Program Buffer configuration to support {ctag} access in general purpose registers is as follows:
+The minimum Program Buffer configuration to support {ctag} access in general-purpose registers is as follows:
 
 * `hartinfo` must be implemented.
 * `hartinfo.nscratch` is at least 1 and the <<dscratch0_y>> register is implemented.
@@ -92,7 +92,7 @@ The minimum Program Buffer configuration to support {ctag} access in general pur
 
 [NOTE]
 ====
-These requirements allow a debugger to read and write {ctag}s in general purpose registers without disturbing other registers.
+These requirements allow a debugger to read and write {ctag}s in general-purpose registers without disturbing other registers.
 These requirements may be relaxed if _Access Register_ abstract commands support full capability access.
 ====
 
@@ -147,7 +147,7 @@ no way to discover the former property.
 
 [NOTE]
 ====
-Accessing capabilities held in general purpose registers is a foundational operation that
+Accessing capabilities held in general-purpose registers is a foundational operation that
 allows for more complex debugger accesses.
 
 If the full capability access via _Access Register_ abstract command is not
@@ -158,7 +158,7 @@ through the Program Buffer.
 Analogously, if the full capability access is not available through the _Access Memory_ abstract command, the debugger may access capabilities in memory indirectly
 by executing `ly` and `sy` instructions via the Program Buffer.
 
-Any general purpose registers that serve as temporaries during these operations
+Any general-purpose registers that serve as temporaries during these operations
 must be saved by the debugger before use and restored afterwards.
 ====
 

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -188,14 +188,12 @@ to this specification. The `pc` metadata has no architectural effect in debug
 mode. Therefore, `ASR-permission` is implicitly granted for access to all CSRs for
 instruction execution.
 
-On debug mode entry, <<dpc_y>> is updated with the
-capability in the `pc`, whose address field equals to the address of the next
-instruction to be executed upon debug mode exit as described in the _RISC-V Debug Specification_.
+On debug mode entry, <<dpc_y>> is updated with the capability in the `pc`, whose address field equals to the address of the next instruction to be executed upon debug mode exit as described in the _RISC-V Debug Specification_.
 
-When leaving debug mode, the value in <<dpc_y>> is unsealed if it is a {sentry_cap_uc} and is written to PC.
+When leaving debug mode, the value in <<dpc_y>> is unsealed if it is a {sentry_cap_uc} and is written to the `pc`.
 
-NOTE: A debugger may write <<dpc_y>> to change where the hart resumes and its mode, permissions, sealing or bounds.
- The value saved from the `pc` on debug mode entry cannot be sealed.
+NOTE: A debugger may write <<dpc_y>> to change where the hart resumes and its mode, permissions, sealing, or bounds.
+The value saved from the `pc` on debug mode entry cannot be sealed.
 
 The legalization of <<dpc_y>> follows the same rules described for `mepc`.
 

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -197,7 +197,7 @@ The TIDC bit controls access to the <<stidc>> (really <<vstidc>>) CSR.
 === Hypervisor Load and Store Instructions For Capability Data
 
 Hypervisor virtual-machine load (<<HLV_CAP>>) and store (<<HSV_CAP>>) are added.
-They are analogous to HLV.W and HSV.W but access capability data.
+These instructions are analogous to HLV.W and HSV.W, but access capability data.
 
 include::insns/hypv-virt-load-cap.adoc[]
 include::insns/hypv-virt-store-cap.adoc[]

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -149,7 +149,8 @@ include::img/vsepccreg.edn[]
 === Virtual Supervisor Thread Identifier Capability (vstidc)
 
 The <<vstidc>> register is used to identify the current software thread in VS-mode.
-When V=1, <<vstidc>> substitutes for the usual <<stidc>>, so instructions that normally read or modify <<stidc>> actually access <<vstidc>>instead. The contents of <<vstidc>>never directly affect the behavior of the machine.
+When V=1, <<vstidc>> substitutes for the usual <<stidc>>, so instructions that normally read or modify <<stidc>> actually access <<vstidc>> instead.
+The contents of <<vstidc>> never directly affect the behavior of the machine.
 
 .Virtual supervisor thread identifier capability register
 include::img/vstidcreg.edn[]

--- a/src/cheri/insns/atomic_exceptions.adoc
+++ b/src/cheri/insns/atomic_exceptions.adoc
@@ -3,7 +3,7 @@ Requires <<r_perm>> and <<w_perm>> in the authorizing capability.
 If <<c_perm>> isn't granted then the {ctag} will be stored as zero.
 +
 Exceptions::
-Raise a store/AMO access fault exception when the effective address is not aligned to YLEN/8.
+Raise a store/AMO access fault exception when the effective address is not naturally aligned to YLEN/8.
 +
 Exceptions occur when the authorizing capability fails one of the checks listed below:
 +

--- a/src/cheri/insns/cram_32bit.adoc
+++ b/src/cheri/insns/cram_32bit.adoc
@@ -14,7 +14,7 @@ include::wavedrom/cram.adoc[]
 
 Description::
 `rd[XLEN-1:0]` is set to a mask that can be used to round addresses down to a value that is sufficiently aligned to set exact bounds for the nearest representable length of `rs1[XLEN-1:0]`.
-The upper bits of `rd` are zero extended.
+The upper bits of `rd` are zero-extended.
 See <<section_cap_bounds>> for the algorithm used to compute the next representable length.
 
 NOTE: This {cheri_base_ext_name} instruction only handles XLEN operands and produces an XLEN result.

--- a/src/cheri/insns/dret.adoc
+++ b/src/cheri/insns/dret.adoc
@@ -18,9 +18,8 @@ It unseals <<dpc_y>> if it is sealed as a {sentry_cap_uc} and writes the result 
 It also restores `ddc` from <<dddc>>.
 
 NOTE: The `DRET` instruction is a documented method of exiting debug mode.
-However, it is a pseudoinstruction to return that technically does not execute
-from the program buffer or memory. It does not require the `pc` to
-grant `ASR-permission` so it never raises an exception.
+However, it is a pseudoinstruction that technically does not execute from the program buffer or memory.
+It does not require the `pc` to grant `ASR-permission`, so it never raises an exception.
 
 NOTE: The definition of `DRET` is not part of Sdext, and is suggested as an implementation choice in the _RISC-V Debug Specification_.
 This specification assumes the recommended specification including the recommended encoding.

--- a/src/cheri/insns/gcperm_32bit.adoc
+++ b/src/cheri/insns/gcperm_32bit.adoc
@@ -21,7 +21,7 @@ include::wavedrom/gcperm.adoc[]
 Description::
 Convert the unpacked <<AP-field>> and <<SDP-field>>s of capability `{cs1}`
 into a bit field, with the same format as used by <<CLRPERM>> (see <<gcperm_bit_field>>),
-zero extend and write the result to `rd`.
+zero-extend, and write the result to `rd`.
 +
 All bits in the `[23:0]` range that are reserved or assigned to extensions that are not implemented by the current hart are hardwired to 1.
 +

--- a/src/cheri/insns/gctag_32bit.adoc
+++ b/src/cheri/insns/gctag_32bit.adoc
@@ -18,7 +18,7 @@ Encoding::
 include::wavedrom/gctag.adoc[]
 
 Description::
-Zero extend the value of `{cs1}.tag` and write the result to `rd`.
+Zero-extend the value of `{cs1}.tag` and write the result to `rd`.
 
 Operation::
 +

--- a/src/cheri/insns/gctype_32bit.adoc
+++ b/src/cheri/insns/gctype_32bit.adoc
@@ -19,7 +19,7 @@ Encoding::
 include::wavedrom/gctype.adoc[]
 
 Description::
-Decode the architectural capability type (<<sec_cap_type>>) from `{cs1}`, zero extend and write the result to `rd`.
+Decode the architectural capability type (<<sec_cap_type>>) from `{cs1}`, zero-extend, and write the result to `rd`.
 +
 include::no_tag_affect.adoc[]
 

--- a/src/cheri/insns/load_32bit_cap.adoc
+++ b/src/cheri/insns/load_32bit_cap.adoc
@@ -22,7 +22,7 @@ Authorize the memory access with the capability in `{cs1}`.
 +
 Load a naturally aligned YLEN-bit data value and associated {ctag} from memory.
 +
-NOTE: The loaded {ctag} may be set to zero under platform specified conditions, such as by a hardware based use-after-free prevention scheme.
+NOTE: The loaded {ctag} may be set to zero under platform-specified conditions, such as by a hardware-based use-after-free prevention scheme.
  Privileged mechanisms may also set the loaded {ctag} to zero such as PMA settings or virtual memory system page table entry configuration.
 +
 NOTE: Extensions may also specify additional conditions which set the {ctag} to zero.
@@ -33,7 +33,7 @@ The final value of `{cd}` is determined as follows:
 +
 . If `{cs1}` does not grant <<c_perm>> then set `{cd}.tag=0`.
 +
-. If `{cd}.tag=1`, `{cs1}` does not grant <<lm_perm>> and `{cd}` is not sealed, then an implicit <<CLRPERM>> is performed to clear <<w_perm>> and <<lm_perm>> from `{cd}`.
+. If `{cd}.tag=1`, `{cs1}` does not grant <<lm_perm>>, and `{cd}` is not sealed, then an implicit <<CLRPERM>> is performed to clear <<w_perm>> and <<lm_perm>> from `{cd}`.
 +
 NOTE: The implicit <<CLRPERM>> is not required to set `{cd}.tag=0` if the loaded data fails any <<section_cap_integrity,integrity>> checks.
  A suggested implementation is to only check the <<AP-field>> for legal values, and set the whole <<AP-field>> to zero if the check fails.

--- a/src/cheri/insns/load_exceptions.adoc
+++ b/src/cheri/insns/load_exceptions.adoc
@@ -1,5 +1,5 @@
 Exceptions::
-Raise a load access fault exception when the effective address is not aligned to YLEN/8.
+Raise a load access fault exception when the effective address is not naturally aligned to YLEN/8.
 +
 Exceptions occur when the authorizing capability fails one of the checks listed below:
 +

--- a/src/cheri/insns/store_32bit_cap.adoc
+++ b/src/cheri/insns/store_32bit_cap.adoc
@@ -29,7 +29,7 @@ Set the stored {ctag} to zero if:
 +
 . `{cs2}.tag=0`, or
 . `{cs1}` does not grant <<c_perm>>, or
-. Platform specified conditions or privileged configurations (e.g., PMAs or PTEs) specify that it must be set to zero.
+. Platform-specified conditions or privileged configurations (e.g., PMAs or PTEs) specify that it must be set to zero.
 +
 NOTE: Extensions may define further circumstances under which stored capabilities may have their {ctag}s set to zero.
  <<section_zylevels1>> is an example of this.

--- a/src/cheri/insns/store_32bit_cap.adoc
+++ b/src/cheri/insns/store_32bit_cap.adoc
@@ -35,7 +35,7 @@ NOTE: Extensions may define further circumstances under which stored capabilitie
  <<section_zylevels1>> is an example of this.
 +
 Exceptions::
-Raise a store/AMO access fault exception when the effective address is not aligned to YLEN/8.
+Raise a store/AMO access fault exception when the effective address is not naturally aligned to YLEN/8.
 +
 include::store_exceptions.adoc[]
 

--- a/src/cheri/insns/store_cond_cap_32bit.adoc
+++ b/src/cheri/insns/store_cond_cap_32bit.adoc
@@ -28,7 +28,7 @@ The written {ctag} may be cleared following the same modification rules as <<STO
 include::malformed_no_check.adoc[]
 +
 Exceptions::
-Raise a store/AMO access fault exception when the effective address is not aligned to YLEN/8.
+Raise a store/AMO access fault exception when the effective address is not naturally aligned to YLEN/8.
 +
 include::store_exceptions.adoc[]
 

--- a/src/cheri/insns/zcmt_cmjalt.adoc
+++ b/src/cheri/insns/zcmt_cmjalt.adoc
@@ -34,7 +34,7 @@ If the <<jvt_y>> check fails, then set the {ctag} of the target <<pcc>> to zero.
 include::zcm_common.adoc[]
 
 Permissions ({cheri_base32_ext_name})::
-Requires <<jvt_y>> to have its {ctag} set to one, not be sealed, have <<x_perm>> and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
+Requires <<jvt_y>> to have its {ctag} set to one, not be sealed, grant <<x_perm>>, and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/cheri/insns/zcmt_cmjt.adoc
+++ b/src/cheri/insns/zcmt_cmjt.adoc
@@ -34,7 +34,7 @@ If the <<jvt_y>> check fails, then set the {ctag} of the target <<pcc>> to zero.
 include::zcm_common.adoc[]
 
 Permissions ({cheri_base32_ext_name})::
-Requires <<jvt_y>> to have its {ctag} set to one, not be sealed, have <<x_perm>> and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
+Requires <<jvt_y>> to have its {ctag} set to one, not be sealed, grant <<x_perm>>, and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -46,9 +46,9 @@ This section lists new extensions available to {cheri_base_ext_name}, and also e
 Almost all existing RISC-V extensions can be added to an implementation, but in most
 cases they will have some behavioral differences and/or new instructions operating on capabilities.
 
-==== Stable Extensions and Specifications
+==== Extensions and Specifications
 
-.Unprivileged stable {cheri_base_ext_name} base ISAs and extensions
+.Unprivileged {cheri_base_ext_name} base ISAs and extensions
 [#unpriv-extension-status]
 [options=header,align=center,width="90%"]
 |=============================================================================================================================================================
@@ -67,18 +67,20 @@ endif::[]
 |<<rvy_zaamo_insn_table, {rvy_zaamo_ext_name}>>             | New 32-bit encodings added to Zaamo
 |=============================================================================================================================================================
 
-.Unprivileged stable extensions where {cheri_base_ext_name} modifies the behavior
+.Standard base ISAs and extensions with differences under {cheri_base_ext_name}
 [#unpriv-mod-extension-status]
 [options=header,align=center,width="90%"]
 |=============================================================================================================================================================
-| Extension or Specification                                | Description
-|<<{rvy_i_mod_file_name},     {rvy_i_mod_ext_name}>>        | RVI instructions modified by {cheri_base_ext_name}
-|<<{rvy_zca_mod_file_name},   {rvy_zca_mod_ext_name}>>      | C instructions modified by {cheri_base_ext_name}
-|<<section_cheri_vector_integration, V ({cheri_base_ext_name} modified behavior)>> | V instructions modified by {cheri_base_ext_name}
-|<<{rvy_zicbom_mod_file_name},{rvy_zicbom_mod_ext_name}>>   | Zicbom instructions modified by {cheri_base_ext_name}
-|<<{rvy_zicbop_mod_file_name},{rvy_zicbop_mod_ext_name}>>   | Zicbop instructions modified by {cheri_base_ext_name}
-|<<{rvy_zicboz_mod_file_name},{rvy_zicboz_mod_ext_name}>>   | Zicboz instructions modified by {cheri_base_ext_name}
-|<<{rvy_zicsr_mod_file_name}, {rvy_zicsr_mod_ext_name}>>    | Zicsr instructions modified by {cheri_base_ext_name}
+| Base ISA or Extension | Differences
+|<<{rvy_i_mod_file_name},     I>>      | Control flow instructions and load/stores use capability values as address operands.
+Load/stores require capability operands and check permissions and bounds
+|<<{rvy_zca_mod_file_name},   Zca>>    | Compressed control-flow, load/store, and stack-pointer adjustment instructions operate on capabilities.
+Load/stores require capability operands and check permissions and bounds
+|<<section_cheri_vector_integration, V>> | Vector memory access instructions require capability operands and check permissions and bounds.
+|<<{rvy_zicbom_mod_file_name}, Zicbom>> | Cache-block management operations require capability operands and check permissions and bounds.
+|<<{rvy_zicbop_mod_file_name}, Zicbop>> | Cache-block prefetch operations require capability operands and check permissions and bounds.
+|<<{rvy_zicboz_mod_file_name}, Zicboz>> | Cache-block zero operations require capability operands and check permissions and bounds.
+|<<{rvy_zicsr_mod_file_name}, Zicsr>>  | Access to privileged and select unprivileged CSRs is constrained by <<asr_perm>>.
 |=============================================================================================================================================================
 CHERI defines new state and behavior for the privileged modes:
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -735,7 +735,7 @@ If _pte_._{pte_cap_rw_name_lc}_=1 then:
 * All capability loads and capability stores operate as normal.
 
 NOTE: The reserved bits _pte_._{rv64y_pte4_field_name_lc}[2:0]_ follow the standard reserved behavior for PTE bits.
-They are allocated by <<section_cheri_priv_crg_ext,{cheri_priv_crg_ext}>>, which redefines the entire _pte_._{rv64y_pte4_field_name_lc}_ field when enabled.
+These bits are allocated by <<section_cheri_priv_crg_ext,{cheri_priv_crg_ext}>>, which redefines the entire _pte_._{rv64y_pte4_field_name_lc}_ field when enabled.
 
 See <<sv32algorithm_rvy>> for the effect on the Virtual Address Translation Process.
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -158,7 +158,7 @@ NOTE: The list also includes <<ddc>> if <<section_cheri_hybrid_ext>> is implemen
 NOTE: This restriction ensures M-mode software cannot drop CHERI checks by modifying <<misa_y,misa>> once they have been configured.
  A simpler conforming implementation could prevent setting <<misa_y,misa>>.{CRE} to zero if the capability metadata of any of these registers has ever been written to, rather than dynamically checking the current metadata.
 
-Either misa.I or misa.E is _also_ set to indicate whether 32 or 16 general purpose registers are present.
+Either misa.I or misa.E is _also_ set to indicate whether 32 or 16 general-purpose registers are present.
 
 NOTE: Implementations which allow misa.C to be writable need to legalize `__x__epc`
  on _reading_ if the misa.C value has changed since the value was written as this
@@ -373,7 +373,7 @@ NOTE: In the table below `auth_cap` is `{cs1}`, unless {cheri_default_ext_name} 
 | All                                            | {cheri_excep_cause_pc}     | {cheri_excep_name_pc} | Any byte of the current instruction is out of <<pcc>> bounds^1^
 | All                                            | {cheri_excep_cause_pc}     | {cheri_excep_name_pc} | <<pcc>> fails any <<section_cap_integrity,integrity>> checks.
 4+| *CSR/Xret additional exception check*
-| CSR*, <<MRET_CHERI>>, <<SRET_CHERI>>, <<CBO_INVAL_CHERI>> | 2 | Illegal instruction | <<pcc>> does not grant <<asr_perm>> when required for CSR access or execution of <<MRET_CHERI>>, <<SRET_CHERI>> or <<CBO_INVAL_CHERI>>
+| CSR*, <<MRET_CHERI>>, <<SRET_CHERI>>, <<CBO_INVAL_CHERI>> | 2 | Illegal instruction | <<pcc>> does not grant <<asr_perm>> when required for CSR access or execution of <<MRET_CHERI>>, <<SRET_CHERI>>, or <<CBO_INVAL_CHERI>>
 4+| *Load additional exception checks*
 | All loads                                      | {cheri_excep_cause_ld}     | {cheri_excep_name_ld} | `auth_cap` {ctag} is zero
 | All loads                                      | {cheri_excep_cause_ld}     | {cheri_excep_name_ld} | `auth_cap` is sealed
@@ -408,7 +408,7 @@ NOTE: CHERI adds architectural guarantees that can prove to be micro-architectur
  +
  Programmers should be able to rely on instructions that fail CHERI permission checks not to update microarchitectural state, e.g., not updating cache state for a load which fails a bound check.
  +
- When implementing an {cheri_base_ext_name} hart, micro-architects need to carefully consider the interaction of raising exceptions late in the pipeline, speculation windows and the resulting side-channel attacks.
+ When implementing an {cheri_base_ext_name} hart, micro-architects need to carefully consider the interaction of raising exceptions late in the pipeline, speculation windows, and the resulting side-channel attacks.
 
 [#section_pma]
 === Physical Memory Attributes (PMA)

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -3,7 +3,7 @@
 
 This chapter introduces a new set of base ISAs called {cheri_base_ext_name} that extend the RV32[IE]/RV64[IE] base ISAs with CHERI.
 
-The {cheri_base_ext_name} base ISA can be composed with other standard options to bases such as Zfinx.
+The {cheri_base_ext_name} base ISA will also be compatible with other standard bases, such as a Zfinx base.
 
 === CHERI Overview
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -19,7 +19,7 @@ The _capability encoding format_ gives full details of how CHERI capabilities ar
 For example, in {rv64y_uni_base_name}:
 
 . `XLEN=64`
-. `L` denotes a parameterized base.
+. `L` denotes a long base name.
 . `Y` denotes a CHERI base.
 . `A` denotes the capability encoding format.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -20,10 +20,12 @@ For example, in {rv64y_uni_base_name}:
 
 . `XLEN=64`
 . `L` denotes a long base name.
+. When `I` or `E` is omitted, the default is 32 integer registers (`I`); `E` specifies 16 integer registers (e.g., `RV64LEYA`).
 . `Y` denotes a CHERI base.
-. `A` denotes the capability encoding format.
+. `A` denotes the capability encoding format; the capability encoding format after `Y` is mandatory.
 
 NOTE: This naming scheme is based on the RISC-V https://lists.riscv.org/g/tech-unprivileged/topic/longer_base_name_proposal/116854896["longer base name" proposal], which allows base ISA names longer than two characters.
+Making the capability encoding format after `Y` mandatory simplifies future long base naming.
 
 NOTE: Future RV64 CHERI capability encoding formats could be named RV64LYB, RV64LYC, and so on, or they may have more descriptive names after the RV64LY prefix.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -117,7 +117,6 @@ It indicates whether a YLEN-bit register or YLEN-aligned memory location contain
 If the {ctag} is set to one, the capability is valid and may authorize operations, subject to type, permission, <<sec_cap_bounds_overview,bounds>>, and integrity checks.
 
 All registers or memory locations able to hold a valid capability are YLEN bits wide and have an associated {ctag}.
-These are referred to as being _YLEN-bit_ in this specification.
 
 Not all memory in a real system will support {ctag}s.
 The Execution Environment Interface (EEI) will define what regions of the address space support them.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -123,7 +123,7 @@ The Execution Environment Interface (EEI) will define what regions of the addres
 
 The {ctag} cannot be directly set by software; it is _not_ a conventionally accessible bit of state.
 If the {ctag} is set to one then it shows that the capability has been derived correctly according to the principles listed above (_provenance_, _integrity_, _monotonicity_).
-If the rules are followed then the {ctag} will propagate through the instructions that modify, load, or store the capability.
+If the rules are followed then the {ctag} will propagate through the instructions that modify, load, or store the capability value.
 
 Therefore, whenever an instruction writes a capability with the {ctag} set to one to a register or to memory:
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -122,7 +122,7 @@ The Execution Environment Interface (EEI) will define what regions of the addres
 
 The {ctag} cannot be directly set by software; it is _not_ a conventionally accessible bit of state.
 If the {ctag} is set to one then it shows that the capability has been derived correctly according to the principles listed above (_provenance_, _integrity_, _monotonicity_).
-If the rules are followed then the {ctag} will propagate through the instructions that modify, load, or store the capability value.
+If the rules are followed then the {ctag} will propagate through the instructions that derive, load, or store the capability value.
 
 Therefore, whenever an instruction writes a capability with the {ctag} set to one to a register or to memory:
 
@@ -133,12 +133,13 @@ Therefore, whenever an instruction writes a capability with the {ctag} set to on
 * The instruction may have checked that none of the input capabilities were corrupted.
 ** This is the _integrity_ check. Not all instructions check all input operands for _integrity_.
 
-Capability load/store require the _provenance_ check:
+For capability loads and stores, provenance is preserved across memory:
 
-* Any store that wrote the capability to memory was correctly authorized.
-* Any load that read the capability from memory was correctly authorized.
+* Storing a capability to memory preserves the {ctag} only if the store is performed using a valid capability that authorizes storing capabilities to that memory location by checking that every stored byte is within capability bounds, and that suitable permissions are granted to write to memory.
+* Loading a capability from memory preserves the {ctag} in the destination register only if the load is performed using a valid capability that authorizes loading capabilities from that memory location by checking that every byte is within capability bounds, and that suitable permissions are granted to read from memory.
 
-When an operation fails a check, either due to software error or malicious intent, the operation raises an exception or sets the resulting {ctag} to zero, as defined by each instruction.
+When a memory access fails a check, either due to software error or malicious intent, the operation raises an exception.
+For other instructions a failed check will typically set the resulting {ctag} to zero, the exact behavior is defined by each instruction.
 
 For a capability to be valid, the {ctag} must be set, otherwise a capability is invalid.
 
@@ -152,7 +153,8 @@ When the {ctag} associated with the memory location is zero, the location contai
 
 Every YLEN-bit register has a one-bit {ctag}, indicating whether the capability in the register is valid to be dereferenced.
 This {ctag} is set to 0 whenever an invalid capability operation is performed.
-Examples of such invalid operations include writing only the integer portion (the address field) of the register or attempting to increase bounds or permissions.
+
+NOTE: Examples of such invalid operations include writing only the integer portion (the address field) of the register or attempting to increase bounds or permissions.
 
 ==== {ctag_cap}s in memory
 
@@ -188,7 +190,7 @@ In a typical load/store unit, the expansion of the bounds from `{cs1}` and bound
 
 A compressed format is used to encode the bounds with a scheme similar to floating-point using an exponent and a mantissa.
 Therefore, small exponents can allow byte granularity on the bounds, but larger exponents give coarser granularity.
-The standard bounds encoding format for {rv64y_uni_base_name} is based upon the compressed bounds encoding scheme cite:[woodruff2019cheri] and defined in <<section_cap_bounds>>.
+The standard bounds encoding format for {rv64y_uni_base_name} is based upon the compressed bounds encoding scheme cite:[woodruff2019cheri] and is defined in <<section_cap_bounds>>.
 
 NOTE: Future CHERI bases may use encoding formats with different bounds encoding schemes (see <<sec_cap_encoding_formats>>).
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -266,12 +266,8 @@ A capability's <<section_cap_representable_check>> is also circular, so address 
 However, the decoded top bound address of a capability is XLEN + 1 bits wide and does *not* wrap.
 For example, a hypothetical capability with base 2^XLEN^ - 1 and top 2^XLEN^ + 1 is not a subset of the infinite capability and authorizes access to the last byte of the address space only, and does not authorize access to the byte at address 0.
 
-Like malformed bounds (see xref:section_cap_malformed[xrefstyle=short]), it is impossible for
-a CHERI core to generate a valid capability with architectural top > 2^XLEN^.
-
-If such a capability exists then it must have been caused by a logic or memory fault.
-Unlike malformed bounds, the top overflowing is not treated as a special case in the
-architecture: normal bounds check rules should be followed.
+A capability with architectural top > 2^XLEN^ is impossible for a CHERI core to generate and is only possible due to a logic or memory fault (similar to malformed bounds; see xref:section_cap_malformed[xrefstyle=short]).
+Unlike malformed bounds, the top overflowing is not treated as a special case in the architecture: normal bounds check rules should be followed.
 
 
 [#sec_cap_type, reftext="CT-field"]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -189,7 +189,7 @@ In a typical load/store unit, the expansion of the bounds from `{cs1}` and bound
 
 A compressed format is used to encode the bounds with a scheme similar to floating-point using an exponent and a mantissa.
 Therefore, small exponents can allow byte granularity on the bounds, but larger exponents give coarser granularity.
-One bounds encoding format based upon cite:[woodruff2019cheri] is defined in <<section_cap_bounds>>.
+The standard bounds encoding format for {rv64y_uni_base_name} is based upon the compressed bounds encoding scheme cite:[woodruff2019cheri] and defined in <<section_cap_bounds>>.
 
 NOTE: Future CHERI bases may use encoding formats with different bounds encoding schemes (see <<sec_cap_encoding_formats>>).
 
@@ -226,7 +226,7 @@ The number of shared bits depends on the exponent, see xref:section_cap_bounds[x
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the CHERI Concentrate cite:[woodruff2019cheri] encoding scheme for memory bounds shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the standard bounds encoding scheme shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>>.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -332,15 +332,15 @@ endif::[]
 Sentry capabilities can establish a form of control-flow integrity between mutually distrusting code.
 Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not elsewhere in a function.
 
-A sealed entry point capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
+A sealed entry point capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>; an unsealed version of this capability value is written to the <<pcc>>.
 If `{cd}` is not `{creg}0`, the link capability written to `{cd}` is written as a <<sentry_cap>>.
 
 ifndef::cheri_ratification_v1_only[]
 Sentry types may be restricted to _forward-edge_ only and _backward-edge_ only transitions to further improve control-flow integrity.
 
-* When <<JALR_CHERI>> is used as a function call only _forward-edge_ sentries in `{cs1}` are _unsealed_ on dereference.
-  If `{cd}` is not `{creg}0`, the returned `{cd}` value is always _sealed_ as a _backward-edge_ sentry type.
-* When <<JALR_CHERI>> is used as a function return only _backward-edge_ sentries in `{cs1}` are _unsealed_ on dereference.
+* When <<JALR_CHERI>> is used as a function call, an unsealed version of `{cs1}` is written to the <<pcc>> only if `{cs1}` is a forward-edge sentry.
+  If `{cd}` is not `{creg}0`, the link capability written to `{cd}` is sealed as a backward-edge sentry type.
+* When <<JALR_CHERI>> is used as a function return, an unsealed version of `{cs1}` is written to the <<pcc>> only if `{cs1}` is a backward-edge sentry.
 endif::[]
 
 NOTE: In addition to using sealed capabilities for sealed entry points, sealed capabilities can also be useful to software as secure software tokens.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -49,8 +49,7 @@ capabilities are always derived via valid manipulations of other capabilities
 that exceed those of their source capabilities (_monotonicity_).
 Tampering or modifying capabilities
 in an attempt to elevate their rights will yield an invalid capability.
-Attempting to dereference via an invalid capability
-will result in raising an exception.
+Attempting to dereference via an invalid capability will raise an exception.
 
 ^1^ Not all possible corrupted states are detected, see xref:section_cap_integrity[xrefstyle=full].
 
@@ -113,7 +112,7 @@ endif::[]
 ==== {ctag_title}
 
 The {ctag} is a single additional bit associated with YLEN-bit memory locations and YLEN-bit registers.
-It is stored separately (i.e., is _out-of-band_ or _hidden_), and is _hardware managed_.
+It is stored separately (i.e., is _out-of-band_ or _hidden_), and is _hardware-managed_.
 It indicates whether a YLEN-bit register or YLEN-aligned memory location contains a valid capability.
 If the {ctag} is set to one, the capability is valid and may authorize operations, subject to type, permission, <<sec_cap_bounds_overview,bounds>>, and integrity checks.
 
@@ -125,7 +124,7 @@ The Execution Environment Interface (EEI) will define what regions of the addres
 
 The {ctag} cannot be directly set by software; it is _not_ a conventionally accessible bit of state.
 If the {ctag} is set to one then it shows that the capability has been derived correctly according to the principles listed above (_provenance_, _integrity_, _monotonicity_).
-If the rules are followed then the {ctag} will propagate through the instructions that modify, load or store the capability.
+If the rules are followed then the {ctag} will propagate through the instructions that modify, load, or store the capability.
 
 Therefore, whenever an instruction writes a capability with the {ctag} set to one to a register or to memory:
 
@@ -300,7 +299,7 @@ ifndef::cheri_ratification_v1_only[All CHERI systems must support unsealed capab
 [#sealed_cap,reftext="sealed capability"]
 Sealed capabilities::
 Capabilities with `CT{ne}0` are sealed against modification and cannot be dereferenced to access memory.
-Instructions that operate on capabilities will produce a result with the {ctag} set to zero if the source capability is sealed and the operation would alter its address, bounds, or permissions.
+Instructions that operate on capabilities will produce a result with the {ctag} set to zero if the source capability is sealed and the operation would result in altered address, bounds, or permissions.
 ifndef::cheri_ratification_v1_only[Extensions that extend the capability metadata must describe their interaction(s) with sealed capabilities.]
 
 Sealing::
@@ -335,7 +334,7 @@ They can establish a form of control-flow integrity between mutually distrusting
 Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not elsewhere in a function.
 
 A sealed entry point capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
-If `{cd}` is not `{creg}0`, the link capability written to `{cd}` is also written as a <<sentry_cap>>.
+If `{cd}` is not `{creg}0`, the link capability written to `{cd}` is written as a <<sentry_cap>>.
 
 ifndef::cheri_ratification_v1_only[]
 Sentry types may be restricted to _forward-edge_ only and _backward-edge_ only transitions to further improve control-flow integrity.
@@ -371,8 +370,8 @@ ifdef::cheri_ratification_v1_only[]
 endif::[]
 ifndef::cheri_ratification_v1_only[]
 | Unrestricted <<sentry_cap>>   | 1                 | Immutable _unrestricted sentry_ type for both _forward-edge_ and _backward-edge_ transitions.
-| Forward-edge  <<sentry_cap>>  | Extension defined | Immutable _sentry_ type for _forward-edge_ transitions.
-| Backward-edge <<sentry_cap>>  | Extension defined | Immutable _sentry_ type for _backward-edge_ transitions.
+| Forward-edge  <<sentry_cap>>  | Extension-defined | Immutable _sentry_ type for _forward-edge_ transitions.
+| Backward-edge <<sentry_cap>>  | Extension-defined | Immutable _sentry_ type for _backward-edge_ transitions.
 endif::[]
 |===
 
@@ -418,7 +417,7 @@ Future extensions and capability encoding formats may declare new <<CT-field>> v
 This metadata field encodes architecturally defined permissions of the capability.
 Permissions grant access subject to the <<cap_valid_tag>> being set to one, the capability being unsealed, and bounds checks passing.
 
-NOTE: Any memory operation is also contingent on requirements imposed by other RISC-V architectural features, such as virtual memory, PMP and PMAs, even if the capability grants sufficient permissions.
+NOTE: Any memory operation is also contingent on requirements imposed by other RISC-V architectural features, such as virtual memory, PMP, and PMAs, even if the capability grants sufficient permissions.
 
 The permissions defined in {cheri_base_ext_name} are listed in <<ap_field_summary>>.
 All capability encoding formats must support at least this set of permissions.
@@ -566,7 +565,7 @@ Extensions introducing new permissions may require these to be provided by root 
 [#null-cap,reftext="NULL"]
 NULL Capability::
 A capability with all-zero metadata, its {ctag} set to zero, and an address of zero is referred to as the _NULL_ capability.
-This capability grants no permissions and any dereference results in raising an exception.
+This capability grants no permissions and any dereference raises an exception.
 
 [#sec_cap_encoding_formats, reftext="capability encoding format"]
 === Capability encoding formats
@@ -662,9 +661,9 @@ As stated above, unless noted otherwise, state which can hold addresses is exten
 NOTE: The privileged `mconfigptr` CSR is the only documented exception to the rule.
 
 
-NOTE: A reminder that _all_ YLEN state also has a hardware managed {ctag}.
+NOTE: A reminder that _all_ YLEN state also has a hardware-managed {ctag}.
 
-==== General Purpose Registers
+==== General-Purpose Registers
 
 The <<gprs,XLEN-wide integer registers>> (e.g., `x1`, `x2`) are all widened to YLEN bits, each gaining an associated {ctag}, as shown in <<base_cap_registers>>.
 
@@ -696,7 +695,7 @@ The zero register (`x0`) is extended with zero metadata and its {ctag} set to ze
 ==== The Program Counter Capability (`{pcc}`)
 
 The `pc` is widened to a capability.
-Widening the `pc` allows the range of branches, jumps and linear execution for currently executing code to be restricted.
+Widening the `pc` allows the range of branches, jumps, and linear execution for currently executing code to be restricted.
 The <<pcc>> address field is the `pc` in the base RISC-V ISA so that the
 hardware automatically updates it as instructions are executed.
 
@@ -762,7 +761,7 @@ include::img/utidcreg.edn[]
 Each thread (as scheduled by the kernel) can have its own context stored in privileged data structures managed by the compartmentalization TCB, for example a stack of user-level compartment entries and exits.
 <<utidc>> allows compartment-switching code to determine the currently running thread without a call into the operating system.
 This is read-only without <<asr_perm>> to prevent a malicious compartment from tricking the switching mechanism into accessing data corresponding to the wrong thread.
-While the RISC-V ABI includes a _thread pointer (tp)_ register, it is not usable for the purpose of reliably identifying the current software thread because the tp register is a general purpose register and can be changed arbitrarily by untrusted code.
+While the RISC-V ABI includes a _thread pointer (tp)_ register, it is not usable for the purpose of reliably identifying the current software thread because the tp register is a general-purpose register and can be changed arbitrarily by untrusted code.
 Extending <<utidc>> to a capability allows a data structure to be shared (guarded by e.g., the subset sealing mechanism), which allows for example efficient recovery of a trusted stack, without requiring additional indirection.
 =====
 
@@ -1153,7 +1152,7 @@ All load instructions, except for <<LOAD_CAP>>, always set the {ctag} and the me
 All store instructions, except for <<STORE_CAP>>, always write zero to the {ctag} or {ctag}s associated with the memory locations that are written to.
 Therefore, misaligned stores may clear up to two associated {ctag}s.
 
-The changed interpretation of the base register also applies to all loads, stores and all other memory operations defined in later chapters of this specification with a base operand of `rs1` unless stated otherwise.
+The changed interpretation of the base register also applies to all loads, stores, and all other memory operations defined in later chapters of this specification with a base operand of `rs1` unless stated otherwise.
 
 IMPORTANT: Under {cheri_base_ext_name} _all_ loads and stores are authorized by `{cs1}`.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -372,6 +372,7 @@ ifndef::cheri_ratification_v1_only[]
 | Forward-edge  <<sentry_cap>>  | Extension-defined | Immutable _sentry_ type for _forward-edge_ transitions.
 | Backward-edge <<sentry_cap>>  | Extension-defined | Immutable _sentry_ type for _backward-edge_ transitions.
 endif::[]
+| All other values              | Reserved          | Reserved for future standard extensions or capability encoding formats.
 |===
 
 ifndef::cheri_ratification_v1_only[]
@@ -406,7 +407,7 @@ endif::[]
 Future extensions and capability encoding formats may declare new <<CT-field>> values, examples of which are:
 
 * Sealed types which cannot be used as a <<sentry_cap>>
-* <<sentry_cap>> types which can be only used for function calls or for function returns for improved CFI.
+* <<sentry_cap>> types which can be used only for function calls or only for function returns for improved CFI: specific <<CT-field>> values are required for each, in contrast with the current <<sentry_cap>> which can be used for both.
 
 ====
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -141,18 +141,18 @@ For capability loads and stores, provenance is preserved across memory:
 When a memory access fails a check, either due to software error or malicious intent, the operation raises an exception.
 For other instructions a failed check will typically set the resulting {ctag} to zero, the exact behavior is defined by each instruction.
 
-For a capability to be valid, the {ctag} must be set, otherwise a capability is invalid.
+For a capability to be valid, the {ctag} must be set to one, otherwise a capability is invalid.
 
 Using an invalid capability to dereference memory or authorize any operation raises an exception.
 All capabilities derived from invalid capabilities are themselves invalid, i.e., their {ctag}s are zero.
 
-NOTE: Writing non-capability data into a register or memory location causes the {ctag} to be set to 0.
+NOTE: Writing non-capability data into a register or memory location causes the {ctag} to be set to zero.
 When the {ctag} associated with the memory location is zero, the location contains non-capability data.
 
 ==== {ctag_cap}s in registers
 
 Every YLEN-bit register has a one-bit {ctag}, indicating whether the capability in the register is valid to be dereferenced.
-This {ctag} is set to 0 whenever an invalid capability operation is performed.
+This {ctag} is set to zero whenever an invalid capability operation is performed.
 
 NOTE: Examples of such invalid operations include writing only the integer portion (the address field) of the register or attempting to increase bounds or permissions.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -53,12 +53,9 @@ Attempting to dereference via an invalid capability will raise an exception.
 
 ^1^ Not all possible corrupted states are detected, see xref:section_cap_integrity[xrefstyle=full].
 
-CHERI capabilities may be held in registers or memory, and are loaded,
-stored, and dereferenced using CHERI-aware instructions that expect capability
-operands rather than integer addresses. On system initialization, initial capabilities
-are made available to software by the execution environment via general purpose
-registers. All other capabilities will be derived from these initial valid
-capabilities through valid capability transformations.
+CHERI capabilities may be held in registers or memory, and are loaded, stored, and dereferenced using CHERI-aware instructions that expect capability operands rather than integer addresses.
+Upon initialization, the execution environment provides initial capabilities to software via general-purpose registers.
+All other capabilities will be derived from these initial valid capabilities through valid capability transformations.
 
 Developers can use CHERI to build fine-grained spatial and temporal memory
 protection into their system software and applications and significantly
@@ -203,7 +200,7 @@ NOTE: The _length_ and _top_ are (XLEN+1)-bit values, so <<GCLEN>> and <<GCTOP>>
 
 ==== Deriving New Bounds
 
-On system initialization, one or more <<root-cap>> capabilities are available.
+Upon initialization, the execution environment defines how the <<root-cap>> capabilities are made available to the execution context.
 All capabilities with smaller bounds are derived from these.
 
 The bounds are reduced using the <<SCBNDS>>, <<SCBNDSI>> and <<SCBNDSR>> instructions.
@@ -544,14 +541,14 @@ NOTE: Software is completely free to define the usage of these bits.
 
 [#root-cap,reftext="Root"]
 Root Capabilities::
-_Root_ capabilities are those provided by the system on initialization.
+_Root_ capabilities are those provided by the execution environment upon initialization.
 In some capability encoding formats there is a single _Infinite_ capability value,
 which grants all permissions and has bounds covering the whole 2^XLEN^ address space;
 in such systems, _root_ capabilities are often _Infinite_.
 +
 Other capability encoding formats may have a set of _root_ capabilities distinguishing between data and executable capabilities as shown below.
 +
-At system initialization the set of all _root_ capabilities must be made available to software.
+Upon initialization, the execution environment defines how root capabilities are made available to software.
 +
 NOTE: Implementations are not required to provide access to the entire address space to a single hart, the _root_ capabilities may be restricted to only cover a subset of the entire address space, or to remove certain permissions.
 
@@ -714,7 +711,7 @@ A failing check raises a CHERI exception.
 * All bytes of the instruction must be in bounds.
 * All <<section_cap_integrity,integrity>> checks must have passed.
 
-On system initialization the `pc` bounds and permissions must be set such that the program can run successfully (e.g., by setting it to a <<root-rx-cap>> capability to ensure _all_ instructions are in bounds).
+Upon initialization, the execution environment must set `<<pcc>>` bounds and permissions such that the program can run successfully (e.g., by setting `<<pcc>>` to a <<root-rx-cap>> capability to ensure _all_ instructions are in bounds).
 
 NOTE: Future ISA extensions should respect these rules so that the checked bits do not need to be stored in all copies of the <<pcc>> in the implementation.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -113,7 +113,7 @@ endif::[]
 
 The {ctag} is a single additional bit associated with YLEN-bit memory locations and YLEN-bit registers.
 It is stored separately (i.e., is _out-of-band_ or _hidden_), and is _hardware-managed_.
-It indicates whether a YLEN-bit register or YLEN-aligned memory location contains a valid capability.
+It indicates whether a YLEN-bit register or naturally aligned YLEN-bit memory location contains a valid capability.
 If the {ctag} is set to one, the capability is valid and may authorize operations, subject to type, permission, <<sec_cap_bounds_overview,bounds>>, and integrity checks.
 
 All registers or memory locations able to hold a valid capability are YLEN bits wide and have an associated {ctag}.
@@ -157,8 +157,8 @@ Examples of such invalid operations include writing only the integer portion (th
 
 ==== {ctag_cap}s in memory
 
-{ctag_cap}s are tracked through the memory subsystem: every aligned YLEN-bit wide region has a non-addressable one-bit {ctag}, which the hardware manages atomically with the data.
-The implementation must set the {ctag} to zero if any byte in the YLEN/8 aligned memory region is ever written using an operation other than a store of a capability operand.
+{ctag_cap}s are tracked through the memory subsystem: every naturally aligned YLEN-bit wide region has a non-addressable one-bit {ctag}, which the hardware manages atomically with the data.
+The implementation must set the {ctag} to zero if any byte in the naturally aligned YLEN-bit memory region is ever written using an operation other than a store of a capability operand.
 For example, the <<STORE_CAP>> instruction sets the {ctag} to one if all the instruction's prerequisites are met, including `{cs2}` 's {ctag} being set to one, but <<ldst,SW>> will always set the stored {ctag} to zero.
 
 NOTE: All system memory and caches that store capabilities must preserve this abstraction, handling the {ctag}s atomically with the data.
@@ -1059,11 +1059,10 @@ If <<c_perm>> is not granted then:
 //stores of capabilities to raise exceptions when the authorizing capability does not grant both
 //<<w_perm>> and <<c_perm>> and the stored capability has the {ctag} set.
 
-All capability data memory access instructions require YLEN-aligned addresses, and will
-take an access fault exception if this requirement is not met.
+All capability data memory access instructions require naturally aligned addresses, and will take an access fault exception if this requirement is not met.
 They cannot be emulated.
 
-NOTE: An access fault is raised instead of a misaligned exception since these instructions cannot be emulated since there is one hidden {ctag} per YLEN-aligned memory region.
+NOTE: An access fault is raised instead of a misaligned exception because these instructions cannot be emulated since there is one hidden {ctag} per naturally aligned YLEN-bit memory region.
 
 All memory accesses, of any type, require permission from the authorizing capability in `{cs1}`.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -208,7 +208,7 @@ All capabilities with smaller bounds are derived from these.
 
 The bounds are reduced using the <<SCBNDS>>, <<SCBNDSI>> and <<SCBNDSR>> instructions.
 
-They all copy `{cs1}` to the output `{cd}`, set the _base_ bound address of `{cd}` to `{cs1}.address`, subject to encoding granularity constraints, and set the _length_ of `{cd}` from `rs2` or the immediate field depending on the instruction.
+These bounds-reducing instructions all copy `{cs1}` to the output `{cd}`, set the _base_ bound address of `{cd}` to `{cs1}.address`, subject to encoding granularity constraints, and set the _length_ of `{cd}` from `rs2` or the immediate field depending on the instruction.
 
 * <<SCBNDS>> sets the _base_ to `{cs1}.address`, and the _length_ to `rs2`.
 ** The {ctag} is set to zero if the bounds cannot be encoded exactly.
@@ -329,7 +329,7 @@ ifdef::cheri_ratification_v1_only[]
 NOTE: Such function pointers are sometimes known as "sentries", a contraction of "sealed entries".
 endif::[]
 
-They can establish a form of control-flow integrity between mutually distrusting code.
+Sentry capabilities can establish a form of control-flow integrity between mutually distrusting code.
 Because they are immutable, the jump target cannot be modified, ensuring that control flow can only enter at the specific address encoded in the capability and not elsewhere in a function.
 
 A sealed entry point capability may be passed as the `{cs1}` argument to <<JALR_CHERI>>, and is _unsealed_ on dereference.
@@ -396,7 +396,7 @@ an additional bit to the <<sec_cap_type>> field.
 
 Capability encoding formats will explicitly state whether these are relevant to them.
 
-They are not used by <<rv64y_cap_description>>, but are by the CHERIoT formats.
+Permission-dependent types are not used by <<rv64y_cap_description>>, but are by the CHERIoT formats.
 ====
 endif::[]
 
@@ -524,8 +524,8 @@ Capability encoding formats may impose additional constraints to reduce the numb
 [#SDP-field, reftext="SDP-field"]
 ==== Software-Defined Permissions (SDP)
 The metadata also contains an encoding-dependent number of software-defined permission (SDP) bits.
-They can be inspected by the kernel or application programs to enforce restrictions on API calls (e.g., permit/deny system calls, memory allocation, etc.).
-They can be cleared by <<CLRPERM>> but are not interpreted by the CPU otherwise.
+Software-defined permissions can be inspected by the operating system or application programs to enforce restrictions on API calls (e.g., permit/deny system calls, memory allocation, etc.).
+These permissions can be cleared by <<CLRPERM>> but are not interpreted by the CPU otherwise.
 
 While these bits are not used by the hardware as architectural permissions, modification follows the same rules: SDP bits can only be cleared and never set on valid capabilities.
 
@@ -1041,7 +1041,7 @@ include::insns/cram_32bit.adoc[]
 === Instructions to Load and Store Capability Data
 
 New loads and stores are introduced to handle capability data, <<LOAD_CAP>> and <<STORE_CAP>>.
-They atomically access YLEN bits of data and the associated {ctag}.
+These capability load and store instructions atomically access YLEN bits of data and the associated {ctag}.
 
 All capability memory accesses check for <<c_perm>> in the authorizing capability in `{cs1}`.
 
@@ -1060,7 +1060,7 @@ If <<c_perm>> is not granted then:
 //<<w_perm>> and <<c_perm>> and the stored capability has the {ctag} set.
 
 All capability data memory access instructions require naturally aligned addresses, and will take an access fault exception if this requirement is not met.
-They cannot be emulated.
+Misaligned capability accesses cannot be emulated.
 
 NOTE: An access fault is raised instead of a misaligned exception because these instructions cannot be emulated since there is one hidden {ctag} per naturally aligned YLEN-bit memory region.
 
@@ -1103,7 +1103,7 @@ include::insns/store_32bit_cap.adoc[]
 `ADD` and `ADDI` are not affected by the rule above.
 Even though they _are_ used for handling addresses, they also have other uses.
 New encodings are used for capability addition: <<CADD>> and <<CADDI>>.
-They must be used for all capability address incrementing.
+These capability add instructions must be used for all capability address incrementing.
 
 [NOTE]
 ====

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -471,12 +471,17 @@ NOTE: *CHERI v9 Note:* This permission does not exist in CHERI v9, but is simila
 endif::[]
 
 [#asr_perm,reftext="ASR-permission"]
-Access System Registers Permission (ASR, primarily used to authorize CSR accesses):: Allow read and write access to all privileged CSRs and some unprivileged CSRs, and the execution of some privileged instructions.
-<<asr_perm>> checks always use the permission in the <<pcc>>.
+Access System Registers Permission (ASR)::
+Authorize the execution of privileged instructions and access to CSRs.
+This permission only has an effect when the capability is installed in the <<pcc>>.
+<<asr_perm>> acts as an additional constraint and does not bypass normal privilege mode checks: having <<asr_perm>> in the <<pcc>> does not grant an unprivileged mode access to privileged CSRs.
+Lacking <<asr_perm>> in the <<pcc>> prevents access to privileged CSRs and restricted instructions even if the current privilege mode would otherwise permit it.
++
+Only the unprivileged CSRs listed below require <<asr_perm>>; other unprivileged CSRs remain accessible as usual.
 
 In the unprivileged {cheri_base_ext_name} ISA, the following are affected by <<asr_perm>>:
 
-* **Thread ID CSRs:** The <<utidc>> CSR requires <<asr_perm>> for writing but not for reading.
+* **Thread ID CSRs:** Writing to <<utidc>> requires <<asr_perm>> in the <<pcc>>, but reading does not require <<asr_perm>>.
 * **Instructions:** <<CBO_INVAL_CHERI>> requires <<asr_perm>> in the <<pcc>>.
 
 In the privileged {cheri_base_ext_name} ISA, the following are affected by <<asr_perm>>:

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -421,10 +421,6 @@ NOTE: Any memory operation is also contingent on requirements imposed by other R
 
 The permissions defined in {cheri_base_ext_name} are listed in <<ap_field_summary>>.
 All capability encoding formats must support at least this set of permissions.
-Extensions building on top of {cheri_base_ext_name} may define additional permissions.
-
-NOTE: An example of such an extension is <<section_zylevels1>>.
-
 Permissions can be cleared when deriving a new capability value (using <<CLRPERM>>) but they can never be added.
 
 .AP-field summary
@@ -438,6 +434,10 @@ Permissions can be cleared when deriving a new capability value (using <<CLRPERM
 | <<lm_perm>>  | Data memory permission         | Used to restrict the permissions of loaded capabilities.
 | <<asr_perm>> | Privileged state permission    | Authorize privileged instructions and CSR accesses.
 |==============================================================================
+
+Extensions building on top of {cheri_base_ext_name} may define additional permissions.
+
+NOTE: An example of such an extension is <<section_zylevels1>>.
 
 [#r_perm,reftext="R-permission"]
 Read Permission \(R):: Allow reading data from memory.

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -265,7 +265,7 @@ Depending on the size of the capability some addresses above top may be represen
 
 ===== Encoding bounds
 
-When <<SCBNDS>> is used to set the bounds of a capability the E, B and T fields are computed from the desired base and length as follows:
+When <<SCBNDS>> is used to set the bounds of a capability the E, B, and T fields are computed from the desired base and length as follows:
 
 [source]
 ----

--- a/src/cheri/rvy-cheriot-isa-unpriv.adoc
+++ b/src/cheri/rvy-cheriot-isa-unpriv.adoc
@@ -46,7 +46,7 @@ define any <<sec_cap_type_ambient,ambiently available>> sentry types.
 ==== Refining CHERI Capabilities
 
 [#zycheriot_u0_perm, reftext="CHERIoT U0 Permission"]
-===== Software Defined Permissions
+===== Software-Defined Permissions
 
 {cheriot_unpriv_ext_name} defines SDPLEN,
 the number of software-defined permissions, to be `1`.

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -24,7 +24,7 @@ The bit ranges in <<cap_encoding_xlen32_field_table>> are relative to the XLEN-b
 [#cap_encoding_xlen32_field_table,width="100%",options=header,cols="1,1,4"]
 |==============================================================================
 | Field      | Bit range | Comment
-| SDP        | 31:30     | <<SDP-field, Software Defined Permissions>>.
+| SDP        | 31:30     | <<SDP-field, Software-Defined Permissions>>.
 | AP         | 29:25     | <<AP-field-encoding32, Architectural Permissions>> (includes fields for <<section_cheri_hybrid_ext>> and <<section_zylevels1>>).
 | GL         | 24        | <<zylevels1_gl_flag, Global (GL) flag>> (<<section_zylevels1>> only).
 | CT         | 20        | <<CT-field, Capability Type field>>.

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -209,7 +209,7 @@ EF=1: The exponent is zero; TE, BE, and L8 form part of the address bounds.
 ^1^ Only valid if `enableL8=1`.
 
 The variables in <<rvy64_uni_base_name_bndsenc_param_summary>> are either taken directly from the capability metadata (see <<cap_encoding_xlen64_field_table>>) or, in the case of the upper and lower bits of `T` and `B`, are calculated from it.
-They are used as shown in the <<bounds_variable_usage,pseudo-code>> below.
+These variables are used as shown in the <<bounds_variable_usage,pseudo-code>> below.
 
 The bit widths of `T` and `B` are defined in terms of the mantissa width (`MW`) which
 is set depending on capability encoding as shown in

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -179,8 +179,6 @@ value of 0 represents CAP_MAX_E, and CAP_MAX_E represents 0 from the previous
 specification.
 endif::[]
 
-This bounds encoding scheme is based upon cite:[woodruff2019cheri].
-
 The bounds encode the _base_ and _top_ addresses that constrain memory accesses.
 The capability can be used to access any memory location A in the range base
 {le} A < top. The bounds are encoded in a compressed format, so it is not
@@ -234,10 +232,8 @@ when the {ctag} is set to one (see xref:section_cap_malformed[xrefstyle=short]).
 [#section_cap_bounds_decoding]
 ===== Calculation of Variables
 
-The metadata is encoded in a compressed format termed CHERI Concentrate cite:[woodruff2019cheri]. It
-uses a floating-point representation to encode the bounds relative to the
-capability address. The following subsections describe how the _base_ and _top_
-bounds are decoded from the metadata.
+The metadata uses a floating-point representation to encode the compressed bounds relative to the capability address.
+The following subsections describe how the _base_ and _top_ bounds are decoded from the metadata.
 
 The pseudocode below is normative.
 In this notation, `/` means "integer division", `[]` are the bit-select operators, `{}` is bit concatenation, `?:` is the conditional operator, and arithmetic is signed.

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -33,7 +33,7 @@ The bit ranges in <<cap_encoding_xlen64_field_table>> are relative to the XLEN-b
 [#cap_encoding_xlen64_field_table,width="100%",options=header,cols="1,1,4"]
 |==============================================================================
 | Field      | Bit range | Comment
-| SDP        | 63:60     | <<SDP-field64, Software Defined Permissions>>.
+| SDP        | 63:60     | <<SDP-field64, Software-Defined Permissions>>.
 | AP         | 52:45     | <<AP-field, Architectural Permissions>>, see <<cap_perms_encoding64>>.
 | P          | 44        | <<p_bit, Pointer Mode>> (<<section_cheri_hybrid_ext>> only).
 | GL         | 43        | <<zylevels1_gl_flag, Global (GL) flag>> (<<section_zylevels1>> only).
@@ -103,8 +103,8 @@ NOTE: Future extensions which define new permissions must augment <<cap_perms_en
 
 There are 9 bits in total allocated to the <<AP-field>> and the <<p_bit>>.
 
-* The total valid combinations of C, W, R, LM, LG and SL are 18.
-* The total valid combinations of X, ASR and P are 5.
+* The total valid combinations of C, W, R, LM, LG, and SL are 18.
+* The total valid combinations of X, ASR, and P are 5.
 * The two groups are fully orthogonal.
 
 Therefore there are 90 valid combinations encoded in 9-bits.
@@ -201,9 +201,9 @@ The variables related to the bounds decoding are shown in <<rvy64_uni_base_name_
 | BE        | Value either substituted into the exponent or the _base_ bound address depending on EF.
 | E         | Exponent that determines the position at which T and B are substituted into the capability's address.
 | L~8~^1^   | Value used to form either the MSB of the exponent or the MSB of the _top_ bound address.
-| EF        | Exponent format flag indicating the encoding for T, B and E: +
+| EF        | Exponent format flag indicating the encoding for T, B, and E: +
 EF=0: The exponent is calculated from TE and BE, and conditionally L8, so it is 'internal'. +
-EF=1: The exponent is zero; TE, BE and L8 form part of the address bounds.
+EF=1: The exponent is zero; TE, BE, and L8 form part of the address bounds.
 |==============================================================================
 
 ^1^ Only valid if `enableL8=1`.

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -16,7 +16,7 @@ There are two types of bus connections used in SoCs which contain CHERI CPUs:
 .. These buses will write the {ctag} to memory as an extension of the data write.
 . Non-{ctag}-aware buses, i.e., current non-CHERI-aware buses.
 .. Reads of tagged memory will not read the {ctag}.
-.. Writes to tagged memory will set the {ctag} of any YLEN-aligned YLEN-wide memory location to zero where any byte is overwritten by the memory write.
+.. Writes to tagged memory will set the {ctag} of any naturally aligned YLEN-bit memory location to zero where any byte is overwritten by the memory write.
 
 The fundamental rule for any CHERI system is that the {ctag} and data are always accessed atomically. For every naturally aligned YLEN-wide memory location, it must never be possible to:
 

--- a/src/cheri/vector-integration.adoc
+++ b/src/cheri/vector-integration.adoc
@@ -9,7 +9,7 @@ NOTE: A future extension may allow {ctag}s to be stored in vector registers.
   memory copying in software, such as the `memcpy()` standard C library function,
   that requires capabilities to be preserved,
   because the vector registers do not hold capabilities, so the {ctag}s of any
-  copied capabilities will be set to 0 in the destination memory.
+  copied capabilities will be set to zero in the destination memory.
 
 Under {cheri_base_ext_name}, vector loads and stores follow the standard rules for _active_ elements:
 

--- a/src/cheri/zylevelsN.adoc
+++ b/src/cheri/zylevelsN.adoc
@@ -39,7 +39,7 @@ In the base ISA this is a single bit comparison, behaving as follows:
 NOTE: Future extensions may make this field wider to enable more use cases.
 
 ifdef::cheri_v9_annotations[]
-NOTE: For `LVLBITS=1` this permission is equivalent to _StoreLocal_ in CHERI v9, Morello and CHERIoT.
+NOTE: For `LVLBITS=1` this permission is equivalent to _StoreLocal_ in CHERI v9, Morello, and CHERIoT.
 endif::[]
 
 [#zylevelsN_el_perm,reftext="EL-permission"]
@@ -116,7 +116,7 @@ NOTE: if W=0 or C=0 then SL is irrelevant
 |==============================================================================
 
 ifdef::cheri_v9_annotations[]
-NOTE: The current specification only defines up to two levels, equivalent to _local_ and _global_ capabilities from CHERI v9, Morello and CHERIoT.
+NOTE: The current specification only defines up to two levels, equivalent to _local_ and _global_ capabilities from CHERI v9, Morello, and CHERIoT.
 endif::[]
 
 === Encoding material (TODO)


### PR DESCRIPTION
This addresses most of the comments on https://drive.google.com/file/d/1O0UvR3vYf-R7vCZmqkrr-NfLlD-5mZQR/view?usp=sharing&resourcekey=0-yExBSDXWl2DmjsjQCYYeRA.



Should have addressed almost all PDF annotations. The following are open:

- naming of YSUNSEAL. ARC suggested YUNSEAL but that conflicts with the general one. Maybe we need a "S" suffix?
- Early introduction of Program Counter Capability (PCC)
- Names for privileged extensions
- Renaming YSENTRY->YSEALE. This is a normative change so needs to be a separate PR