### PR TITLE
remove outdated note

### DIFF
--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -1,9 +1,5 @@
 == Introduction
 
-ifdef::cheri_standalone_spec[]
-WARNING: This chapter is only included in the standalone CHERI spec and not part of the integrated document.
-endif::[]
-
 === CHERI Concepts and Terminology
 
 Current CPU architectures (including RISC-V) allow memory access solely by


### PR DESCRIPTION
This text must go in the integrated doc, and so this comment seems wrong.
