### PR TITLE
Consistently use 'set to one/zero'

### DIFF
--- a/src/cheri/cheri-pte-ext.adoc
+++ b/src/cheri/cheri-pte-ext.adoc
@@ -79,19 +79,19 @@ NOTE: It may make sense to subdivide this into two extensions as _Capability Dir
 
 _pte_._{pte_cap_r_name_lc}_ and _pte_._{pte_cap_crg_pte_name_lc}_ control whether capability loads or AMOs write the loaded {ctag} to `{cd}`.
 
-When _pte_._{pte_cap_r_name_lc}_ is clear, _pte_._{pte_cap_crg_pte_name_lc}_ selects the behavior of capability loads:
-if _pte_._{pte_cap_crg_pte_name_lc}_ is clear, the loaded {ctag} is written to `{cd}` as zero; if _pte_._{pte_cap_crg_pte_name_lc}_ is set, the load operates as normal.
+When _pte_._{pte_cap_r_name_lc}_ is set to zero, _pte_._{pte_cap_crg_pte_name_lc}_ selects the behavior of capability loads:
+if _pte_._{pte_cap_crg_pte_name_lc}_ is set to zero, the loaded {ctag} is written to `{cd}` as zero; if _pte_._{pte_cap_crg_pte_name_lc}_ is set to one, the load operates as normal.
 
-When _pte_._{pte_cap_r_name_lc}_ is set, _pte_._{pte_cap_crg_pte_name_lc}_ can be used to trap on capability loads or AMOs when it does not match the Capability Read Generation value that is represented by the value of `sstatus.U{pte_cap_crg_pte_name}` for userspace pages (_pte_._u=1_) or `sstatus.S{pte_cap_crg_pte_name}` for kernel pages (_pte_._u=0_).
+When _pte_._{pte_cap_r_name_lc}_ is set to one, _pte_._{pte_cap_crg_pte_name_lc}_ can be used to trap on capability loads or AMOs when it does not match the Capability Read Generation value that is represented by the value of `sstatus.U{pte_cap_crg_pte_name}` for userspace pages (_pte_._u=1_) or `sstatus.S{pte_cap_crg_pte_name}` for kernel pages (_pte_._u=0_).
 
 The implementation raises a {cheri_excep_name_pte_ld} when, in addition to the rules above, all of the following are true:
 
 . A capability load or AMO is executed.
-. _pte_._{pte_cap_r_name_lc}_ is set.
+. _pte_._{pte_cap_r_name_lc}_ is set to one.
 . if _pte_._u=1_, _pte_._{pte_cap_crg_pte_name_lc}_ does not equal `sstatus.U{pte_cap_crg_pte_name}`.
 . if _pte_._u=0_, _pte_._{pte_cap_crg_pte_name_lc}_ does not equal `sstatus.S{pte_cap_crg_pte_name}`.
-. The loaded {ctag} is set, unless the implementation traps conservatively^1^.
-. Any other platform specific rules have not forced the loaded {ctag} to be clear.
+. The loaded {ctag} is set to one, unless the implementation traps conservatively^1^.
+. Any other platform specific rules have not forced the loaded {ctag} to be set to zero.
 
 ^1^ Implementations that trap conservatively may raise the fault regardless of the value of the loaded {ctag}, as shown in <<pte_rvy_load_summary>>.
 
@@ -101,7 +101,7 @@ The implementation raises a {cheri_excep_name_pte_ld} when, in addition to the r
 Checking the value of the {ctag} requires taking data dependent exceptions on loaded capabilities for loads or AMOs.
 Ideally all implementations would trap precisely (taking the {ctag} into account in all cases) rather than conservatively (trapping more often, potentially on every loaded capability).
 However, the loaded {ctag} may not be available in all implementations when determining whether to raise the exception, and therefore flexibility is permitted.
-As a result, the software is required to be tolerant of raising the trap when the {ctag} is not set, potentially resulting in spurious traps from pages that have _pte_._{pte_cap_r_name_lc}=1_, and so are likely to store valid capabilities.
+As a result, the software is required to be tolerant of raising the trap when the {ctag} is not set to one, potentially resulting in spurious traps from pages that have _pte_._{pte_cap_r_name_lc}=1_, and so are likely to store valid capabilities.
 
 Implementations that already take synchronous traps on loaded data, such as ECC faults, are recommended to check the loaded {ctag} when determining whether to raise the fault.
 
@@ -132,19 +132,19 @@ NOTE: In the case of AMOs that could trigger both a {cheri_excep_name_pte_st}, d
 [#sec_cap_dirty_tracking,reftext="Capability Dirty Tracking"]
 === Capability Dirty Tracking
 
-When _pte_._{pte_cap_w_name_lc}_ is clear, capability stores or AMOs where the to-be-stored {ctag} is set will raise a {cheri_excep_name_pte_st}.
+When _pte_._{pte_cap_w_name_lc}_ is set to zero, capability stores or AMOs where the to-be-stored {ctag} is set to one will raise a {cheri_excep_name_pte_st}.
 
-When _pte_._{pte_cap_w_name_lc}_ is set, capability stores to the virtual page are permitted.
-In addition, the _pte_._{pte_cap_dirty_name_lc}_ bit indicates that a capability was stored to the virtual page since the last time the _pte_._{pte_cap_dirty_name_lc}_ bit was cleared.
+When _pte_._{pte_cap_w_name_lc}_ is set to one, capability stores to the virtual page are permitted.
+In addition, the _pte_._{pte_cap_dirty_name_lc}_ bit indicates that a capability was stored to the virtual page since the last time the _pte_._{pte_cap_dirty_name_lc}_ bit was cleared to zero.
 
 NOTE: This is equivalent to the behavior of the _pte_._d_ bit except that _pte_._{pte_cap_dirty_name_lc}_ only tracks stores of valid capabilities instead of _all_ stores.
 
 Capability dirty tracking behavior is enabled when, in addition to the rules above, all of the following are true:
 
 . A capability store or AMO instruction is executed.
-. The to-be-stored {ctag} is set.
-. _pte_._{pte_cap_w_name_lc}_ is set.
-. _pte_._{pte_cap_dirty_name_lc}_ is clear.
+. The to-be-stored {ctag} is set to one.
+. _pte_._{pte_cap_w_name_lc}_ is set to one.
+. _pte_._{pte_cap_dirty_name_lc}_ is set to zero.
 
 Two schemes for capability dirty tracking are permitted, and the scheme in use is determined by whether the _Svade_ or _Svadu_ extensions are enabled.
 
@@ -169,9 +169,9 @@ hardware _pte_._{pte_cap_dirty_name_lc}_ update (_Svadu_)
 ^1^ The to-be-stored {ctag}.
 
 The capability dirty tracking is resolved during memory translation, but there are cases where it is not known if there will be a {ctag} stored to memory or not at this point.
-Capability dirty tracking _must_ be triggered when _pte_._{pte_cap_w_name_lc}_=1 and _pte_._{pte_cap_dirty_name_lc}_=0 and the to-be-stored {ctag} is set, and _may_ be triggered in the following case where it is not known if there will be a stored {ctag} during translation:
+Capability dirty tracking _must_ be triggered when _pte_._{pte_cap_w_name_lc}_=1 and _pte_._{pte_cap_dirty_name_lc}_=0 and the to-be-stored {ctag} is set to one, and _may_ be triggered in the following case where it is not known if there will be a stored {ctag} during translation:
 
-* SC{LD_ST_DOT_CAP} triggers capability dirty tracking if the {ctag} is set in {cs2}, even if the store fails.
+* SC{LD_ST_DOT_CAP} triggers capability dirty tracking if the {ctag} is set to one in {cs2}, even if the store fails.
   This matches the semantics of SC.* with regard to _pte_._d_.
 
 [NOTE]
@@ -185,7 +185,7 @@ In this case, the _pte_._{pte_cap_dirty_name_lc}_ bit would still be set.
 Future AMOs fall into this category:
 
 * For future AMOCAS{LD_ST_DOT_CAP}, it is not known whether the store will happen until the load has executed, and the compare has been done.
-  Therefore, AMOCAS{LD_ST_DOT_CAP} is likely to trigger capability dirty tracking if the {ctag} is set in {cs2}.
+  Therefore, AMOCAS{LD_ST_DOT_CAP} is likely to trigger capability dirty tracking if the {ctag} is set to one in {cs2}.
 * For future AMOADD{LD_ST_DOT_CAP}, the stored {ctag} depends upon the loaded {ctag} which is not known during translation and on the execution of the {CADD}.
  Therefore, AMOADD{LD_ST_DOT_CAP}, is likely to always trigger capability dirty tracking.
 

--- a/src/cheri/insns/yseal_32bit.adoc
+++ b/src/cheri/insns/yseal_32bit.adoc
@@ -14,7 +14,7 @@ Copy `{cs2}` into `{cd}`, and then...
 +
 --
 - `{cs2}` is sealed (has a non-zero <<sec_cap_type>> value)
-- `{cs1}` has a clear `{ctag}`
+- `{cs1}` has its `{ctag}` set to zero
 - `{cs1}` does not grant <<zyseal_se_perm>>
 - The address of `{cs1}` is out of bounds
 - The address of `{cs1}` is not a <<sec_cap_type>> value that the capability encoding can encode on the capability in `{cs2}`

--- a/src/cheri/insns/yunseal_32bit.adoc
+++ b/src/cheri/insns/yunseal_32bit.adoc
@@ -20,7 +20,7 @@ Copy `{cs2}` into `{cd}`, and then...
 . Set the {ctag} of the capability in `{cd}` to zero if any of the following hold:
 +
 --
-- `{cs1}` has a clear `{ctag}`
+- `{cs1}` has its `{ctag}` set to zero
 - `{cs1}` does not grant <<zyseal_us_perm>>
 - The address of `{cs1}` is out of bounds
 - The address of `{cs1}` is not equal to the <<sec_cap_type>> of the capability in `{cs2}`.

--- a/src/cheri/insns/zcmt_cmjalt.adoc
+++ b/src/cheri/insns/zcmt_cmjalt.adoc
@@ -34,7 +34,7 @@ If the <<jvt_y>> check fails, then set the {ctag} of the target <<pcc>> to zero.
 include::zcm_common.adoc[]
 
 Permissions ({cheri_base32_ext_name})::
-Requires <<jvt_y>> to have its {ctag} set, not be sealed, have <<x_perm>> and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
+Requires <<jvt_y>> to have its {ctag} set to one, not be sealed, have <<x_perm>> and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/cheri/insns/zcmt_cmjt.adoc
+++ b/src/cheri/insns/zcmt_cmjt.adoc
@@ -34,7 +34,7 @@ If the <<jvt_y>> check fails, then set the {ctag} of the target <<pcc>> to zero.
 include::zcm_common.adoc[]
 
 Permissions ({cheri_base32_ext_name})::
-Requires <<jvt_y>> to have its {ctag} set, not be sealed, have <<x_perm>> and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
+Requires <<jvt_y>> to have its {ctag} set to one, not be sealed, have <<x_perm>> and for the full XLEN-wide table access to be in <<jvt_y>> bounds.
 
 include::pcrel_debug_warning.adoc[]
 

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -182,7 +182,7 @@ The following <<CLRPERM>> permission rule is added:
 The effective {cheri_mode_name} cannot be determined just by reading the <<p_bit>> from the <<pcc>> since it also depends on the execution environment.
 The following code sequence demonstrates how a program can observe the current, effective {cheri_mode_name}.
 It will write, to `x1`, the value `1` for {cheri_cap_mode_name} (where <<AUIPC_CHERI>> derives a valid capability from the <<pcc>>)
-or `0` for {cheri_int_mode_name} (where `auipc` reverts to its standard behavior and writes an integer result with a clear {ctag}):
+or `0` for {cheri_int_mode_name} (where `auipc` reverts to its standard behavior and writes an integer result with its {ctag} set to zero):
 
 [source,subs=attributes+]
 ----

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -429,7 +429,7 @@ There are three levels of support:
 |=========================================================================================
 
 ^1^ The access fault is triggered on all capability stores or atomics such as <<STORE_CAP>> or <<AMOSWAP_CAP>> when <<c_perm>> and <<w_perm>> are granted and the to-be-stored {ctag} is set to one.
- For <<STORE_COND_CAP>>, the access fault is raised if the to-be-stored {ctag} is set in `{cs2}`, independent of the reservation outcome.
+ For <<STORE_COND_CAP>>, the access fault is raised if the to-be-stored {ctag} is set to one in `{cs2}`, independent of the reservation outcome.
  This matches the semantics of SC.* with regard to _pte_._d_ (see also xref:sec_cap_dirty_tracking[xrefstyle=short]).
 
 Only memory regions that have the _CHERI {ctag_title}_ PMA require storage for {ctag}s.
@@ -728,7 +728,7 @@ The definition of the {cheri_base_ext_name} field is as follows:
 If _pte_._{pte_cap_rw_name_lc}_=0 then:
 
 * All capability loads set the loaded {ctag} to zero
-* All capability stores with the to-be-stored {ctag} set raise a {cheri_excep_name_pte_st}.
+* All capability stores with the to-be-stored {ctag} set to one raise a {cheri_excep_name_pte_st}.
 
 If _pte_._{pte_cap_rw_name_lc}_=1 then:
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -113,7 +113,7 @@ endif::[]
 The {ctag} is a single additional bit associated with YLEN-bit memory locations and YLEN-bit registers.
 It is stored separately (i.e., is _out-of-band_ or _hidden_), and is _hardware managed_.
 It indicates whether a YLEN-bit register or YLEN-aligned memory location contains a valid capability.
-If the {ctag} is set, the capability is valid and may authorize operations, subject to type, permission, <<sec_cap_bounds_overview,bounds>>, and integrity checks.
+If the {ctag} is set to one, the capability is valid and may authorize operations, subject to type, permission, <<sec_cap_bounds_overview,bounds>>, and integrity checks.
 
 All registers or memory locations able to hold a valid capability are YLEN bits wide and have an associated {ctag}.
 These are referred to as being _YLEN-bit_ in this specification.
@@ -122,12 +122,12 @@ Not all memory in a real system will support {ctag}s.
 The Execution Environment Interface (EEI) will define what regions of the address space support them.
 
 The {ctag} cannot be directly set by software; it is _not_ a conventionally accessible bit of state.
-If the {ctag} is set then it shows that the capability has been derived correctly according to the principles listed above (_provenance_, _integrity_, _monotonicity_).
+If the {ctag} is set to one then it shows that the capability has been derived correctly according to the principles listed above (_provenance_, _integrity_, _monotonicity_).
 If the rules are followed then the {ctag} will propagate through the instructions that modify, load or store the capability.
 
-Therefore, whenever an instruction writes a capability with the {ctag} set to a register or to memory:
+Therefore, whenever an instruction writes a capability with the {ctag} set to one to a register or to memory:
 
-* At least one {ctag} must have been set in the input operands.
+* At least one {ctag} must have been set to one in the input operands.
 ** This is the _provenance_ check.
 * The requested operation must have been legal and not increase bounds or permissions.
 ** This is the _monotonicity_ check.
@@ -259,7 +259,7 @@ Therefore, the ISA specification uses the phrase *represented exactly* for this 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
 space of 2^XLEN^ bytes for all memory accesses. Each memory region capable of
 holding a capability also stores a {ctag} for each naturally aligned YLEN bits
-(e.g., 16 bytes in RV64), so that capabilities with their {ctag} set can only be
+(e.g., 16 bytes in RV64), so that capabilities with their {ctag} set to one can only be
 stored in naturally aligned addresses. {ctag_cap}s must be atomically bound to the
 data they protect.
 
@@ -414,7 +414,7 @@ Future extensions and capability encoding formats may declare new <<CT-field>> v
 ==== Architectural Permissions (AP)
 
 This metadata field encodes architecturally defined permissions of the capability.
-Permissions grant access subject to the <<cap_valid_tag>> being set, the capability being unsealed, and bounds checks passing.
+Permissions grant access subject to the <<cap_valid_tag>> being set to one, the capability being unsealed, and bounds checks passing.
 
 NOTE: Any memory operation is also contingent on requirements imposed by other RISC-V architectural features, such as virtual memory, PMP and PMAs, even if the capability grants sufficient permissions.
 
@@ -459,7 +459,7 @@ If <<c_perm>> is missing then the {ctag}s for capability loads and stores are re
 Load Mutable Permission (LM):: Allow preserving the <<w_perm>> of capabilities loaded from memory.
 If a capability grants <<r_perm>> and <<c_perm>>, but no <<lm_perm>>, then a capability loaded via this authorizing capability will have <<w_perm>> and <<lm_perm>> removed.
 +
-The permission stripping behavior _only_ applies to loaded capabilities with their {ctag} set and that are not sealed after all other checks.
+The permission stripping behavior _only_ applies to loaded capabilities with their {ctag} set to one and that are not sealed after all other checks.
 This ensures that capability loads of non-capability data do not modify the loaded value, and that sealed capabilities are not modified.
 
 NOTE: Clearing a capability's <<lm_perm>> and <<w_perm>> allows sharing a read-only version of a data structure without making a copy.
@@ -563,7 +563,7 @@ Extensions introducing new permissions may require these to be provided by root 
 
 [#null-cap,reftext="NULL"]
 NULL Capability::
-A capability with all-zero metadata, a zero {ctag}, and an address of zero is referred to as the _NULL_ capability.
+A capability with all-zero metadata, its {ctag} set to zero, and an address of zero is referred to as the _NULL_ capability.
 This capability grants no permissions and any dereference results in raising an exception.
 
 [#sec_cap_encoding_formats, reftext="capability encoding format"]
@@ -626,7 +626,7 @@ CHERI defines the following integrity check rules:
 
 NOTE: An example of a reserved field value is an illegal set of permissions such as <<asr_perm>> without <<x_perm>>.
 
-If any of the above rules do not hold for a capability with the {ctag} set, it indicates either:
+If any of the above rules do not hold for a capability with the {ctag} set to one, it indicates either:
 
 * State corruption due to memory or logic faults, or
 * The presence of incompatible or faulty CHERI IP within the system.
@@ -634,7 +634,7 @@ If any of the above rules do not hold for a capability with the {ctag} set, it i
 NOTE: These checks are much less rigorous than parity or ECC protection, and are only
 used to detect simple problems with the capability metadata.
 
-Instructions that are defined to accept arbitrary input bit patterns, and can write an output with the {ctag} set, _must_ perform an integrity check on the input capability if its {ctag} is set to zero.
+Instructions that are defined to accept arbitrary input bit patterns, and can write an output with the {ctag} set to one, _must_ perform an integrity check on the input capability if its {ctag} is set to zero.
 
 NOTE: In the {cheri_base_ext_name} ISA this only affects <<CBLD>>.
 
@@ -688,7 +688,7 @@ The <<gprs,XLEN-wide integer registers>> (e.g., `x1`, `x2`) are all widened to Y
 // The register can be referred to either way - as `{creg}1` accessing all YLEN bits or as `{creg}1` accessing only the address field (i.e., the lower XLEN bits).
 // For the ABI register names the `y` prefix is added, e.g., `{abi_creg}sp` to refer to all YLEN bits, and so the assembler can refer to either `sp` or `{abi_creg}sp` depending on the instruction operand.
 
-The zero register (`x0`) is extended with zero metadata and a zero {ctag}: this is called the <<null-cap>> capability.
+The zero register (`x0`) is extended with zero metadata and its {ctag} set to zero: this is called the <<null-cap>> capability.
 
 [#pcc,reftext="{pcc}"]
 ==== The Program Counter Capability (`{pcc}`)
@@ -947,8 +947,8 @@ The definition is:
 . `cap2` 's base bound address is greater than or equal to `cap1` 's base bound address, and
 . `cap1` and `cap2` pass all <<section_cap_integrity,integrity>> checks
 
-NOTE: A capability whose {ctag} is set is assumed to satisfy the <<section_cap_integrity,integrity>> checks, so this rule can only affect the result for an operand whose {ctag} is zero.
-Among the instructions that use the subset relation, this is only material for the `{cs2}` operand of <<CBLD>> (which can set a {ctag} on an arbitrary bit pattern) and for <<SCSS>> (which can compare operands whose {ctag}s are zero).
+NOTE: A capability whose {ctag} is set to one is assumed to satisfy the <<section_cap_integrity,integrity>> checks, so this rule can only affect the result for an operand whose {ctag} is set to zero.
+Among the instructions that use the subset relation, this is only material for the `{cs2}` operand of <<CBLD>> (which can set a {ctag} on an arbitrary bit pattern) and for <<SCSS>> (which can compare operands whose {ctag}s are set to zero).
 
 .Summary of {cheri_base_ext_name} instructions that create a modified capability
 [#tab_cap_manip_summary,%autowidth,options=header,align="center",cols="1,4"]

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -205,8 +205,7 @@ This is used to encode 15 different sealing types by distinguishing between exec
 
 [NOTE]
 =====
-Attempts to seal a capability with a type not compatible with its <<x_perm>> value
-will yield a result with a clear {ctag}.
+Attempts to seal a capability with a type not compatible with its <<x_perm>> value will yield a result with its {ctag} set to zero.
 =====
 
 [NOTE]
@@ -260,7 +259,7 @@ base <= address < base + (1 << (e + 9))
 ----
 
 This must be checked by all operations that change the capability address.
-If this check fails the resulting capability will have its {ctag} cleared.
+If this check fails, the resulting capability will have its {ctag} set to zero.
 Note that this means that it is not possible to represent a capability with an address less than the base.
 Depending on the size of the capability some addresses above top may be representable, but in the worst case the highest representable address is equal to top (one byte beyond the end of the dereferenceable region).
 

--- a/src/cheri/rvy-cheriot-isa-priv.adoc
+++ b/src/cheri/rvy-cheriot-isa-priv.adoc
@@ -32,7 +32,7 @@ we have not yet found a compelling reason to formally specify this composition.
 
 The {cheri_base_ext_name} base privileged ISA tends to define
 M-mode CSRs' reset values either as <<root-rx-cap>> capabilities or
-as otherwise unspecified values with clear {ctag}s.
+as otherwise unspecified values with their {ctag}s set to zero.
 To make available {cheriot_unpriv_ext_name}'s multiple
 //<<sec_zycheriot_unpriv_permission_roots,root>>
 root capability values,
@@ -40,13 +40,13 @@ we redefine two CSRs' reset values:
 
 <<mtidc>>::
 The <<mtidc>> register's reset value is changed to be
-{cheriot_unpriv_ext_name}'s <<root-rw-cap>> capability value (with set {ctag}),
-rather than the unspecified value with zero {ctag} of {cheri_base_ext_name}.
+{cheriot_unpriv_ext_name}'s <<root-rw-cap>> capability value (with its {ctag} set to one),
+rather than the unspecified value with its {ctag} set to zero of {cheri_base_ext_name}.
 
 <<mscratch_y>>::
 The <<mscratch_y>> register's reset value is changed to be
-{cheriot_unpriv_ext_name}'s _sealing_ capability value (with set {ctag}),
-rather than the unspecified value with zero {ctag} of {cheri_base_ext_name}.
+{cheriot_unpriv_ext_name}'s _sealing_ capability value (with its {ctag} set to one),
+rather than the unspecified value with its {ctag} set to zero of {cheri_base_ext_name}.
 
 === Additional CSR Legalization Requirements
 

--- a/src/cheri/rvy-cheriot-isa-unpriv.adoc
+++ b/src/cheri/rvy-cheriot-isa-unpriv.adoc
@@ -153,7 +153,7 @@ to modify the behavior of <<JALR_CHERI>>:
   based on the register selectors used,
   as detailed in <<tab_cheriot_unpriv_jalr_regs>>.
   Prohibited combinations of register selectors and <<sec_cap_type>> value
-  will cause the target <<pcc>> to have a clear {ctag} and so raise a
+  will cause the target <<pcc>> to have its {ctag} set to zero and so raise a
   {cheri_excep_name_pc}.
 
 In light of the last rule, we call capabilities granting <<x_perm>> and...

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -229,7 +229,7 @@ The values of `EW` and `CAP_MAX_E` are shown in
 xref:rvy64_uni_base_name_param_summary[xrefstyle=short].
 
 NOTE: The address and bounds must be representable in valid capabilities i.e.,
-when the {ctag} is set (see xref:section_cap_malformed[xrefstyle=short]).
+when the {ctag} is set to one (see xref:section_cap_malformed[xrefstyle=short]).
 
 [#section_cap_bounds_decoding]
 ===== Calculation of Variables

--- a/src/cheri/vector-integration.adoc
+++ b/src/cheri/vector-integration.adoc
@@ -2,7 +2,7 @@
 == Vector "V" Extension ({cheri_base_ext_name})
 
 The Vector extension for {cheri_base_ext_name} does not support {ctag}s in the vector registers.
-Consequently, vector stores will always clear {ctag}s in memory.
+Consequently, vector stores will always set the associated {ctag}s in memory to zero.
 
 NOTE: A future extension may allow {ctag}s to be stored in vector registers.
   Until that time, vector load and store instructions must not be used to implement generic

--- a/src/cheri/zylevelsN.adoc
+++ b/src/cheri/zylevelsN.adoc
@@ -29,12 +29,12 @@ Implementations of ZylevelsN may choose how many <<zylevelsN_cl_field>> bits (`L
 [#zylevelsN_sl_perm,reftext="SL-permission"]
 Store Level Permission (SL):: This field that allows limiting the propagation of capabilities using the following logic:
 +
-Capabilities with a <<zylevelsN_cl_field>> (see below) less than the inverse of the authorizing capability's <<zylevelsN_sl_perm>> will be stored with a zero {ctag}.
+Capabilities with a <<zylevelsN_cl_field>> (see below) less than the inverse of the authorizing capability's <<zylevelsN_sl_perm>> will be stored with their {ctag}s set to zero.
 +
 In the base ISA this is a single bit comparison, behaving as follows:
 
 * If this field (as well as <<c_perm>> and <<w_perm>>) is set to one then capabilities may be stored via this capability regardless of their associated <<zylevelsN_cl_field>>.
-* If this field is zero, then any capability with a <<zylevelsN_cl_field>> of zero (i.e., _local_), will be stored with the {ctag} cleared.
+* If this field is zero, then any capability with a <<zylevelsN_cl_field>> of zero (i.e., _local_), will be stored with its {ctag} set to zero.
 
 NOTE: Future extensions may make this field wider to enable more use cases.
 
@@ -62,7 +62,7 @@ NOTE: This specification only defines the architectural mechanics of this featur
 The _Capability Level_ can hold two values:
 
 * 1: the capability is _global_, in general allowing it to be stored using any authorizing capability.
-* 0: the capability is _local_, and can only be stored by authorizing capabilities with the <<zylevelsN_sl_perm>> set.
+* 0: the capability is _local_, and can only be stored by authorizing capabilities with <<zylevelsN_sl_perm>> granted.
 
 Furthermore, the <<zylevelsN_el_perm>> can be used to restrict loading of _global_ capabilities -- causing the hardware to automatically set the level of loaded capabilities to _local_ instead.
 
@@ -100,7 +100,7 @@ TODO
     h|*W*    h|*C* h|*SL* h|*CL* h| Notes
 .3+.^|1  .3+.^| 1   | 1    | X    | Store data capability unmodified
                .2+.^| 0    | 1    | Store data capability unmodified (`CL ≥ ~SL`)
-                           | 0    | Store data capability with {ctag} cleared (`CL < ~SL`)
+                           | 0    | Store data capability with {ctag} set to zero (`CL < ~SL`)
 |==============================================================================
 
 NOTE: if W=0 or C=0 then SL is irrelevant


### PR DESCRIPTION
ARC pointed out that a plain set/clear can be ambiguous in some
cases. Replace all remaining instances of bare 'is set' and 'tag set'
with explicit 'set to one/zero' across all chapters (including ones
not submitted for review).

Also consistently use 'set to one/zero' instead of 'set to 1/0'. We
were using both, and this inconsistency was flagged.

Addresses ARC review comment on v0.9.9-ar20260810.

Signed-off-by: Alex Richardson <alexrichardson@google.com>
