### PR TITLE
CT -> CTag in register diagrams - and specify endianness

### DIFF
--- a/src/cheri/img/ddcreg.edn
+++ b/src/cheri/img/ddcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["XLEN" "" "" "XLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "ddc (Metadata)" {:span 32})
+(draw-box "ddc (Address)" {:span 32})
 
-(draw-box "ddc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "ddc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "XLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/ddcreg.edn
+++ b/src/cheri/img/ddcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "ddc (Metadata)" {:span 32})
+(draw-box "ddc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "ddc (Address)"  {:span 32})
+(draw-box "ddc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "XLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "XLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/dddcreg.edn
+++ b/src/cheri/img/dddcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["DXLEN" "" "" "DXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "dddc (Metadata)" {:span 32})
+(draw-box "dddc (Address)" {:span 32})
 
-(draw-box "dddc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "dddc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "DXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/dddcreg.edn
+++ b/src/cheri/img/dddcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "dddc (Metadata)" {:span 32})
+(draw-box "dddc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "dddc (Address)"  {:span 32})
+(draw-box "dddc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "DXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "DXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/dpccreg.edn
+++ b/src/cheri/img/dpccreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "dpc (Metadata)" {:span 32})
+(draw-box "dpc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "dpc (Address)"  {:span 32})
+(draw-box "dpc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "DXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "DXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/dpccreg.edn
+++ b/src/cheri/img/dpccreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["DXLEN" "" "" "DXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "dpc (Metadata)" {:span 32})
+(draw-box "dpc (Address)" {:span 32})
 
-(draw-box "dpc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "dpc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "DXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/drootcreg.edn
+++ b/src/cheri/img/drootcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["DXLEN" "" "" "DXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "drootc (Metadata)" {:span 32})
+(draw-box "drootc (Address)" {:span 32})
 
-(draw-box "drootc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "drootc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "DXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/drootcreg.edn
+++ b/src/cheri/img/drootcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "drootc (Metadata)" {:span 32})
+(draw-box "drootc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "drootc (Address)"  {:span 32})
+(draw-box "drootc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "DXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "DXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/dscratch0creg.edn
+++ b/src/cheri/img/dscratch0creg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["DXLEN" "" "" "DXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "dscratch0 (Metadata)" {:span 32})
+(draw-box "dscratch0 (Address)" {:span 32})
 
-(draw-box "dscratch0 (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "dscratch0 (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "DXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/dscratch0creg.edn
+++ b/src/cheri/img/dscratch0creg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "dscratch0 (Metadata)" {:span 32})
+(draw-box "dscratch0 (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "dscratch0 (Address)"  {:span 32})
+(draw-box "dscratch0 (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "DXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "DXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/dscratch1creg.edn
+++ b/src/cheri/img/dscratch1creg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "dscratch1 (Metadata)" {:span 32})
+(draw-box "dscratch1 (Metadata)" {:span 31})
 
-(draw-box ""    {:span 2 :borders {}})
+(draw-box ""    {:span 3 :borders {}})
 
-(draw-box "dscratch1 (Address)"  {:span 32})
+(draw-box "dscratch1 (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "DXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "DXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/dscratch1creg.edn
+++ b/src/cheri/img/dscratch1creg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "DXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["DXLEN" "" "" "DXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "dscratch1 (Metadata)" {:span 32})
+(draw-box "dscratch1 (Address)" {:span 32})
 
-(draw-box "dscratch1 (Metadata)" {:span 31})
-
-(draw-box ""    {:span 3 :borders {}})
-
-(draw-box "dscratch1 (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "DXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
+(draw-box "DXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/jvtcreg.edn
+++ b/src/cheri/img/jvtcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "jvt (Metadata)" {:span 32})
+(draw-box "jvt (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "jvt (Address)"  {:span 32})
+(draw-box "jvt (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "XLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "XLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/jvtcreg.edn
+++ b/src/cheri/img/jvtcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["XLEN" "" "" "XLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "jvt (Metadata)" {:span 32})
+(draw-box "jvt (Address)" {:span 32})
 
-(draw-box "jvt (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "jvt (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "XLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/mepccreg.edn
+++ b/src/cheri/img/mepccreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "mepc (Metadata, WARL)" {:span 32})
+(draw-box "mepc (Metadata, WARL)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "mepc (Address, WARL)"  {:span 32})
+(draw-box "mepc (Address, WARL)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "MXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "MXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/mepccreg.edn
+++ b/src/cheri/img/mepccreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["MXLEN" "" "" "MXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "mepc (Metadata, WARL)" {:span 32})
+(draw-box "mepc (Address, WARL)" {:span 32})
 
-(draw-box "mepc (Metadata, WARL)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "mepc (Address, WARL)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "MXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/mscratchcreg.edn
+++ b/src/cheri/img/mscratchcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["MXLEN" "" "" "MXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "mscratch (Metadata)" {:span 32})
+(draw-box "mscratch (Address)" {:span 32})
 
-(draw-box "mscratch (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "mscratch (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "MXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/mscratchcreg.edn
+++ b/src/cheri/img/mscratchcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "mscratch (Metadata)" {:span 32})
+(draw-box "mscratch (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "mscratch (Address)"  {:span 32})
+(draw-box "mscratch (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "MXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "MXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/mtidcreg.edn
+++ b/src/cheri/img/mtidcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "mtidc (Metadata)" {:span 32})
+(draw-box "mtidc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "mtidc (Address)"  {:span 32})
+(draw-box "mtidc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "MXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "MXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/mtidcreg.edn
+++ b/src/cheri/img/mtidcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["MXLEN" "" "" "MXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "mtidc (Metadata)" {:span 32})
+(draw-box "mtidc (Address)" {:span 32})
 
-(draw-box "mtidc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "mtidc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "MXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/mtveccreg.edn
+++ b/src/cheri/img/mtveccreg.edn
@@ -5,20 +5,18 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["MXLEN" "" "" "MXLEN-1"] (repeat 21 "") ["2" "1"] (repeat 6 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
-
-(draw-box "Metadata           (WARL)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "BASE [MXLEN-1:2] (WARL)" {:span 23})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "Metadata           (WARL)" {:span 32})
+(draw-box "BASE [MXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)"               {:span 8})
 
-(draw-box ""          {:span 3 :borders {}})
-(draw-box "MXLEN-2" {:span 23 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "MXLEN bits" {:span 32 :borders {}})
+(draw-box "MXLEN-2" {:span 24 :borders {}})
 (draw-box "2"         {:span 8 :borders {}})
 ----

--- a/src/cheri/img/mtveccreg.edn
+++ b/src/cheri/img/mtveccreg.edn
@@ -8,17 +8,17 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "MXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "Metadata           (WARL)" {:span 32})
+(draw-box "Metadata           (WARL)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "BASE [MXLEN-1:2] (WARL)" {:span 24})
+(draw-box "BASE [MXLEN-1:2] (WARL)" {:span 23})
 (draw-box "MODE (WARL)"               {:span 8})
 
-(draw-box ""          {:span 2 :borders {}})
-(draw-box "MXLEN-2" {:span 24 :borders {}})
+(draw-box ""          {:span 3 :borders {}})
+(draw-box "MXLEN-2" {:span 23 :borders {}})
 (draw-box "2"         {:span 8 :borders {}})
 ----

--- a/src/cheri/img/pccreg.edn
+++ b/src/cheri/img/pccreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["XLEN" "" "" "XLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "{pcc} (Metadata, WARL)" {:span 32})
+(draw-box "{pcc} (Address, WARL)" {:span 32})
 
-(draw-box "{pcc} (Metadata, WARL)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "{pcc} (Address, WARL)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "XLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/pccreg.edn
+++ b/src/cheri/img/pccreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "{pcc} (Metadata, WARL)" {:span 32})
+(draw-box "{pcc} (Metadata, WARL)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "{pcc} (Address, WARL)"  {:span 32})
+(draw-box "{pcc} (Address, WARL)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "XLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "XLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/sepccreg.edn
+++ b/src/cheri/img/sepccreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["SXLEN" "" "" "SXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "sepc (Metadata, WARL)" {:span 32})
+(draw-box "sepc (Address, WARL)" {:span 32})
 
-(draw-box "sepc (Metadata, WARL)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "sepc (Address, WARL)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "SXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/sepccreg.edn
+++ b/src/cheri/img/sepccreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "sepc (Metadata, WARL)" {:span 32})
+(draw-box "sepc (Metadata, WARL)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "sepc (Address, WARL)"  {:span 32})
+(draw-box "sepc (Address, WARL)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "SXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "SXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/sscratchcreg.edn
+++ b/src/cheri/img/sscratchcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["SXLEN" "" "" "SXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "sscratch (Metadata)" {:span 32})
+(draw-box "sscratch (Address)" {:span 32})
 
-(draw-box "sscratch (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "sscratch (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "SXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/sscratchcreg.edn
+++ b/src/cheri/img/sscratchcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "sscratch (Metadata)" {:span 32})
+(draw-box "sscratch (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "sscratch (Address)"  {:span 32})
+(draw-box "sscratch (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "SXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "SXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/stidcreg.edn
+++ b/src/cheri/img/stidcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "stidc (Metadata)" {:span 32})
+(draw-box "stidc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "stidc (Address)"  {:span 32})
+(draw-box "stidc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "SXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "SXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/stidcreg.edn
+++ b/src/cheri/img/stidcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["SXLEN" "" "" "SXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "stidc (Metadata)" {:span 32})
+(draw-box "stidc (Address)" {:span 32})
 
-(draw-box "stidc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "stidc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "SXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/stveccreg.edn
+++ b/src/cheri/img/stveccreg.edn
@@ -5,20 +5,18 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["SXLEN" "" "" "SXLEN-1"] (repeat 21 "") ["2" "1"] (repeat 6 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
-
-(draw-box "Metadata (WARL)"          {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "BASE [SXLEN-1:2] (WARL)" {:span 23})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "Metadata (WARL)" {:span 32})
+(draw-box "BASE [SXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)"               {:span 8})
 
-(draw-box "" {:span 3 :borders {}})
-(draw-box "SXLEN-2" {:span 23 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "SXLEN bits" {:span 32 :borders {}})
+(draw-box "SXLEN-2" {:span 24 :borders {}})
 (draw-box "2"         {:span 8 :borders {}})
 ----

--- a/src/cheri/img/stveccreg.edn
+++ b/src/cheri/img/stveccreg.edn
@@ -8,17 +8,17 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "SXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "Metadata (WARL)"          {:span 32})
+(draw-box "Metadata (WARL)"          {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "BASE [SXLEN-1:2] (WARL)" {:span 24})
+(draw-box "BASE [SXLEN-1:2] (WARL)" {:span 23})
 (draw-box "MODE (WARL)"               {:span 8})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "SXLEN-2" {:span 24 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "SXLEN-2" {:span 23 :borders {}})
 (draw-box "2"         {:span 8 :borders {}})
 ----

--- a/src/cheri/img/utidcreg.edn
+++ b/src/cheri/img/utidcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "utidc (Metadata)" {:span 32})
+(draw-box "utidc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "utidc (Address)"  {:span 32})
+(draw-box "utidc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "XLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "XLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/utidcreg.edn
+++ b/src/cheri/img/utidcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "XLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["XLEN" "" "" "XLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "utidc (Metadata)" {:span 32})
+(draw-box "utidc (Address)" {:span 32})
 
-(draw-box "utidc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "utidc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "XLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/vsepccreg.edn
+++ b/src/cheri/img/vsepccreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["VSXLEN" "" "" "VSXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "vsepc (Metadata)" {:span 32})
+(draw-box "vsepc (Address)" {:span 32})
 
-(draw-box "vsepc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "vsepc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "VSXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/vsepccreg.edn
+++ b/src/cheri/img/vsepccreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "vsepc (Metadata)" {:span 32})
+(draw-box "vsepc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "vsepc (Address)"  {:span 32})
+(draw-box "vsepc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "VSXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "VSXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/vsscratchcreg.edn
+++ b/src/cheri/img/vsscratchcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "vsscratch (Metadata)" {:span 32})
+(draw-box "vsscratch (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "vsscratch (Address)"  {:span 32})
+(draw-box "vsscratch (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "VSXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "VSXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/vsscratchcreg.edn
+++ b/src/cheri/img/vsscratchcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["VSXLEN" "" "" "VSXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "vsscratch (Metadata)" {:span 32})
+(draw-box "vsscratch (Address)" {:span 32})
 
-(draw-box "vsscratch (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "vsscratch (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "VSXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/vstidcreg.edn
+++ b/src/cheri/img/vstidcreg.edn
@@ -5,18 +5,16 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["VSXLEN" "" "" "VSXLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "vstidc (Metadata)" {:span 32})
+(draw-box "vstidc (Address)" {:span 32})
 
-(draw-box "vstidc (Metadata)" {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "vstidc (Address)"  {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-(draw-box "VSXLEN" {:span 31 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
 ----

--- a/src/cheri/img/vstidcreg.edn
+++ b/src/cheri/img/vstidcreg.edn
@@ -8,15 +8,15 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "vstidc (Metadata)" {:span 32})
+(draw-box "vstidc (Metadata)" {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "vstidc (Address)"  {:span 32})
+(draw-box "vstidc (Address)"  {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "VSXLEN" {:span 32 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "VSXLEN" {:span 31 :borders {}})
 ----

--- a/src/cheri/img/vstveccreg.edn
+++ b/src/cheri/img/vstveccreg.edn
@@ -5,20 +5,18 @@
 (def row-header-fn nil)
 (def left-margin 100)
 (def right-margin 100)
-(def boxes-per-row 34)
-(draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
+(def boxes-per-row 68)
+(draw-column-headers {:height 20 :font-size 18 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["VSXLEN" "" "" "VSXLEN-1"] (repeat 21 "") ["2" "1"] (repeat 6 "") ["0"])})
 
 (draw-box "CTag" {:span 2})
-(draw-box ""    {:span 1 :borders {}})
-
-(draw-box "Metadata (WARL)"          {:span 31})
-
-(draw-box "" {:span 3 :borders {}})
-
-(draw-box "BASE[VSXLEN-1:2] (WARL)" {:span 23})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "Metadata (WARL)" {:span 32})
+(draw-box "BASE[VSXLEN-1:2] (WARL)" {:span 24})
 (draw-box "MODE (WARL)" {:span 8})
 
-(draw-box "" {:span 3 :borders {}})
-(draw-box "VSXLEN-2" {:span 23 :borders {}})
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box "" {:span 2 :borders {}})
+(draw-box "VSXLEN bits" {:span 32 :borders {}})
+(draw-box "VSXLEN-2" {:span 24 :borders {}})
 (draw-box "2" {:span 8 :borders {}})
 ----

--- a/src/cheri/img/vstveccreg.edn
+++ b/src/cheri/img/vstveccreg.edn
@@ -8,17 +8,17 @@
 (def boxes-per-row 34)
 (draw-column-headers {:height 20 :font-size 18 :labels (reverse ["0" "" "" "" "" "" "" "1" "2" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "" "VSXLEN-1" "" ""])})
 
-(draw-box "CT" {:span 1})
+(draw-box "CTag" {:span 2})
 (draw-box ""    {:span 1 :borders {}})
 
-(draw-box "Metadata (WARL)"          {:span 32})
+(draw-box "Metadata (WARL)"          {:span 31})
 
-(draw-box "" {:span 2 :borders {}})
+(draw-box "" {:span 3 :borders {}})
 
-(draw-box "BASE[VSXLEN-1:2] (WARL)" {:span 24})
+(draw-box "BASE[VSXLEN-1:2] (WARL)" {:span 23})
 (draw-box "MODE (WARL)" {:span 8})
 
-(draw-box "" {:span 2 :borders {}})
-(draw-box "VSXLEN-2" {:span 24 :borders {}})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "VSXLEN-2" {:span 23 :borders {}})
 (draw-box "2" {:span 8 :borders {}})
 ----

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -88,13 +88,13 @@ Specific capability encoding formats may support different ISA extensions and ad
 (def boxes-per-row 32)
 (draw-column-headers {:height 50 :font-size 18 :labels (reverse (concat ["0"] (repeat 28 "") ["XLEN-1" "" ""]))})
 
-(draw-box "CT"    {:span 1})
+(draw-box "CTag"    {:span 2})
 (draw-box "" {:span 1 :borders {}})
-(draw-box "Metadata (bounds, permissions, etc.)"    {:span 30})
-(draw-box "" {:span 2 :borders {}})
-(draw-box "Address"     {:span 30})
-(draw-box "" {:span 2 :borders {}})
-(draw-box "XLEN" {:span 30 :borders {}})
+(draw-box "Metadata (bounds, permissions, etc.)"    {:span 29})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "Address"     {:span 29})
+(draw-box "" {:span 3 :borders {}})
+(draw-box "XLEN" {:span 29 :borders {}})
 ----
 
 ==== Address
@@ -676,12 +676,12 @@ The <<gprs,XLEN-wide integer registers>> (e.g., `x1`, `x2`) are all widened to Y
 (def boxes-per-row 66)
 (draw-column-headers {:height 30 :font-size 25 :labels (concat ["YLEN" "" "" "" "" "2*XLEN-1 (YLEN-1)"] (repeat 28 "") ["XLEN XLEN-1"] (repeat 30 "") ["0"])})
 
-(draw-box "0" [:box-first {:span 2}]) (draw-box "x0 (all bits including {ctag} zero)" [:box-last {:span 64 }])
-(draw-box "CT" [:box-first {:span 2}]) (draw-box "{creg}1 (metadata)" [:box-related {:span 32}]) (draw-box "x1" [:box-last {:span 32 }])
+(draw-box "0" [:box-first {:span 4}]) (draw-box "x0 (all bits including {ctag} zero)" [:box-last {:span 62 }])
+(draw-box "CTag" [:box-first {:span 4}]) (draw-box "{creg}1 (metadata)" [:box-related {:span 31}]) (draw-box "x1" [:box-last {:span 31 }])
 (draw-gap "Same layout for {creg}2-{creg}30" {:height 100})
-(draw-box "CT" [:box-first {:span 2}]) (draw-box "{creg}31 (metadata)" [:box-related {:span 32}]) (draw-box "x31" [:box-last {:span 32 }])
-(draw-box "CT" [:box-first {:span 2}]) (draw-box "{pcc} (metadata)" [:box-related {:span 32}]) (draw-box "{pcc}" [:box-last {:span 32 }])
-(draw-box "CTag" {:span 2 :borders {}}) (draw-box "Metadata" {:span 32 :borders {}}) (draw-box "Address" {:span 32 :borders {}})
+(draw-box "CTag" [:box-first {:span 4}]) (draw-box "{creg}31 (metadata)" [:box-related {:span 31}]) (draw-box "x31" [:box-last {:span 31 }])
+(draw-box "CTag" [:box-first {:span 4}]) (draw-box "{pcc} (metadata)" [:box-related {:span 31}]) (draw-box "{pcc}" [:box-last {:span 31 }])
+(draw-box "CTag" {:span 4 :borders {}}) (draw-box "Metadata" {:span 31 :borders {}}) (draw-box "Address" {:span 31 :borders {}})
 ----
 
 // When referring to the extended registers, the `x` prefix is replaced with a `y`: i.e., the extended version of `x1` becomes `{creg}1`.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -82,19 +82,21 @@ Specific capability encoding formats may support different ISA extensions and ad
 [#cap_structure]
 [bytefield]
 ----
-(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 25}])
-(def row-height 80)
+(defattrs :plain [:plain {:font-family "M+ 1p Fallback" :font-size 28}])
+(def row-height 90)
 (def row-header-fn nil)
-(def boxes-per-row 32)
-(draw-column-headers {:height 50 :font-size 18 :labels (reverse (concat ["0"] (repeat 28 "") ["XLEN-1" "" ""]))})
+(def boxes-per-row 68)
+(draw-column-headers {:height 40 :font-size 24 :labels (concat (repeat 5 "") ["YLEN-1"] (repeat 28 "") ["XLEN" "" "" "XLEN-1"] (repeat 29 "") ["0"])})
 
 (draw-box "CTag"    {:span 2})
-(draw-box "" {:span 1 :borders {}})
-(draw-box "Metadata (bounds, permissions, etc.)"    {:span 29})
-(draw-box "" {:span 3 :borders {}})
-(draw-box "Address"     {:span 29})
-(draw-box "" {:span 3 :borders {}})
-(draw-box "XLEN" {:span 29 :borders {}})
+(draw-box ""      {:span 2 :borders {}})
+(draw-box "Metadata (bounds, permissions, etc.)"    {:span 32})
+(draw-box "Address"     {:span 32})
+
+(draw-box "1 bit" {:span 2 :borders {}})
+(draw-box ""      {:span 2 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
+(draw-box "XLEN bits" {:span 32 :borders {}})
 ----
 
 ==== Address

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -676,7 +676,7 @@ The <<gprs,XLEN-wide integer registers>> (e.g., `x1`, `x2`) are all widened to Y
 (def row-height 100)
 (def row-header-fn nil)
 (def boxes-per-row 66)
-(draw-column-headers {:height 30 :font-size 25 :labels (concat ["YLEN" "" "" "" "" "2*XLEN-1 (YLEN-1)"] (repeat 28 "") ["XLEN XLEN-1"] (repeat 30 "") ["0"])})
+(draw-column-headers {:height 30 :font-size 25 :labels (concat ["YLEN" "" "" "" "" "YLEN-1"] (repeat 28 "") ["XLEN XLEN-1"] (repeat 30 "") ["0"])})
 
 (draw-box "0" [:box-first {:span 4}]) (draw-box "x0 (all bits including {ctag} zero)" [:box-last {:span 62 }])
 (draw-box "CTag" [:box-first {:span 4}]) (draw-box "{creg}1 (metadata)" [:box-related {:span 31}]) (draw-box "x1" [:box-last {:span 31 }])


### PR DESCRIPTION
Fix #1210 - It shouldn't be CT in the register diagrams as that's the CT-field not the capability tag.
Also address ARC comment that the register diagrams don't show the endianness of the words. the text has come out quite small for this but at least the diagrams are accurate now.