### PR TITLE
Proposed seal/unseal mnemonic renaming

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -289,8 +289,8 @@ endif::support_varxlen[]
 :CBLD_LC:       ybld
 :CBLD_DESC:     Build capability
 
-:YSUNSEAL:      YSUNSEAL
-:YSUNSEAL_LC:   ysunseal
+:YSUNSEAL:      YUNSEAL
+:YSUNSEAL_LC:   yunseal
 :YSUNSEAL_DESC: Unseal by superset reconstruction
 
 :CLRPERM:       YPERMC
@@ -399,8 +399,8 @@ endif::support_varxlen[]
 :C_JR_CHERI_DESC:          Jump to capability register, 16-bit encoding
 
 
-:YSEAL:      YSEAL
-:YSEAL_LC:   yseal
+:YSEAL:      YSEALT
+:YSEAL_LC:   ysealt
 :YSEAL_DESC: Seal a capability
 
 :sentry_cap_uc:  Sealed entry point capability
@@ -408,12 +408,12 @@ endif::support_varxlen[]
 :sentry_cap_lc:  sealed entry point capability
 :sentry_caps_lc: sealed entry point capabilities
 
-:SENTRY:      YSENTRY
-:SENTRY_LC:   ysentry
+:SENTRY:      YSEALE
+:SENTRY_LC:   yseale
 :SENTRY_DESC: Create a {sentry_cap_lc}
 
-:YUNSEAL:    YUNSEAL
-:YUNSEAL_LC: yunseal
+:YUNSEAL:    YUNSEALT
+:YUNSEAL_LC: yunsealt
 :YUNSEAL_DESC: Unseal a capability authorized using an unsealing capability
 
 // Variables for register names

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -289,8 +289,8 @@ endif::support_varxlen[]
 :CBLD_LC:       ybld
 :CBLD_DESC:     Build capability
 
-:YSUNSEAL:      YUNSEAL
-:YSUNSEAL_LC:   yunseal
+:YSUNSEAL:      YUNSEALS
+:YSUNSEAL_LC:   yunseals
 :YSUNSEAL_DESC: Unseal by superset reconstruction
 
 :CLRPERM:       YPERMC

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -308,15 +308,27 @@ Given a capability with `CT=0`,
 deriving a capability with `CT{ne}0` is termed
 ifdef::cheri_ratification_v1_only[_sealing_. +]
 ifndef::cheri_ratification_v1_only[_sealing_ (or _sealing with type ``x``_ when a particular output ``CT=x`` is meant). +]
-This is achieved using <<SENTRY>>, which doesn't require authorization and seals the output as a <<sentry_cap>>.
+This is achieved using YSEALx instructions. +
++
+* The <<SENTRY>> instruction copies `{cs1}` to `{cd}` and seals it as a <<sentry_cap>>. +
+
+ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YSEALx instructions such as seal by permission or type.]
 
 Unsealing::
 Given a capability with `CT{ne}0`,
 deriving a capability with `CT=0` is termed
 ifdef::cheri_ratification_v1_only[_unsealing_. +]
 ifndef::cheri_ratification_v1_only[_unsealing_ (or _unsealing from type ``x``_ when a particular input ``CT=x`` is meant). +]
-ifdef::cheri_ratification_v1_only[This is achieved using <<YSUNSEAL>>, which authorizes the unsealing of `{cs2}` into `{cd}` with a Superset capability in `{cs1}` (hence the _S_ suffix).]
-ifndef::cheri_ratification_v1_only[This is achieved using <<YSUNSEAL>> (or <<YUNSEAL>> if <<section_zyseal>> is implemented).]
+ifdef::cheri_ratification_v1_only[]
+This is achieved using YUNSEALx instructions. +
++
+* The <<YSUNSEAL>> instruction authorizes the unsealing of `{cs2}` into `{cd}` with a superset capability in `{cs1}` (the S suffix represents Superset).
+endif::[]
+ifndef::cheri_ratification_v1_only[]
++
+* This is achieved using <<YSUNSEAL>> (or <<YUNSEAL>> if <<section_zyseal>> is implemented).
+endif::[]
+ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YUNSEALx instructions such as unseal by permission or type.]
 
 [#sentry_cap,reftext="{sentry_cap_uc}"]
 {sentry_cap_uc}::

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -312,7 +312,7 @@ This is achieved using YSEALx instructions. +
 +
 * The <<SENTRY>> instruction copies `{cs1}` to `{cd}` and seals it as a <<sentry_cap>>. +
 
-ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YSEALx instructions such as seal by permission or type.]
+ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YSEAL``x`` instructions such as seal or type.]
 
 Unsealing::
 Given a capability with `CT{ne}0`,
@@ -328,7 +328,7 @@ ifndef::cheri_ratification_v1_only[]
 +
 * This is achieved using <<YSUNSEAL>> (or <<YUNSEAL>> if <<section_zyseal>> is implemented).
 endif::[]
-ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YUNSEALx instructions such as unseal by permission or type.]
+ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YUNSEAL``x`` instructions such as unseal by type.]
 
 [#sentry_cap,reftext="{sentry_cap_uc}"]
 {sentry_cap_uc}::

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -322,7 +322,7 @@ ifndef::cheri_ratification_v1_only[_unsealing_ (or _unsealing from type ``x``_ w
 ifdef::cheri_ratification_v1_only[]
 This is achieved using YUNSEALx instructions. +
 +
-* The <<YSUNSEAL>> instruction authorizes the unsealing of `{cs2}` into `{cd}` with a superset capability in `{cs1}` (the S suffix represents Superset).
+* The <<YSUNSEAL>> instruction authorizes the unsealing of `{cs2}` into `{cd}` with a superset capability in `{cs1}` (the S suffix represents superset).
 endif::[]
 ifndef::cheri_ratification_v1_only[]
 +

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -312,7 +312,7 @@ This is achieved using YSEALx instructions. +
 +
 * The <<SENTRY>> instruction copies `{cs1}` to `{cd}` and seals it as a <<sentry_cap>>. +
 
-ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YSEAL``x`` instructions such as seal or type.]
+ifdef::cheri_ratification_v1_only[NOTE: Future extensions will add more YSEAL``x`` instructions such as seal by type.]
 
 Unsealing::
 Given a capability with `CT{ne}0`,

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -306,16 +306,16 @@ ifndef::cheri_ratification_v1_only[Extensions that extend the capability metadat
 Sealing::
 Given a capability with `CT=0`,
 deriving a capability with `CT{ne}0` is termed
-ifdef::cheri_ratification_v1_only[_sealing_.]
-ifndef::cheri_ratification_v1_only[_sealing_ (or _sealing with type ``x``_ when a particular output ``CT=x`` is meant).]
-This is achieved using <<SENTRY>>.
+ifdef::cheri_ratification_v1_only[_sealing_. +]
+ifndef::cheri_ratification_v1_only[_sealing_ (or _sealing with type ``x``_ when a particular output ``CT=x`` is meant). +]
+This is achieved using <<SENTRY>>, which doesn't require authorization and seals the output as a <<sentry_cap>>.
 
 Unsealing::
 Given a capability with `CT{ne}0`,
 deriving a capability with `CT=0` is termed
-ifdef::cheri_ratification_v1_only[_unsealing_.]
-ifndef::cheri_ratification_v1_only[_unsealing_ (or _unsealing from type ``x``_ when a particular input ``CT=x`` is meant).]
-ifdef::cheri_ratification_v1_only[This is achieved using <<YSUNSEAL>>.]
+ifdef::cheri_ratification_v1_only[_unsealing_. +]
+ifndef::cheri_ratification_v1_only[_unsealing_ (or _unsealing from type ``x``_ when a particular input ``CT=x`` is meant). +]
+ifdef::cheri_ratification_v1_only[This is achieved using <<YSUNSEAL>>, which authorizes the unsealing of `{cs2}` into `{cd}` with a Superset capability in `{cs1}` (hence the _S_ suffix).]
 ifndef::cheri_ratification_v1_only[This is achieved using <<YSUNSEAL>> (or <<YUNSEAL>> if <<section_zyseal>> is implemented).]
 
 [#sentry_cap,reftext="{sentry_cap_uc}"]

--- a/src/cheri/scripts/rvy_instruction_encodings.py
+++ b/src/cheri/scripts/rvy_instruction_encodings.py
@@ -526,9 +526,9 @@ def get_custom3_insts():
         next_rtype("YBNDSRW", rs1="{cs1}", rd="{cd}"),
         next_rtype("YEQ", rs1="{cs1}", rs2="{cs2}", rd="rd"),
         next_rtype("YSS", rs1="{cs1}", rs2="{cs2}", rd="rd"),
-        next_rtype("YSUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
+        next_rtype("YUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
         next_rtype("YBLD", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
-        next_rtype("YSENTRY", rs1="{cs1}=0", rs2="{cs2}", rd="{cd}", rs1_label="src1=0"),
+        next_rtype("YSEALE", rs1="{cs1}=0", rs2="{cs2}", rd="{cd}", rs1_label="src1=0"),
         next_rtype("YUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}", ext="Zyseal"),
         next_rtype("YMODEW", rs1="{cs1}", rd=f"{{cd}}{NEQ}0", ext="Zyhybrid"),
         RVYRType3Op(

--- a/src/cheri/scripts/rvy_instruction_encodings.py
+++ b/src/cheri/scripts/rvy_instruction_encodings.py
@@ -526,10 +526,10 @@ def get_custom3_insts():
         next_rtype("YBNDSRW", rs1="{cs1}", rd="{cd}"),
         next_rtype("YEQ", rs1="{cs1}", rs2="{cs2}", rd="rd"),
         next_rtype("YSS", rs1="{cs1}", rs2="{cs2}", rd="rd"),
-        next_rtype("YUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
+        next_rtype("YUNSEALS", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
         next_rtype("YBLD", rs1="{cs1}", rs2="{cs2}", rd="{cd}"),
         next_rtype("YSEALE", rs1="{cs1}=0", rs2="{cs2}", rd="{cd}", rs1_label="src1=0"),
-        next_rtype("YUNSEAL", rs1="{cs1}", rs2="{cs2}", rd="{cd}", ext="Zyseal"),
+        next_rtype("YUNSEALT", rs1="{cs1}", rs2="{cs2}", rd="{cd}", ext="Zyseal"),
         next_rtype("YMODEW", rs1="{cs1}", rd=f"{{cd}}{NEQ}0", ext="Zyhybrid"),
         RVYRType3Op(
             "YMODESWY",


### PR DESCRIPTION
ARC asked us to rename YSENTRY as YSEALE which is similar to CSealEntry from v9
They also asked why there is a leading S in YSUNSEAL, and to abbreviate it to YUNSEAL. But since that would conflict with the type-based sealing, let's propose YUNSEALS

As a proposal, the CHERIoT YSEAL/YUNSEAL by Type could be YSEALT/YUNSEALT

Partial fix for https://github.com/riscv/riscv-cheri/issues/1237
