### PR TITLE
extended CSRs -> widened CSRs

### DIFF
--- a/src/cheri/insns/csrr_32bit.adoc
+++ b/src/cheri/insns/csrr_32bit.adoc
@@ -26,7 +26,7 @@ Encoding::
 include::wavedrom/csr-instr.adoc[]
 
 Description::
-These CSR instructions have extended functionality for accessing <<ylen_csrs>> and <<extended_csrs>>.
+These CSR instructions have extended functionality for accessing <<ylen_csrs>> and <<widened_csrs>>.
 +
 Access to <<xlen_csrs>> is as defined in Zicsr.
 +
@@ -37,7 +37,7 @@ For the instructions on this page, all writes are XLEN bits only and use the sem
 +
 Read data from <<ylen_csrs>> is always YLEN bits.
 +
-Read data from <<extended_csrs>> is YLEN bits in {cheri_cap_mode_name} or XLEN bits in {cheri_int_mode_name}.
+Read data from <<widened_csrs>> is YLEN bits in {cheri_cap_mode_name} or XLEN bits in {cheri_int_mode_name}.
 
 Permissions::
 Accessing CSRs may require <<asr_perm>>.

--- a/src/cheri/insns/csrrw_32bit.adoc
+++ b/src/cheri/insns/csrrw_32bit.adoc
@@ -14,25 +14,25 @@ CSR access (CSRRW) 32-bit encodings for {cheri_base_ext_name}
 Mnemonic::
 `csrrw {cd}, csr, {cs1}`
 
-//Mnemonic for accessing extended CSRs in {cheri_cap_mode_name}::
+//Mnemonic for accessing widened csrs in {cheri_cap_mode_name}::
 //`csrrw {cd}, csr, {cs1}`
 //
-//Mnemonic for accessing extended CSRs in {cheri_int_mode_name}::
+//Mnemonic for accessing widened csrs in {cheri_int_mode_name}::
 //`csrrw rd, csr, rs1`
 
 Encoding::
 include::wavedrom/csrw-instr.adoc[]
 
 Description::
-CSRRW has extended functionality for accessing <<ylen_csrs>> and <<extended_csrs>>.
+CSRRW has extended functionality for accessing <<ylen_csrs>> and <<widened_csrs>>.
 +
 Access to <<xlen_csrs>> is as defined in Zicsr.
 +
 CSRRW accesses to <<ylen_csrs>> read YLEN bits into `{cd}` and write YLEN bits of `{cs1}` into the CSR.
 +
-CSRRW accesses to <<extended_csrs>> read YLEN bits into `{cd}` and write YLEN bits of `{cs1}` into the CSR.
-However, if {cheri_default_ext_name} is supported and the current mode is {cheri_int_mode_name}, accesses to <<extended_csrs>> are XLEN-wide.
-The final write data for <<extended_csrs>> is determined using the semantics of the <<SCADDR>> instruction.
+CSRRW accesses to <<widened_csrs>> read YLEN bits into `{cd}` and write YLEN bits of `{cs1}` into the CSR.
+However, if {cheri_default_ext_name} is supported and the current mode is {cheri_int_mode_name}, accesses to <<widened_csrs>> are XLEN-wide.
+The final write data for <<widened_csrs>> is determined using the semantics of the <<SCADDR>> instruction.
 +
 In all cases, when writing YLEN bits of `{cs1}`, if any <<section_cap_integrity,integrity>> checks fail then set the {ctag} to zero before writing to the CSR.
 

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -105,7 +105,7 @@ Prefetches are also checked against the appropriate CSR (<<ddc>> for <<PREFETCH_
 +
 NOTE: Authorization of prefetches is useful to mitigate against side channels, e.g., preventing userspace from fetching kernel memory into a cache.
 +
-Reads to extended CSRs are XLEN-wide, and writes use the semantics of the <<SCADDR>> instruction (see <<rvy_zicsr_mod_insn_table>>).
+Reads to widened csrs are XLEN-wide, and writes use the semantics of the <<SCADDR>> instruction (see <<rvy_zicsr_mod_insn_table>>).
 
 The _<<cheri_execution_mode>>_ is key in providing backwards compatibility with the base RV32[IE]/RV64[IE] ISAs.
 
@@ -235,7 +235,7 @@ include::{generated_dir}/{rvy_zicsr_mod_file_name}.adoc[]
 
 {cheri_default_ext_name} makes {cheri_int_mode_name} available.
 
-In addition to the rules in <<rvy_csr_classes>>, when executing in {cheri_int_mode_name}, <<extended_csrs>> are always accessed as XLEN-wide for backwards compatibility.
+In addition to the rules in <<rvy_csr_classes>>, when executing in {cheri_int_mode_name}, <<widened_csrs>> are always accessed as XLEN-wide for backwards compatibility.
 The final written value is determined using the semantics of the <<SCADDR>> instruction.
 <<ylen_csrs>> (including <<ddc>>) continue to be accessed as YLEN-wide.
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -825,7 +825,7 @@ All CSRs that can hold addresses are widened to YLEN bits.
 [[xlen_csrs, XLEN-bit CSRs]]XLEN-bit CSRs::
 These do not contain pointers (e.g., _fcsr_ from the "F" extension).
 
-[[widened_csrs, widened csrs]]Widened csrs::
+[[widened_csrs, Existing CSRs widened to YLEN bits]]Existing CSRs widened to YLEN bits::
 These are XLEN-bit CSRs widened to YLEN bits, which are able to contain pointers
 // No unprivileged pointer-type CSRs in v1.0, so let's use mtvec here.
 ifdef::cheri_ratification_v1_only[]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -764,7 +764,7 @@ Each thread (as scheduled by the kernel) can have its own context stored in priv
 <<utidc>> allows compartment-switching code to determine the currently running thread without a call into the operating system.
 This is read-only without <<asr_perm>> to prevent a malicious compartment from tricking the switching mechanism into accessing data corresponding to the wrong thread.
 While the RISC-V ABI includes a _thread pointer (tp)_ register, it is not usable for the purpose of reliably identifying the current software thread because the tp register is a general-purpose register and can be changed arbitrarily by untrusted code.
-Extending <<utidc>> to a capability allows a data structure to be shared (guarded by e.g., the subset sealing mechanism), which allows for example efficient recovery of a trusted stack, without requiring additional indirection.
+Widening <<utidc>> to a capability allows a data structure to be shared (guarded by e.g., the subset sealing mechanism), which allows for example efficient recovery of a trusted stack, without requiring additional indirection.
 =====
 
 ifdef::cheri_xycfg_csr[]
@@ -825,7 +825,7 @@ All CSRs that can hold addresses are widened to YLEN bits.
 [[xlen_csrs, XLEN-bit CSRs]]XLEN-bit CSRs::
 These do not contain pointers (e.g., _fcsr_ from the "F" extension).
 
-[[extended_csrs, extended CSRs]]Extended CSRs::
+[[widened_csrs, widened csrs]]Widened csrs::
 These are XLEN-bit CSRs widened to YLEN bits, which are able to contain pointers
 // No unprivileged pointer-type CSRs in v1.0, so let's use mtvec here.
 ifdef::cheri_ratification_v1_only[]
@@ -843,20 +843,20 @@ These are added by {cheri_base_ext_name} and contain pointers (e.g., <<utidc>>).
 When accessing CSRs these rules are followed:
 
 . Accesses to <<xlen_csrs>> are as specified by Zicsr
-. Accesses to <<ylen_csrs>> and <<extended_csrs>>, using CSRRW will:
+. Accesses to <<ylen_csrs>> and <<widened_csrs>>, using CSRRW will:
 .. Read YLEN bits
 .. Write YLEN bits, and will write the {ctag} to zero if the written value fails any of the checks in xref:section_cap_integrity[xrefstyle=full]
-. Accesses to <<ylen_csrs>> and <<extended_csrs>>, using instructions other than CSRRW will:
+. Accesses to <<ylen_csrs>> and <<widened_csrs>>, using instructions other than CSRRW will:
 .. Read YLEN bits
 .. For CSRRS/CSRRC, compute the XLEN-bit address-field value using the standard Zicsr bitwise set or clear operation on the old CSR address field and the XLEN source operand.
 .. For immediate forms, compute the XLEN-bit address-field value using the standard Zicsr operation with the zero-extended `uimm` operand.
 .. Write the computed XLEN-bit value to the address field, and use the semantics of the <<SCADDR>> instruction to determine the final written value
 
-NOTE: Any <<ylen_csrs, YLEN-bit>> or <<extended_csrs, extended CSR>> may have additional rules defined to determine the final written value of the metadata and/or to write zero to the {ctag}.
+NOTE: Any <<ylen_csrs, YLEN-bit>> or <<widened_csrs, extended CSR>> may have additional rules defined to determine the final written value of the metadata and/or to write zero to the {ctag}.
 
 The assembler pseudoinstruction to read a capability CSR `csrr {cd}, csr`, is encoded as `csrrs {cd}, csr, {creg}0`.
 
-.<<ylen_csrs, YLEN-bit CSR>> and <<extended_csrs, Extended CSR>> access summary for {cheri_base_ext_name}
+.<<ylen_csrs, YLEN-bit CSR>> and <<widened_csrs, Extended CSR>> access summary for {cheri_base_ext_name}
 [#clen_access_summary_base,%autowidth,options=header,align="center"]
 |=======================
 |Instruction          | Read Width  | Write Width
@@ -883,7 +883,7 @@ Instruction fetches and data memory accesses raise an exception if the access is
 * All store instructions require <<w_perm>> and are authorized by the capability in `{cs1}`
 * All instruction fetches require <<x_perm>> in <<pcc>>
 
-Instruction fetches are authorized by the program counter capability (<<pcc>>) which extends the *pc*.
+Instruction fetches are authorized by the program counter capability (<<pcc>>) which widens the *pc*.
 
 NOTE: This allows code fetch to be bounded, preventing a wide range of attacks that subvert control flow with non-capability data.
 


### PR DESCRIPTION
Naming consistency, the previous move from extended to widened wasn't applied consistently