### PR TITLE
stop the PCC from being a mutable variable (non-ARC review content) - ready for review

### DIFF
--- a/src/cheri/insns/zcmt_cmjalt.adoc
+++ b/src/cheri/insns/zcmt_cmjalt.adoc
@@ -27,7 +27,7 @@ Encoding::
 Description ({cheri_base32_ext_name})::
 Redirect instruction fetch via the jump table defined by the indexing via `jvt.address+ index*XLEN/8`, checking every byte of the jump table access against <<jvt_y>> bounds (not against <<pcc>>) and requiring <<x_perm>>. Link to `cra`.
 +
-The target <<pcc>> is calculated by replacing the current <<pcc>> address with the value read from the jump table, and is updated using the semantics of the <<SCADDR>> instruction.
+The target <<pcc>> is calculated by copying the current <<pcc>> and setting its address to the value read from the jump table, using the semantics of the <<SCADDR>> instruction.
 +
 If the <<jvt_y>> check fails, then set the {ctag} of the target <<pcc>> to zero.
 

--- a/src/cheri/insns/zcmt_cmjt.adoc
+++ b/src/cheri/insns/zcmt_cmjt.adoc
@@ -27,7 +27,7 @@ Encoding::
 Description ({cheri_base32_ext_name})::
 Redirect instruction fetch via the jump table defined by the indexing via `jvt.address+ index*XLEN/8`, checking every byte of the jump table access against <<jvt_y>> bounds (not against <<pcc>>) and requiring <<x_perm>>.
 +
-The target <<pcc>> is calculated by replacing the current <<pcc>> address with the value read from the jump table, and is updated using the semantics of the <<SCADDR>> instruction.
+The target <<pcc>> is calculated by copying the current <<pcc>> and setting its address to the value read from the jump table, using the semantics of the <<SCADDR>> instruction.
 +
 If the <<jvt_y>> check fails, then set the {ctag} of the target <<pcc>> to zero.
 


### PR DESCRIPTION
Claude says this is only remaining place where a capability is a mutable variable.