### PR TITLE
Clarify that in-bounds addresses are always representable

### DIFF
--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -219,11 +219,7 @@ These bounds-reducing instructions all copy `{cs1}` to the output `{cd}`, set th
 ** If the requested bounds cannot be encoded exactly, the result uses the smallest representable bounds that contain the requested range and remain within the initial bounds.
 * <<CRAM>> can be used to calculate the nearest precisely encodable _length_ and _base_ values for a given size.
 
-The bounds are encoded using:
-
-* A range of upper bits of the address field, defined by the exponent.
-* Fields in the metadata.
-
+The bounds are encoded relative to the address field, using some upper bits of the address combined with bits from the capability metadata.
 The exact method for encoding the bounds varies by capability encoding format.
 See xref:section_cap_bounds[xrefstyle=short] for the method used for {rv64y_uni_base_name}.
 
@@ -232,16 +228,15 @@ See xref:section_cap_bounds[xrefstyle=short] for the method used for {rv64y_uni_
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the CHERI encoding scheme for memory bounds uses some of the upper bits of the address to calculate the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the standard bounds encoding scheme shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.
-
 The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>>.
 
 NOTE: The C standard permits forming a one-past-the-end pointer (but no more than one), as long as it is not dereferenced.
   Real-world software has been observed to temporarily create pointers that point multiple bytes past the end or even before the start.
-  To maximize software compatibility, the bounds representation is designed to allow for out-of-bounds pointers.
+  To maximize software compatibility, the bounds representation was designed to allow for out-of-bounds pointers.
 
 [#cap_bounds_map]
 .Memory address bounds and representable range encoded within a capability
@@ -250,13 +245,13 @@ image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
-Deriving a new capability with an address outside the representable range changes the resulting bounds.
+Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with a different address could change the resulting bounds.
 All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the bounds.
-If the bounds _do_ change then the {ctag} of the derived capability is set to zero, so that the capability becomes invalid.
+If an address calculation moves the address outside the representable range, the hardware detects that the bounds can no longer be represented correctly, and sets the {ctag} to zero so that the derived capability becomes invalid.
 
-NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>>, (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
-Such implementations may only allow the minimum one-past-the-end as required by the C standard.
-To accommodate this the capability encoding formats support the option of REP_RANGE being `rc0` and the ISA specification uses the phrase *represented exactly* for checking that the bounds have not been altered by deriving a new capability with an updated address field.
+NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
+Such implementations must still support one-past-the-end pointers as required by the C standard, but are not required to support a representable range larger than that.
+Therefore, the ISA specification uses the phrase *represented exactly* for this check.
 
 ==== Memory space
 
@@ -617,12 +612,7 @@ Two parameters use non-numeric values:
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
 REP_RANGE::
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no or minimal guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
-
-Two parameters use non-numeric values:
-
-AP_ENC::
- Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
+ Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
 
 NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.
  {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability encoding formats will exist.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -219,7 +219,7 @@ These bounds-reducing instructions all copy `{cs1}` to the output `{cd}`, set th
 ** If the requested bounds cannot be encoded exactly, the result uses the smallest representable bounds that contain the requested range and remain within the initial bounds.
 * <<CRAM>> can be used to calculate the nearest precisely encodable _length_ and _base_ values for a given size.
 
-The bounds are encoded relative to the address field, sharing some upper bits of the address.
+The bounds are encoded relative to the address field by sharing some upper bits of the address.
 The number of shared bits depends on the exponent, see xref:section_cap_bounds[xrefstyle=short].
 
 [#section_rep_check_concept]
@@ -227,29 +227,31 @@ The number of shared bits depends on the exponent, see xref:section_cap_bounds[x
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the standard bounds encoding scheme shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the CHERI encoding scheme for memory bounds shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.
-The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>>.
+
+The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>> where the outer range exists only if the capability encoding format sets <<rep_range,REP_RANGE>> to `rc1`.
 
 NOTE: The C standard permits forming a one-past-the-end pointer (but no more than one), as long as it is not dereferenced.
   Real-world software has been observed to temporarily create pointers that point multiple bytes past the end or even before the start.
-  To maximize software compatibility, the bounds representation was designed to allow for out-of-bounds pointers.
+  To maximize software compatibility, the bounds representation when <<rep_range,REP_RANGE>> is `rc1` is designed to allow for out-of-bounds pointers.
 
 [#cap_bounds_map]
-.Memory address bounds and representable range encoded within a capability
+.Memory address bounds and representable range encoded within a capability for `REP_RANGE=rc1`
 image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 
 NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
-Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with an address outside the representable range could change the resulting bounds.
+Deriving a new capability with an address outside the representable range changes the resulting bounds.
 All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the bounds.
 If the bounds _do_ change then the {ctag} of the derived capability is set to zero, so that the capability becomes invalid.
 
-NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check, and may never allow the address to be out of bounds.
-Therefore, the ISA specification uses the phrase *represented exactly* for this check.
+NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>>, which has <<rep_range,REP_RANGE>> set to `rc1`, (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
+Such implementations may never allow the address to be out of bounds and will so set <<rep_range,REP_RANGE>> to `rc0` to represent this.
+To accommodate this the ISA specification uses the phrase *represented exactly* for the check that the bounds have not been altered by deriving a new capability with an updated address field.
 
 ==== Memory space
 
@@ -610,6 +612,7 @@ Two parameters use non-numeric values:
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
 REP_RANGE::
+anchor:rep_range[]
  Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
 
 NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -847,8 +847,8 @@ When accessing CSRs these rules are followed:
 .. Write YLEN bits, and will write the {ctag} to zero if the written value fails any of the checks in xref:section_cap_integrity[xrefstyle=full]
 . Accesses to <<ylen_csrs>> and <<extended_csrs>>, using instructions other than CSRRW will:
 .. Read YLEN bits
-.. For CSRRS/CSRRC, compute the XLEN-bit address-field value using the standard Zicsr bitwise set or clear operation on the old CSR address field and the XLEN source operand.
-.. For immediate forms, compute the XLEN-bit address-field value using the standard Zicsr operation with the zero-extended `uimm` operand.
+.. For CSRRS/CSRRC, compute the XLEN-bit address field value using the standard Zicsr bitwise set or clear operation on the old CSR address field and the XLEN source operand.
+.. For immediate forms, compute the XLEN-bit address field value using the standard Zicsr operation with the zero-extended `uimm` operand.
 .. Write the computed XLEN-bit value to the address field, and use the semantics of the <<SCADDR>> instruction to determine the final written value
 
 NOTE: Any <<ylen_csrs, YLEN-bit>> or <<extended_csrs, extended CSR>> may have additional rules defined to determine the final written value of the metadata and/or to write zero to the {ctag}.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -256,7 +256,7 @@ If the bounds _do_ change then the {ctag} of the derived capability is set to ze
 
 NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>>, (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
 Such implementations may only allow the minimum one-past-the-end as required by the C standard.
-To accommodate this the ISA specification uses the phrase *represented exactly* for checking that the bounds have not been altered by deriving a new capability with an updated address field.
+To accommodate this the capability encoding formats support the option of REP_RANGE being `rc0` and the ISA specification uses the phrase *represented exactly* for checking that the bounds have not been altered by deriving a new capability with an updated address field.
 
 ==== Memory space
 
@@ -609,7 +609,15 @@ NOTE: The default settings all match <<rv64y_cap_description>>.
 | AP_ENC      | full<suffix>/ part<suffix>| full1             | Encoding scheme for the <<AP-field>>
 4+| *Other parameters*
 | AUIPC_SHIFT | integer values up to 12 | 12                | Shift distance of the immediate in AUIPC
+| REP_RANGE   | rc1/r0               | rc1                  | Whether out of bounds addresses are representable
 |==============================================================================
+
+Two parameters use non-numeric values:
+
+AP_ENC::
+ Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
+REP_RANGE::
+ Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no or minimal guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
 
 Two parameters use non-numeric values:
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -219,15 +219,20 @@ These bounds-reducing instructions all copy `{cs1}` to the output `{cd}`, set th
 ** If the requested bounds cannot be encoded exactly, the result uses the smallest representable bounds that contain the requested range and remain within the initial bounds.
 * <<CRAM>> can be used to calculate the nearest precisely encodable _length_ and _base_ values for a given size.
 
-The bounds are encoded relative to the address field by sharing some upper bits of the address.
-The number of shared bits depends on the exponent, see xref:section_cap_bounds[xrefstyle=short].
+The bounds are encoded using:
+
+* A range of upper bits of the address field, defined by the exponent.
+* Fields in the metadata.
+
+The exact method for encoding the bounds varies by capability encoding format.
+See xref:section_cap_bounds[xrefstyle=short] for the method used for {rv64y_uni_base_name}.
 
 [#section_rep_check_concept]
 ==== Representability and Updating the Address
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the CHERI encoding scheme for memory bounds shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the CHERI encoding scheme for memory bounds uses a range of the upper bits of the address to calculate the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.
@@ -251,7 +256,7 @@ If the bounds _do_ change then the {ctag} of the derived capability is set to ze
 
 NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>>, which has <<rep_range,REP_RANGE>> set to `rc1`, (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
 Such implementations may never allow the address to be out of bounds and will so set <<rep_range,REP_RANGE>> to `rc0` to represent this.
-To accommodate this the ISA specification uses the phrase *represented exactly* for the check that the bounds have not been altered by deriving a new capability with an updated address field.
+To accommodate this the ISA specification uses the phrase *represented exactly* for checking that the bounds have not been altered by deriving a new capability with an updated address field.
 
 ==== Memory space
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -249,7 +249,7 @@ Since the upper bits of the address are used to calculate the top and base bound
 All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the decoding of the bounds.
 If an address calculation moves the address outside the representable range, the hardware detects that the bounds can no longer be represented correctly, and sets the {ctag} to zero so that the derived capability becomes invalid.
 
-NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
+NOTE: {cheri_base_ext_name} implementations that use a different capability-encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
 Such implementations must still support one-past-the-end pointers as required by the C standard, but are not required to support a representable range larger than that.
 Therefore, the ISA specification uses the phrase *represented exactly* for this check.
 
@@ -604,12 +604,7 @@ NOTE: The default settings all match <<rv64y_cap_description>>.
 | AP_ENC      | full<suffix>/ part<suffix>| full1             | Encoding scheme for the <<AP-field>>
 4+| *Other parameters*
 | AUIPC_SHIFT | integer values up to 12 | 12                | Shift distance of the immediate in AUIPC
-ifdef::cheri_ratification_v1_only[]
-| REP_RANGE   | rc1                  | rc1                  | Whether out of bounds addresses are representable
-endif::[]
-ifndef::cheri_ratification_v1_only[]
 | REP_RANGE   | rc1/r0               | rc1                  | Whether out of bounds addresses are representable
-endif::[]
 |==============================================================================
 
 Two parameters use non-numeric values:
@@ -617,14 +612,7 @@ Two parameters use non-numeric values:
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
 REP_RANGE::
-ifdef::cheri_ratification_v1_only[]
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region.
-+
-NOTE: Future settings of REP_RANGE could be used by capability encoding formats where no mantissa bits are used for out-of-bounds capabilities and there is limited <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
-endif::[]
-ifndef::cheri_ratification_v1_only[]
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
-endif::[]
+ Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_rep_check_concept,representable range>> for out-of-bounds addresses.
 
 NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.
  {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability encoding formats will exist.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -229,6 +229,8 @@ Software sometimes uses out-of-bounds pointers, for example, to represent a one-
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
 Because the standard bounds encoding scheme shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
+
+Any address that is within the capability's bounds is always representable and preserves the {ctag}.
 The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>>.
 
 NOTE: The C standard permits forming a one-past-the-end pointer (but no more than one), as long as it is not dereferenced.
@@ -239,18 +241,12 @@ NOTE: The C standard permits forming a one-past-the-end pointer (but no more tha
 .Memory address bounds and representable range encoded within a capability
 image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 
-The maximum range of address values that the pointer can take without changing the calculation of the bounds is defined by the <<section_cap_representable_check,representable range>>.
-
 NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
-Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with a different address could change the resulting bounds.
-All instructions that derive a capability with a new address must check that the new address does not change the bounds.
+Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with an address outside the representable range could change the resulting bounds.
+All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the bounds.
 If the bounds _do_ change then the {ctag} of the derived capability is set to zero, so that the capability becomes invalid.
-
-Software can derive a capability with a new address using instructions such as <<SCADDR>>, <<CADD>> and <<CADDI>>.
-
-NOTE: <<SCADDR>> writes back a derived capability with a new address field and, if the {ctag} was previously set, sets the {ctag} of the derived capability to one if the resulting capability still has the same bounds.
 
 NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check, and may never allow the address to be out of bounds.
 Therefore, the ISA specification uses the phrase *represented exactly* for this check.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -232,7 +232,7 @@ See xref:section_cap_bounds[xrefstyle=short] for the method used for {rv64y_uni_
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the CHERI encoding scheme for memory bounds uses a range of the upper bits of the address to calculate the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the CHERI encoding scheme for memory bounds uses some of the upper bits of the address to calculate the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -228,7 +228,7 @@ See xref:section_cap_bounds[xrefstyle=short] for the method used for {rv64y_uni_
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the standard bounds encoding scheme uses for the computation of the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the standard bounds encoding scheme uses upper bits of the address for the computation of the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -604,7 +604,12 @@ NOTE: The default settings all match <<rv64y_cap_description>>.
 | AP_ENC      | full<suffix>/ part<suffix>| full1             | Encoding scheme for the <<AP-field>>
 4+| *Other parameters*
 | AUIPC_SHIFT | integer values up to 12 | 12                | Shift distance of the immediate in AUIPC
+ifdef::cheri_ratification_v1_only[]
 | REP_RANGE   | rc1                  | rc1                  | Whether out of bounds addresses are representable
+endif::[]
+ifndef::cheri_ratification_v1_only[]
+| REP_RANGE   | rc1/r0               | rc1                  | Whether out of bounds addresses are representable
+endif::[]
 |==============================================================================
 
 Two parameters use non-numeric values:
@@ -612,9 +617,14 @@ Two parameters use non-numeric values:
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
 REP_RANGE::
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional mantissa bit and a _centered_ out-of-bounds region, to give a guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
-
+ifdef::cheri_ratification_v1_only[]
+ Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region.
++
 NOTE: Future settings of REP_RANGE could be used by capability encoding formats where no mantissa bits are used for out-of-bounds capabilities and there is limited <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
+endif::[]
+ifndef::cheri_ratification_v1_only[]
+ Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
+endif::[]
 
 NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.
  {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability encoding formats will exist.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -237,14 +237,14 @@ This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.
 
-The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>> where the outer range exists only if the capability encoding format sets <<rep_range,REP_RANGE>> to `rc1`.
+The relationship between the bounds and the representable range is illustrated in <<cap_bounds_map>>.
 
 NOTE: The C standard permits forming a one-past-the-end pointer (but no more than one), as long as it is not dereferenced.
   Real-world software has been observed to temporarily create pointers that point multiple bytes past the end or even before the start.
-  To maximize software compatibility, the bounds representation when <<rep_range,REP_RANGE>> is `rc1` is designed to allow for out-of-bounds pointers.
+  To maximize software compatibility, the bounds representation is designed to allow for out-of-bounds pointers.
 
 [#cap_bounds_map]
-.Memory address bounds and representable range encoded within a capability for `REP_RANGE=rc1`
+.Memory address bounds and representable range encoded within a capability
 image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 
 NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
@@ -254,8 +254,8 @@ Deriving a new capability with an address outside the representable range change
 All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the bounds.
 If the bounds _do_ change then the {ctag} of the derived capability is set to zero, so that the capability becomes invalid.
 
-NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>>, which has <<rep_range,REP_RANGE>> set to `rc1`, (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
-Such implementations may never allow the address to be out of bounds and will so set <<rep_range,REP_RANGE>> to `rc0` to represent this.
+NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>>, (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.
+Such implementations may only allow the minimum one-past-the-end as required by the C standard.
 To accommodate this the ISA specification uses the phrase *represented exactly* for checking that the bounds have not been altered by deriving a new capability with an updated address field.
 
 ==== Memory space
@@ -609,16 +609,12 @@ NOTE: The default settings all match <<rv64y_cap_description>>.
 | AP_ENC      | full<suffix>/ part<suffix>| full1             | Encoding scheme for the <<AP-field>>
 4+| *Other parameters*
 | AUIPC_SHIFT | integer values up to 12 | 12                | Shift distance of the immediate in AUIPC
-| REP_RANGE   | rc1/r0               | rc1                  | Whether out of bounds addresses are representable
 |==============================================================================
 
 Two parameters use non-numeric values:
 
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
-REP_RANGE::
-anchor:rep_range[]
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
 
 NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.
  {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability encoding formats will exist.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -228,7 +228,7 @@ See xref:section_cap_bounds[xrefstyle=short] for the method used for {rv64y_uni_
 
 Software sometimes uses out-of-bounds pointers, for example, to represent a one-past-the-end pointer to an array in C (`arr + size`).
 To support this pattern, CHERI must allow these out-of-bounds pointers to be held in capabilities while still protecting the bounds and integrity.
-Because the standard bounds encoding scheme shares the upper bits of the address with the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
+Because the standard bounds encoding scheme uses for the computation of the bounds, only a limited range of out-of-bounds pointers can be represented for any given set of bounds.
 This range is known as the *representable range*.
 
 Any address that is within the capability's bounds is always representable and preserves the {ctag}.
@@ -246,7 +246,7 @@ NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability 
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
 Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with a different address could change the resulting bounds.
-All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the bounds.
+All instructions that derive a capability with a new address (such as <<SCADDR>>, <<CADD>>, and <<CADDI>>) must check that the new address does not change the decoding of the bounds.
 If an address calculation moves the address outside the representable range, the hardware detects that the bounds can no longer be represented correctly, and sets the {ctag} to zero so that the derived capability becomes invalid.
 
 NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -604,7 +604,7 @@ NOTE: The default settings all match <<rv64y_cap_description>>.
 | AP_ENC      | full<suffix>/ part<suffix>| full1             | Encoding scheme for the <<AP-field>>
 4+| *Other parameters*
 | AUIPC_SHIFT | integer values up to 12 | 12                | Shift distance of the immediate in AUIPC
-| REP_RANGE   | rc1/r0               | rc1                  | Whether out of bounds addresses are representable
+| REP_RANGE   | rc1                  | rc1                  | Whether out of bounds addresses are representable
 |==============================================================================
 
 Two parameters use non-numeric values:
@@ -612,7 +612,9 @@ Two parameters use non-numeric values:
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
 REP_RANGE::
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
+ Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional mantissa bit and a _centered_ out-of-bounds region, to give a guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
+
+NOTE: Future settings of REP_RANGE could be used by capability encoding formats where no mantissa bits are used for out-of-bounds capabilities and there is limited <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
 
 NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.
  {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability encoding formats will exist.


### PR DESCRIPTION
Make explicit that any address within the capability's bounds is
always representable and preserves the tag, and that tag clearing
only occurs when an address calculation exceeds the representable
range.

Addresses ARC review comment on v0.9.9-ar20260810.

Signed-off-by: Alex Richardson <alexrichardson@google.com>