### PR TITLE
Reorder ISA  sections

### DIFF
--- a/src/cheri/app-hybrid-usage.adoc
+++ b/src/cheri/app-hybrid-usage.adoc
@@ -205,7 +205,7 @@ These registers hold the capability for the exception vector.
   When an exception or interrupt occurs, the hardware installs this capability into <<pcc>>, thereby setting the mode for the trap handler.
   For example, if <<stvec_y,stvec>> was set up with its <<p_bit>> set to {CAP_MODE_VALUE}, the processor will switch to {cheri_cap_mode_name} on entry to the trap handler.
 
-=== CHERI Enable Bits in Setup (when changing privilege levels)
+=== CHERI Enable Bits in Setup (When Changing Privilege Levels)
 
 In addition to setting up capabilities and mode bits, the execution environment must manage the CHERI enable bits provided by the privileged architecture:
 

--- a/src/cheri/app-standalone-unpriv-refs.adoc
+++ b/src/cheri/app-standalone-unpriv-refs.adoc
@@ -1,6 +1,6 @@
 ifdef::cheri_standalone_spec[]
 
-== Placeholder references to the unprivileged spec
+== Placeholder References to the Unprivileged Spec
 
 WARNING: This chapter only exists for the standalone document to allow references to resolve.
 

--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -10,7 +10,7 @@
 // Top-level CHERI definitions
 ///////////////////////////////////////////////////////////////////////////////
 
-// Base CHERI extension (without the mode bit in capability encoding format)
+// Base CHERI extension (without the mode bit in capability-encoding format)
 :cheri_base64_ext_name:    RV64Y
 :cheri_base32_ext_name:    RV32Y
 :cheri_base_ext_name:      RVY

--- a/src/cheri/cheri_priv_isa_tables.adoc
+++ b/src/cheri/cheri_priv_isa_tables.adoc
@@ -18,8 +18,8 @@ include::{generated_dir}/{rvy_h_file_name}.adoc[]
 
 endif::[]
 
-[#rvy_m_insn_table, reftext="Machine level ISA for {cheri_base_ext_name}"]
-=== Machine level ISA for {cheri_base_ext_name}
+[#rvy_m_insn_table, reftext="Machine Level ISA for {cheri_base_ext_name}"]
+=== Machine Level ISA for {cheri_base_ext_name}
 
 .Machine level ISA, modified instructions for {cheri_base_ext_name}
 [#rvy_m_isa]
@@ -28,8 +28,8 @@ endif::[]
 include::{generated_dir}/RVY_M_insns_table_body.adoc[]
 |==============================================================================
 
-[#rvy_s_insn_table, reftext="Supervisor level ISA for {cheri_base_ext_name}"]
-=== Supervisor level ISA for {cheri_base_ext_name}
+[#rvy_s_insn_table, reftext="Supervisor Level ISA for {cheri_base_ext_name}"]
+=== Supervisor Level ISA for {cheri_base_ext_name}
 
 .Supervisor level ISA, modified instructions for {cheri_base_ext_name}
 [#rvy_s_isa]

--- a/src/cheri/debug-integration.adoc
+++ b/src/cheri/debug-integration.adoc
@@ -28,7 +28,7 @@ When a capability is written via an abstract command it must be derivable from t
 If not then the destination {ctag} is set to zero.
 
 NOTE: If there is only a single root capability, then the derivable check is a _capability subset_ of the written capability against the capability in <<drootc>>.
- If there are multiple root capabilities then checks against multiple root capabilities may be required, as defined by the capability encoding format.
+ If there are multiple root capabilities then checks against multiple root capabilities may be required, as defined by the capability-encoding format.
 
 NOTE: For the capability subset: `cap2` is the capability being written and `cap1` is the value of <<drootc>>.
 
@@ -230,7 +230,7 @@ The reset value is `0`, which must cause <<drootc>> to expose a
 Root Executable capability.
 
 Other capability values may be defined for exposure through <<drootc>>
-by the capability encoding,
+by the capability-encoding format,
 and may be selected by having the debugger write to this register.
 Writes are WARL, so the debugger may confirm that its selection has been applied.
 

--- a/src/cheri/hypervisor-integration.adoc
+++ b/src/cheri/hypervisor-integration.adoc
@@ -155,23 +155,6 @@ The contents of <<vstidc>> never directly affect the behavior of the machine.
 .Virtual supervisor thread identifier capability register
 include::img/vstidcreg.edn[]
 
-ifdef::cheri_xycfg_csr[]
-
-[#vsycfg,reftext="vsycfg"]
-=== Virtual Supervisor CHERI Capability Encoding (vsycfg)
-The <<vsycfg>> register is used to identify which CHERI capability encoding is used by the platform.
-The capability encoding both determines the in-memory representation of a CHERI capability
-and entails a set of extensions present atop {cheri_base_ext_name}.
-The CSR exists in the _writable_ namespace and all bits are defined to be WARL,
-but, absent any future extensions, it is expected that each implementation has exactly one legal value.
-For the meaning of the individual fields, refer to the <<uycfg>> register in the unprivileged specification.
-
-.Virtual Supervisor CHERI capability encoding CSR (`vsycfg`) format
-[#vsycfg_csr_structure]
-include::img/ycfgreg.edn[]
-
-endif::[]
-
 === "Smstateen/Ssstateen" Integration
 The TIDC bit controls access to the <<stidc>> (really <<vstidc>>) CSR.
 

--- a/src/cheri/introduction.adoc
+++ b/src/cheri/introduction.adoc
@@ -49,9 +49,9 @@ cases they will have some behavioral differences and/or new instructions operati
 [options=header,align=center,width="90%"]
 |=============================================================================================================================================================
 | Extension or Specification                                | Description
-|<<rvy,RV64Y>>                                              | CHERI Base ISA and capability encoding format for RV64
+|<<rvy,RV64Y>>                                              | CHERI Base ISA and capability-encoding format for RV64
 ifndef::cheri_ratification_v1_only[]
-|<<rv32y,RV32Y>>                                            | Base ISA additions and capability encoding formats for RV32
+|<<rv32y,RV32Y>>                                            | Base ISA additions and capability-encoding formats for RV32
 endif::[]
 ifndef::cheri_ratification_v1_only[]
 |<<rvy_bndsrdw_insn_ext>>                                   | Extension for setting bounds round down to representable length

--- a/src/cheri/riscv-cheri.adoc
+++ b/src/cheri/riscv-cheri.adoc
@@ -20,7 +20,7 @@ Assume anything could still change, but limited change should be expected.
 ====
 
 [preface]
-== Copyright and license information
+== Copyright and License Information
 This specification is licensed under the Creative Commons
 Attribution 4.0 International License (CC-BY 4.0). The full
 license text is available at
@@ -37,7 +37,7 @@ include::contributors.adoc[]
 
 include::introduction.adoc[]
 
-= Chapters for the unprivileged specification
+= Chapters for the Unprivileged Specification
 
 include::riscv-unpriv-integration.adoc[]
 include::vector-integration.adoc[]
@@ -53,7 +53,7 @@ endif::[]
 
 include::cheri-unpriv-appendix.adoc[]
 
-= Chapters for the privileged specification
+= Chapters for the Privileged Specification
 
 include::riscv-priv-integration.adoc[]
 include::cheri-pte-ext.adoc[]

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -130,12 +130,12 @@ The mode changes when a capability is installed into <<pcc>> (e.g., via an indir
 
 The <<p_bit>> is only valid in capabilities that grant <<x_perm>> (see <<zyhybrid-clrperm-rules>>).
 Capabilities that do not grant <<x_perm>> therefore do not carry a meaningful <<p_bit>>, so <<SCMODE>> cannot modify their <<p_bit>>.
-{cheri_default_ext_name} requires a capability encoding that supports transport of the <<p_bit>> (e.g., <<rv64y_cap_description>>).
+{cheri_default_ext_name} requires a capability-encoding format that supports transport of the <<p_bit>> (e.g., <<rv64y_cap_description>>).
 
 * {cheri_mode_name} (P)={CAP_MODE_VALUE} indicates {cheri_cap_mode_name}.
 * {cheri_mode_name} (P)={INT_MODE_VALUE} indicates {cheri_int_mode_name}.
 
-When executing <<CLRPERM>>, if <<x_perm>> is removed while the <<p_bit>> is set to one, and the capability encoding still permits representing the <<p_bit>>, then the <<p_bit>> must be set to zero.
+When executing <<CLRPERM>>, if <<x_perm>> is removed while the <<p_bit>> is set to one, and the capability-encoding format still permits representing the <<p_bit>>, then the <<p_bit>> must be set to zero.
 
 [#sec_changing_cheri_execution_mode]
 ==== Changing {cheri_mode_name}

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -165,7 +165,7 @@ The <<p_bit>> of a <<x_perm>>-granting capability can be read and written by the
 NOTE: In addition to the mode switching instructions, the current mode can also be updated by setting the <<p_bit>> of a target capability using <<SCMODE>> followed by a <<JALR_CHERI>>.
 
 [#zyhybrid-clrperm-rules]
-==== Additional <<CLRPERM>> permission rule
+==== Additional <<CLRPERM>> Permission Rule
 
 The following <<CLRPERM>> permission rule is added:
 
@@ -190,7 +190,7 @@ auipc {creg}1, 0
 {gctag_lc} x1, {creg}1
 ----
 
-=== Added instructions
+=== Added Instructions
 
 include::insns/scmode_32bit.adoc[]
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -126,23 +126,6 @@ The <<mtidc>> register is used to identify the current software thread in machin
 .Machine thread identifier capability register
 include::img/mtidcreg.edn[]
 
-ifdef::cheri_xycfg_csr[]
-
-[#mycfg,reftext="mycfg"]
-==== Machine CHERI Capability Encoding (mycfg)
-The <<mycfg>> register is used to identify which CHERI capability encoding is used by the platform.
-The capability encoding both determines the in-memory representation of a CHERI capability
-and entails a set of extensions present atop {cheri_base_ext_name}.
-The CSR exists in the _writable_ namespace and all bits are defined to be WARL,
-but, absent any future extensions, it is expected that each implementation has exactly one legal value.
-For the meaning of the individual fields, refer to the <<uycfg>> register in the unprivileged specification.
-
-.Machine CHERI capability encoding CSR (`mycfg`) format
-[#mycfg_csr_structure]
-include::img/ycfgreg.edn[]
-
-endif::[]
-
 === Machine-Level CSRs modified by {cheri_base_ext_name}
 
 [#misa_y, reftext="misa ({cheri_base_ext_name})"]
@@ -591,23 +574,6 @@ The <<stidc>> register is used to identify the current software thread in superv
 .Supervisor thread identifier capability register
 include::img/stidcreg.edn[]
 
-ifdef::cheri_xycfg_csr[]
-
-[#sycfg,reftext="sycfg"]
-==== Supervisor CHERI Capability Encoding (sycfg)
-The <<sycfg>> register is used to identify which CHERI capability encoding is used by the platform.
-The capability encoding both determines the in-memory representation of a CHERI capability
-and entails a set of extensions present atop {cheri_base_ext_name}.
-The CSR exists in the _writable_ namespace and all bits are defined to be WARL,
-but, absent any future extensions, it is expected that each implementation has exactly one legal value.
-For the meaning of the individual fields, refer to the <<uycfg>> register in the unprivileged specification.
-
-.Supervisor CHERI capability encoding CSR (`sycfg`) format
-[#sycfg_csr_structure]
-include::img/ycfgreg.edn[]
-
-endif::[]
-
 === Supervisor-Level CSRs modified by {cheri_base_ext_name}
 
 [#senvcfg_y,reftext="senvcfg ({cheri_base_ext_name})"]
@@ -832,14 +798,6 @@ DDC::
 [#utidc, reftext="utidc"]
 utidc::
  See the unprivileged manual for the definition of the utidc CSR.
-
-ifdef::cheri_xycfg_csr[]
-
-[#uycfg, reftext="uycfg"]
-uycfg::
-See the unprivileged manual for the definition of the uycfg CSR.
-
-endif::[]
 
 [#root-cap, reftext="Root"]
 Root Capability::

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -334,7 +334,7 @@ and <<utidc>> CSRs.
 endif::[]
 
 [#sec_cheri_exception_handling]
-=== CHERI Exception handling
+=== CHERI Exception Handling
 
 CHERI faults are typically higher priority than standard RISC-V faults. E.g., CHERI faults on the <<pcc>> are higher priority than any other fault affecting the program counter such as Instruction Access Fault.
 
@@ -382,8 +382,8 @@ NOTE: In the table below `auth_cap` is `{cs1}`, unless {cheri_default_ext_name} 
 
 ^3^ Misaligned capability accesses raise access faults instead of misaligned faults since they cannot be emulated in software.
 
-[#CHERI_SPEC,reftext="CHERI Exceptions and speculative execution"]
-=== CHERI Exceptions and speculative execution
+[#CHERI_SPEC,reftext="CHERI Exceptions and Speculative Execution"]
+=== CHERI Exceptions and Speculative Execution
 
 NOTE: #ARC-NOTE: Please advise whether this section should remain in this chapter, or whether it should be expanded and placed in a supporting document.#
 
@@ -446,7 +446,7 @@ Setting the MBE, SBE, or UBE field to a value that is not the reset value of MBE
 
 endif::support_varxlen[]
 
-=== Machine-mode YLEN CSR Summary
+=== Machine-Mode YLEN CSR Summary
 
 <<all_capability_CSRs_m>> shows all YLEN Machine-mode CSRs added or modified by {cheri_base_ext_name}.
 
@@ -577,7 +577,7 @@ include::img/stidcreg.edn[]
 === Supervisor-Level CSRs modified by {cheri_base_ext_name}
 
 [#senvcfg_y,reftext="senvcfg ({cheri_base_ext_name})"]
-==== Supervisor environment configuration register (senvcfg)
+==== Supervisor Environment Configuration Register (senvcfg)
 
 <<section_cheri_hybrid_ext>> adds the {CRE} bit to *senvcfg*.
 The {CRE} bit can be used to disable or enable {cheri_base_ext_name} for U-mode, as described in xref:section_cheri_disable[xrefstyle=full].
@@ -612,7 +612,7 @@ See <<utidc>> for a description of the usage.
 
 include::insns/mret_sret.adoc[]
 
-=== Supervisor-mode YLEN CSR Summary
+=== Supervisor-Mode YLEN CSR Summary
 
 <<all_capability_CSRs_s>> shows all YLEN Supervisor-mode CSRs added or modified by {cheri_base_ext_name}.
 
@@ -669,7 +669,7 @@ Such sharing through virtual memory is on the page granularity, so preventing ca
 ====
 
 [#section_pte_rvy,reftext="_pte_._rvy_ field"]
-=== The _pte_._{cheri_base_ext_name_lc}_ field for capability flow control
+=== The _pte_._{cheri_base_ext_name_lc}_ Field for Capability Flow Control
 
 [NOTE]
 ====
@@ -754,7 +754,7 @@ If the effective address of the memory access is invalid, and the authorizing ca
 
 ifndef::cheri_standalone_spec[]
 
-==== List of terms defined in the unprivileged manual
+==== List of Terms Defined in the Unprivileged Manual
 
 NOTE: Due to links to the unprivileged manual being broken, this improves readability.
  Once the two manuals are merged the links will work.

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -883,9 +883,9 @@ Changes to Existing RISC-V Base ISA Instructions::
 Integrity of Capabilities::
   See the unprivileged manual for how to check the Integrity of Capabilities.
 
-[#section_cap_encoding, reftext="Capability Encoding"]
-Capability Encoding::
-  See the unprivileged manual for details of the capability encoding.
+[#section_cap_encoding, reftext="Capability-encoding format"]
+Capability-encoding format::
+  See the unprivileged manual for details of the capability-encoding format.
 
 [#rvy_insn_table, reftext="{cheri_base_ext_name}"]
 Instructions added by {cheri_base_ext_name}::

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -890,7 +890,129 @@ NOTE: This allows code fetch to be bounded, preventing a wide range of attacks t
 
 E.g., `lw t0, 16({abi_creg}sp)` loads a word from memory, getting the address, bounds, and permissions from the `{abi_creg}sp` (capability stack pointer) register.
 
-=== Added Instructions
+<<<
+
+[#section_existing_riscv_insns]
+=== Changes to Existing RISC-V Base ISA Instructions
+
+{cheri_base_ext_name} extends existing instructions that are used for handling addresses so that they manipulate a whole capability.
+
+* Whenever an input operand is used as an address (e.g., the load/store base address), all capability bits are fed into the instruction instead of just XLEN bits.
+* Any instruction that writes back an address (e.g., <<AUIPC_CHERI>> or <<CSRRW_CHERI>>) to the destination register writes a full capability register instead of just XLEN bits.
+  For all other results the high bits of the register and the {ctag} are set to zero.
+* Whenever a capability with a new address is returned, the result is _always_ created using the semantics of the <<SCADDR>> instruction.
+
+`ADD` and `ADDI` are not affected by the rule above.
+Even though they _are_ used for handling addresses, they also have other uses.
+New encodings are used for capability addition: <<CADD>> and <<CADDI>>.
+These capability add instructions must be used for all capability address incrementing.
+
+[NOTE]
+====
+
+Integer add (`ADD`) and capability add (<<CADD>>) have separate encodings.
+Using a single encoding for both is undesirable:
+
+ . Integer ADD is most commonly used for purposes other than address calculations.
+ . For high performance implementations which can issue multiple ADDs, it means that the integer ADD units do not need the upper halves of the operands, and do not need the capability check logic on the result.
+ . The compiler and/or programmer would have to execute another metadata clearing instruction after each ADD to ensure that compartments do not leak capabilities.
+
+====
+
+The rules above apply to the <<rv32,base ISA>> instructions listed in the following subsections, but also apply to instructions added by other extensions.
+Any change to instruction semantics for {cheri_base_ext_name} is called out in the chapter defining the extension.
+
+[#section_cheri_int_load_store_insns]
+==== Changes to Load/Stores
+
+All load and store instructions behave as described in <<ldst>> with one fundamental difference:
+
+* Any memory instruction that has `rs1` as a base address register reads the full capability register instead.
+  The base address is unchanged, i.e., using the value from `rs1`.
+  The metadata and {ctag} are used to <<sec_cap_checks,authorize the access>>.
+
+* For a load instruction, the lower XLEN bits of the result written to the destination register are the same as in the RV32[IE]/RV64[IE] specification.
+
+All load and store instructions authorized by `{cs1}` raise exceptions if any of these checks fail:
+
+* `{cs1}` must not be `{creg}0`^1^
+* The {ctag} (`{cs1}.tag`) must be set to one.
+* `{cs1}` must be unsealed.
+ifdef::invalid_address_viol[]
+* The virtual address in `{cs1}` must not be invalid if virtual memory is enabled.
+endif::[]
+* For loads, <<r_perm>> must be granted in `{cs1}`.
+* For stores, <<w_perm>> must be granted in `{cs1}`.
+* All <<section_cap_integrity,integrity>> checks on `{cs1}` must pass.
+
+^1^ All load/store encodings are _reserved_ if `{cs1}={creg}0` (since dereferencing <<null-cap>> always faults).
+
+All load instructions, except for <<LOAD_CAP>>, always set the {ctag} and the metadata of the result register to zero.
+
+All store instructions, except for <<STORE_CAP>>, always write zero to the {ctag} or {ctag}s associated with the memory locations that are written to.
+Therefore, misaligned stores may clear up to two associated {ctag}s.
+
+The changed interpretation of the base register also applies to all loads, stores, and all other memory operations defined in later chapters of this specification with a base operand of `rs1` unless stated otherwise.
+
+IMPORTANT: Under {cheri_base_ext_name} _all_ loads and stores are authorized by `{cs1}`.
+
+These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_cap_base_ldst_summary>>, and also apply to instructions added by other extensions, e.g.,:
+
+* Floating-point loads and stores.
+* <<section_cheri_vector_integration,Vector load and stores>>.
+* Atomic memory accesses, see <<rvy_zaamo_insn_table>> and <<rvy_zalrsc_insn_table>>.
+
+.Changed RISC-V base ISA load/store instructions summary in {cheri_base_ext_name}
+[#tab_cap_base_ldst_summary,%autowidth,options=header,align="center",cols="2,4"]
+|=======================
+|Mnemonic                   |Description
+|<<section_cheri_int_load_store_insns,LD, LW[U], LH[U], LB[U]>>|Integer loads (authorized by the capability in `{cs1}`)
+|<<section_cheri_int_load_store_insns,SD, SW, SH, SB>>|Integer stores (authorized by the capability in `{cs1}`)
+|=======================
+
+==== Changes to PC
+
+* Whenever the address field of the <<pcc>> is modified, it is _always_ updated using the semantics of the <<SCADDR>> instruction.
+  This includes adding an offset to the <<pcc>> from direct jumps and branches for both the target address and the link register.
+  In this case, e.g., `new_{pcc} = {SCADDR}(old_{pcc}, offset)`
+* <<JALR_CHERI>> copies `{cs1}` into the <<pcc>>, and increments the address field with the offset.
+  In this case, e.g., `new_{pcc} = {SCADDR}(Unseal({cs1}), offset)`
+
+NOTE: Using {SCADDR} to update the <<pcc>> address can cause the target <<pcc>> {ctag} to be set to zero, that raises a _{cheri_excep_name_pc}_ on the target instruction.
+
+NOTE: A future extension may raise an exception on branch and jump instructions if fetching a minimum-sized instruction at the target <<pcc>> will raise a _{cheri_excep_name_pc}_.
+
+These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_cap_base_summary>>, and also apply to instructions added by other extensions.
+
+.Changed RISC-V base ISA PC relative instructions summary in {cheri_base_ext_name}
+[#tab_cap_base_summary,%autowidth,options=header,align="center",cols="2,4"]
+|=======================
+|Mnemonic                   |Description
+|<<AUIPC_CHERI>>            | {AUIPC_CHERI_DESC}
+|<<JAL_CHERI>>              | {JAL_CHERI_DESC}
+|<<JALR_CHERI>>             | {JALR_CHERI_DESC}
+|<<BEQ_CHERI, BEQ ({cheri_base_ext_name})>> | {BEQ_CHERI_DESC}
+|<<BNE_CHERI, BNE ({cheri_base_ext_name})>> | {BNE_CHERI_DESC}
+|=======================
+
+include::insns/auipc_32bit.adoc[]
+include::insns/jal_32bit.adoc[]
+include::insns/jalr_32bit.adoc[]
+
+==== BEQ, BNE ({cheri_base_ext_name})
+anchor:BEQ_CHERI[BEQ ({cheri_base_ext_name})]
+anchor:BNE_CHERI[BNE ({cheri_base_ext_name})]
+
+For `beq` and `bne` only, if `rs1≤rs2` then the encoding is _reserved_.
+This includes all encodings with `rs1=rs2`.
+
+NOTE: The reserved encodings are redundant and may be used by future extensions, suggestions include branching on {ctag} values only, or YLEN-bit compares.
+
+NOTE: For `beq rs1, rs2, offset` and `bne rs1, rs2, offset`, assemblers must emit the operand order whose register-number ordering is not reserved.
+For example, `beq x1, x2, offset` is emitted as `beq x2, x1, offset`.
+For the reserved `rs1=rs2` case, `j`/`jal` can be used instead of an always-taken `beq rs1, rs1, offset`, and a never-taken `bne rs1, rs1, offset` is equivalent to a `nop`.
+
+=== {cheri_base_ext_name} Added Instructions
 {cheri_base_ext_name} adds new instructions to operate on capabilities, and redefines part of the RVI/RVE custom encoding space for this purpose.
 For harts implementing {cheri_base_ext_name}, these opcode spaces are not available for vendor custom instructions except where this specification explicitly returns subspaces to custom use.
 
@@ -1057,22 +1179,10 @@ If <<c_perm>> is not granted then:
 * <<LOAD_CAP>> reads YLEN bits from memory, but does not return the associated {ctag}, instead zero is returned.
 * <<STORE_CAP>> writes YLEN bits to memory, and writes zero to the associated {ctag}.
 
-//NOTE: Future extensions to {cheri_base_ext_name} may add mechanisms that cause
-//stores of capabilities to raise exceptions when the authorizing capability does not grant both
-//<<w_perm>> and <<c_perm>> and the stored capability has the {ctag} set.
-
 All capability data memory access instructions require naturally aligned addresses, and will take an access fault exception if this requirement is not met.
 Misaligned capability accesses cannot be emulated.
 
 NOTE: An access fault is raised instead of a misaligned exception because these instructions cannot be emulated since there is one hidden {ctag} per naturally aligned YLEN-bit memory region.
-
-All memory accesses, of any type, require permission from the authorizing capability in `{cs1}`.
-
-* All loads require <<r_perm>>, otherwise they raise an exception.
-* All stores require <<w_perm>>, otherwise they raise an exception.
-
-//NOTE: Misaligned capability memory accesses cannot be emulated.
-//  To transfer YLEN misaligned bits without a {ctag}, use integer loads and stores.
 
 Under some circumstances <<LOAD_CAP>> will _modify_ the data loaded from memory before writing it back to the destination register.
 See <<LOAD_CAP>> for details.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -724,9 +724,6 @@ include::img/pccreg.edn[]
 
 {cheri_base_ext_name} adds the <<ylen_csrs, YLEN-bit CSR>> shown in
 xref:csrnames-added-y[xrefstyle=short].
-ifdef::cheri_xycfg_csr[]
-It also adds the <<xlen_csrs, XLEN-bit CSR>> shown in xref:csrnames-added-x[xrefstyle=short]
-endif::[]
 
 [[csrnames-added-y]]
 .Capability CSRs added in {cheri_base_ext_name}
@@ -735,18 +732,6 @@ endif::[]
 |YLEN CSR|Permissions|Description
 |<<utidc>>|RW, <<asr_perm>> required for writes, not reads|User Thread ID Capability
 |===
-
-ifdef::cheri_xycfg_csr[]
-
-[[csrnames-added-x]]
-.Integer CSRs added in {cheri_base_ext_name}
-[%autowidth,float="center",align="center",cols="<,<,<",options="header"]
-|===
-|XLEN CSR|Permissions|Description
-|<<uycfg>>|RO; see section for details|Capability encoding version
-|===
-
-endif::[]
 
 [#utidc,reftext="utidc"]
 ===== User Thread Identifier Capability (utidc)
@@ -767,54 +752,6 @@ This is read-only without <<asr_perm>> to prevent a malicious compartment from t
 While the RISC-V ABI includes a _thread pointer (tp)_ register, it is not usable for the purpose of reliably identifying the current software thread because the tp register is a general-purpose register and can be changed arbitrarily by untrusted code.
 Widening <<utidc>> to a capability allows a data structure to be shared (guarded by e.g., the subset sealing mechanism), which allows for example efficient recovery of a trusted stack, without requiring additional indirection.
 =====
-
-ifdef::cheri_xycfg_csr[]
-
-[#uycfg,reftext="uycfg"]
-===== CHERI Capability Encoding (uycfg)
-
-The <<uycfg>> register is a read-only XLEN CSR used to identify which CHERI capability encoding is used by the platform.
-The capability encoding both determines the in-memory representation of a CHERI capability
-and entails a set of extensions present atop {cheri_base_ext_name}.
-
-NOTE:  Alternative capability encoding specifications,
-with, for example, new features and/or different bounds granularity,
-are possible and would not change how CHERI integrates with the RISC-V ISA,
-provided that said encodings still provide the primitives
-detailed in <<sec_capability_registers>>.
-
-NOTE: This CSR is read-only, but future extensions may provide a mechanism to modify the capability encoding currently in use.
-
-.CHERI capability encoding CSR (`uycfg`) format
-[#ycfg_csr_structure]
-include::img/ycfgreg.edn[]
-
-The following values for `uycfg` are defined:
-
-[%autowidth,options=header,cols="^,^,<"]
-|===
-|Base         |Features|Encoding
-| 0x0         | -      | Reserved (unspecified capability encoding)
-.2+|0x1       | 0x0    | <<rv64y_cap_description>> capabilities, without <<section_zylevels1>> features
-              | 0x1   <| <<rv64y_cap_description>> capabilities, with <<section_zylevels1>> features
-|0x2          | 0x0    | Reserved for CHERIoT's (RV32-only) encoding
-|===
-
-NOTE: Future extensions that change capability encoding must define new values.
-
-Extensions that define encodings derived from <<rv64y_cap_description>>
-and are generally compatible with this encoding (e.g., they only assign meaning to previously reserved bits) must preserve the Base Encoding field (the bottom 8 bits) as `0x01`.
-
-[NOTE]
-=====
-We suggest that only low-level, system software query this value directly.
-Operating systems and/or runtime environments should provide a mechanism for software
-to determine if the platform's capability encoding is backwards-compatible with a given, presumed encoding.
-Among other things, such a facility should be used as part of the platform executable loader
-to reject executables that expect unknown or known-incompatible CHERI features or capability encodings.
-=====
-
-endif::[]
 
 [#rvy_csr_classes]
 ==== CSR Classes

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -31,7 +31,7 @@ NOTE: Future RV64 CHERI capability encoding formats could be named RV64LYB, RV64
 
 Also see xref:sec_cap_encoding_formats[xrefstyle=full].
 
-=== CHERI protection model
+=== CHERI Protection Model
 
 The CHERI model is motivated by the _principle of least privilege_, which
 argues that greater security can be obtained by minimizing the privileges
@@ -149,14 +149,14 @@ All capabilities derived from invalid capabilities are themselves invalid, i.e.,
 NOTE: Writing non-capability data into a register or memory location causes the {ctag} to be set to zero.
 When the {ctag} associated with the memory location is zero, the location contains non-capability data.
 
-==== {ctag_cap}s in registers
+==== {ctag_cap}s in Registers
 
 Every YLEN-bit register has a one-bit {ctag}, indicating whether the capability in the register is valid to be dereferenced.
 This {ctag} is set to zero whenever an invalid capability operation is performed.
 
 NOTE: Examples of such invalid operations include writing only the integer portion (the address field) of the register or attempting to increase bounds or permissions.
 
-==== {ctag_cap}s in memory
+==== {ctag_cap}s in Memory
 
 {ctag_cap}s are tracked through the memory subsystem: every naturally aligned YLEN-bit wide region has a non-addressable one-bit {ctag}, which the hardware manages atomically with the data.
 The implementation must set the {ctag} to zero if any byte in the naturally aligned YLEN-bit memory region is ever written using an operation other than a store of a capability operand.
@@ -255,7 +255,7 @@ NOTE: <<SCADDR>> writes back a derived capability with a new address field and, 
 NOTE: {cheri_base_ext_name} implementations that use a different encoding scheme to <<rv64y_cap_description>> (e.g., for accelerators or specific micro-controllers) may specify an alternative to the representable range check, and may never allow the address to be out of bounds.
 Therefore, the ISA specification uses the phrase *represented exactly* for this check.
 
-==== Memory space
+==== Memory Space
 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
 space of 2^XLEN^ bytes for all memory accesses. Each memory region capable of
@@ -571,7 +571,7 @@ A capability with all-zero metadata, its {ctag} set to zero, and an address of z
 This capability grants no permissions and any dereference raises an exception.
 
 [#sec_cap_encoding_formats, reftext="capability encoding format"]
-=== Capability encoding formats
+=== Capability Encoding Formats
 CHERI implementations make trade-offs in their "capability encoding formats", such as the _precision_ of bounds and the _expressible set_ of combinations of permissions, that impact certain behaviors of the ISA.
 The definition of all CHERI base ISAs includes sufficient details of a capability encoding format to precisely define the execution behavior of all base ISA instructions.
 
@@ -874,7 +874,7 @@ The assembler pseudoinstruction to read a capability CSR `csrr {cd}, csr`, is en
 In <<clen_access_summary_base>>, when there is no read or write width shown, the CSR access is _not_ made and there are no side-effects following standard Zicsr rules.
 
 [#sec_cap_checks]
-=== Capability checks
+=== Capability Checks
 
 Every memory access must be authorized by a valid capability.
 
@@ -1088,139 +1088,7 @@ See <<LOAD_CAP>> for details.
 include::insns/load_32bit_cap.adoc[leveloffset=+1]
 include::insns/store_32bit_cap.adoc[leveloffset=+1]
 
-<<<
-
-[#section_existing_riscv_insns]
-=== Changes to Existing RISC-V Base ISA Instructions
-
-{cheri_base_ext_name} extends existing instructions that are used for handling addresses so that they manipulate a whole capability.
-
-* Whenever an input operand is used as an address (e.g., the load/store base address), all capability bits are fed into the instruction instead of just XLEN bits.
-* Any instruction that writes back an address (e.g., <<AUIPC_CHERI>> or <<CSRRW_CHERI>>) to the destination register writes a full capability register instead of just XLEN bits.
-  For all other results the high bits of the register and the {ctag} are set to zero.
-* Whenever a capability with a new address is returned, the result is _always_ created using the semantics of the <<SCADDR>> instruction.
-
-`ADD` and `ADDI` are not affected by the rule above.
-Even though they _are_ used for handling addresses, they also have other uses.
-New encodings are used for capability addition: <<CADD>> and <<CADDI>>.
-These capability add instructions must be used for all capability address incrementing.
-
-[NOTE]
-====
-
-Integer add (`ADD`) and capability add (<<CADD>>) have separate encodings.
-Using a single encoding for both is undesirable:
-
- . Integer ADD is most commonly used for purposes other than address calculations.
- . For high performance implementations which can issue multiple ADDs, it means that the integer ADD units do not need the upper halves of the operands, and do not need the capability check logic on the result.
- . The compiler and/or programmer would have to execute another metadata clearing instruction after each ADD to ensure that compartments do not leak capabilities.
-
-====
-
-The rules above apply to the <<rv32,base ISA>> instructions listed in the following subsections, but also apply to instructions added by other extensions.
-Any change to instruction semantics for {cheri_base_ext_name} is called out in the chapter defining the extension.
-
-[#section_cheri_int_load_store_insns]
-==== Changes to load/stores
-
-All load and store instructions behave as described in <<ldst>> with one fundamental difference:
-
-* Any memory instruction that has `rs1` as a base address register reads the full capability register instead.
-  The base address is unchanged, i.e., using the value from `rs1`.
-  The metadata and {ctag} are used to <<sec_cap_checks,authorize the access>>.
-
-* For a load instruction, the lower XLEN bits of the result written to the destination register are the same as in the RV32[IE]/RV64[IE] specification.
-
-All load and store instructions authorized by `{cs1}` raise exceptions if any of these checks fail:
-
-* `{cs1}` must not be `{creg}0`^1^
-* The {ctag} (`{cs1}.tag`) must be set to one.
-* `{cs1}` must be unsealed.
-ifdef::invalid_address_viol[]
-* The virtual address in `{cs1}` must not be invalid if virtual memory is enabled.
-endif::[]
-* For loads, <<r_perm>> must be granted in `{cs1}`.
-* For stores, <<w_perm>> must be granted in `{cs1}`.
-* All <<section_cap_integrity,integrity>> checks on `{cs1}` must pass.
-
-^1^ All load/store encodings are _reserved_ if `{cs1}={creg}0` (since dereferencing <<null-cap>> always faults).
-
-All load instructions, except for <<LOAD_CAP>>, always set the {ctag} and the metadata of the result register to zero.
-
-All store instructions, except for <<STORE_CAP>>, always write zero to the {ctag} or {ctag}s associated with the memory locations that are written to.
-Therefore, misaligned stores may clear up to two associated {ctag}s.
-
-The changed interpretation of the base register also applies to all loads, stores, and all other memory operations defined in later chapters of this specification with a base operand of `rs1` unless stated otherwise.
-
-IMPORTANT: Under {cheri_base_ext_name} _all_ loads and stores are authorized by `{cs1}`.
-
-These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_cap_base_ldst_summary>>, and also apply to instructions added by other extensions, e.g.,:
-
-* Floating-point loads and stores.
-* <<section_cheri_vector_integration,Vector load and stores>>.
-* Atomic memory accesses, see <<rvy_zaamo_insn_table>> and <<rvy_zalrsc_insn_table>>.
-
-.Changed RISC-V base ISA load/store instructions summary in {cheri_base_ext_name}
-[#tab_cap_base_ldst_summary,%autowidth,options=header,align="center",cols="2,4"]
-|=======================
-|Mnemonic                   |Description
-|<<section_cheri_int_load_store_insns,LD, LW[U], LH[U], LB[U]>>|Integer loads (authorized by the capability in `{cs1}`)
-|<<section_cheri_int_load_store_insns,SD, SW, SH, SB>>|Integer stores (authorized by the capability in `{cs1}`)
-|=======================
-
-==== Changes to PC
-
-* Whenever the address field of the <<pcc>> is modified, it is _always_ updated using the semantics of the <<SCADDR>> instruction.
-  This includes adding an offset to the <<pcc>> from direct jumps and branches for both the target address and the link register.
-  In this case, e.g., `new_{pcc} = {SCADDR}(old_{pcc}, offset)`
-* <<JALR_CHERI>> copies `{cs1}` into the <<pcc>>, and increments the address field with the offset.
-  In this case, e.g., `new_{pcc} = {SCADDR}(Unseal({cs1}), offset)`
-
-NOTE: Using {SCADDR} to update the <<pcc>> address can cause the target <<pcc>> {ctag} to be set to zero, that raises a _{cheri_excep_name_pc}_ on the target instruction.
-
-NOTE: A future extension may raise an exception on branch and jump instructions if fetching a minimum-sized instruction at the target <<pcc>> will raise a _{cheri_excep_name_pc}_.
-
-These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_cap_base_summary>>, and also apply to instructions added by other extensions.
-
-.Changed RISC-V base ISA PC relative instructions summary in {cheri_base_ext_name}
-[#tab_cap_base_summary,%autowidth,options=header,align="center",cols="2,4"]
-|=======================
-|Mnemonic                   |Description
-|<<AUIPC_CHERI>>            | {AUIPC_CHERI_DESC}
-|<<JAL_CHERI>>              | {JAL_CHERI_DESC}
-|<<JALR_CHERI>>             | {JALR_CHERI_DESC}
-|<<BEQ_CHERI, BEQ ({cheri_base_ext_name})>> | {BEQ_CHERI_DESC}
-|<<BNE_CHERI, BNE ({cheri_base_ext_name})>> | {BNE_CHERI_DESC}
-|=======================
-
-include::insns/auipc_32bit.adoc[]
-include::insns/jal_32bit.adoc[]
-include::insns/jalr_32bit.adoc[]
-
-==== BEQ, BNE ({cheri_base_ext_name})
-anchor:BEQ_CHERI[BEQ ({cheri_base_ext_name})]
-anchor:BNE_CHERI[BNE ({cheri_base_ext_name})]
-
-For `beq` and `bne` only, if `rs1≤rs2` then the encoding is _reserved_.
-This includes all encodings with `rs1=rs2`.
-
-NOTE: The reserved encodings are redundant and may be used by future extensions, suggestions include branching on {ctag} values only, or YLEN-bit compares.
-
-NOTE: For `beq rs1, rs2, offset` and `bne rs1, rs2, offset`, assemblers must emit the operand order whose register-number ordering is not reserved.
-For example, `beq x1, x2, offset` is emitted as `beq x2, x1, offset`.
-For the reserved `rs1=rs2` case, `j`/`jal` can be used instead of an always-taken `beq rs1, rs1, offset`, and a never-taken `bne rs1, rs1, offset` is equivalent to a `nop`.
-
-=== {cheri_base_ext_name} ISA summary
-
-[#rvy_insn_table, reftext="{cheri_base_ext_name}"]
-==== {cheri_base_ext_name} added instructions
-
-.{cheri_base_ext_name} added instructions
-[#{rvy_file_name}]
-[width="100%",options=header,cols="2,5",]
-|==============================================================================
-include::{generated_dir}/{rvy_file_name}.adoc[]
-|==============================================================================
+=== {cheri_base_ext_name} ISA Summary
 
 [#rvy_i_mod_insn_table, reftext="{rvy_i_mod_ext_name}"]
 ==== {rvy_i_mod_ext_name}
@@ -1232,12 +1100,22 @@ include::{generated_dir}/{rvy_file_name}.adoc[]
 include::{generated_dir}/{rvy_i_mod_file_name}.adoc[]
 |==============================================================================
 
+[#rvy_insn_table, reftext="{cheri_base_ext_name}"]
+==== {cheri_base_ext_name} Added Instructions
+
+.{cheri_base_ext_name} added instructions
+[#{rvy_file_name}]
+[width="100%",options=header,cols="2,5",]
+|==============================================================================
+include::{generated_dir}/{rvy_file_name}.adoc[]
+|==============================================================================
+
 include::rvy64-encoding.adoc[]
 
 ifdef::cheri_standalone_spec[]
 
 [#rvy_zca_insn_table, reftext="{rvy_zca_ext_name}"]
-== Zca ({cheri_base_ext_name} added and modified instructions)
+== Zca ({cheri_base_ext_name} Added and Modified Instructions)
 
 ifndef::cheri_ratification_v1_only[]
 Zcf (RV32) and Zcd (RV64) are incompatible with the {cheri_base_ext_name} base ISA, as their encodings are reused for the capability loads and stores below.
@@ -1257,13 +1135,13 @@ include::{generated_dir}/{rvy_zca_file_name}.adoc[]
 
 ifndef::cheri_ratification_v1_only[]
 //this has all been integrated into the relevant chapter
-=== RV32 / {cheri_base32_ext_name} RVC load/store mapping summary
+=== RV32 / {cheri_base32_ext_name} RVC Load/Store Mapping Summary
 
 include::rv32c_mapping_table.adoc[]
 endif::[]
 
 <<<
-=== RV64 / {cheri_base64_ext_name} RVC load/store mapping summary
+=== RV64 / {cheri_base64_ext_name} RVC Load/Store Mapping Summary
 
 include::rv64c_mapping_table.adoc[]
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -1012,14 +1012,13 @@ NOTE: For `beq rs1, rs2, offset` and `bne rs1, rs2, offset`, assemblers must emi
 For example, `beq x1, x2, offset` is emitted as `beq x2, x1, offset`.
 For the reserved `rs1=rs2` case, `j`/`jal` can be used instead of an always-taken `beq rs1, rs1, offset`, and a never-taken `bne rs1, rs1, offset` is equivalent to a `nop`.
 
-=== {cheri_base_ext_name} Added Instructions
-{cheri_base_ext_name} adds new instructions to operate on capabilities, and redefines part of the RVI/RVE custom encoding space for this purpose.
-For harts implementing {cheri_base_ext_name}, these opcode spaces are not available for vendor custom instructions except where this specification explicitly returns subspaces to custom use.
+=== {cheri_base_ext_name} Encoding Space and Instructions
+{cheri_base_ext_name} adds new instructions to operate on capabilities, and redefines part of the RVI/RVE custom encoding space for this purpose as shown in <<rvyopcodemap>>.
 
-. The RVI _custom-3_ space is renamed to *{cheri_base_ext_name}-A* and is used for standard {cheri_base_ext_name} encodings.
-. The RVI _custom-2_ space is renamed to *{cheri_base_ext_name}-B* and is used for standard {cheri_base_ext_name} encodings.
-. The RVI _custom-1_ space is renamed to *{cheri_base_ext_name}-C* and is used for standard {cheri_base_ext_name} encodings.
-. The RVI _custom-0_ space is still available for custom encodings.
+. *{cheri_base_ext_name}-A* and is used for standard {cheri_base_ext_name} encodings.
+. *{cheri_base_ext_name}-B* and is used for standard {cheri_base_ext_name} encodings.
+. *{cheri_base_ext_name}-C* and is used for standard {cheri_base_ext_name} encodings.
+. _custom_ space is available for custom encodings.
 
 [[rvyopcodemap]]
 .RISC-V base opcode map for {cheri_base_ext_name}, inst[1:0]=11
@@ -1027,15 +1026,15 @@ For harts implementing {cheri_base_ext_name}, these opcode spaces are not availa
 |===
 |inst[4:2] .2+|000 .2+|001   .2+|010     .2+|011   .2+|100 .2+|101     .2+|110          .2+|111 (>32b)
 |inst[6:5]
-|00           |LOAD   |LOAD-FP  |_custom-0_ |MISC-MEM |OP-IMM |AUIPC      |OP-IMM-32       |_reserved_
+|00           |LOAD   |LOAD-FP  |_custom_   |MISC-MEM |OP-IMM |AUIPC      |OP-IMM-32       |_reserved_
 |01           |STORE  |STORE-FP |*{cheri_base_ext_name}-C*    |AMO      |OP     |LUI        |OP-32           |_reserved_
 |10           |MADD   |MSUB     |NMSUB      |NMADD    |OP-FP  |OP-V       |*{cheri_base_ext_name}-B*         |_reserved_
 |11           |BRANCH |JALR     |_reserved_ |JAL      |SYSTEM |OP-VE      |*{cheri_base_ext_name}-A*         |_reserved_
 |===
 
-NOTE: Standard {cheri_base_ext_name} encodings will _never_ be placed in _custom-0_.
+NOTE: Standard {cheri_base_ext_name} encodings will _never_ be placed in _custom_.
 
-NOTE: Parts of *{cheri_base_ext_name}-A/B/C* may be returned to custom space in the future.
+NOTE: Parts of *{cheri_base_ext_name}-A/B/C* may be allocated for custom use in the future.
 
 ==== Instructions to Update The Capability Pointer
 

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -512,6 +512,7 @@ For the base set of permissions just defined, the rules in <<base_clrperm_rule_s
 |===
 
 NOTE: These rules enforce sensible permission combinations.
+ Capability-encoding formats which encode a subset of valid combinations of permissions in the <<AP-field>> reference and extend these rules.
 
 Extensions that define new permission bits may also introduce new dependency constraints.
 Currently defined examples are:
@@ -914,9 +915,7 @@ NOTE: Standard {cheri_base_ext_name} encodings will _never_ be placed in _custom
 
 NOTE: Parts of *{cheri_base_ext_name}-A/B/C* may be returned to custom space in the future.
 
-:leveloffset: +1
-
-=== Instructions to Update The Capability Pointer
+==== Instructions to Update The Capability Pointer
 
 Creating a new capability with a different address (i.e., updating the pointer) requires specific instructions instead of integer ADD/ADDI.
 These instructions all include a check that the resulting address can be <<section_cap_representable_check,represented exactly>> within the new capability.
@@ -930,12 +929,12 @@ These instructions all include a check that the resulting address can be <<secti
 |<<SCADDR>>   | {SCADDR_DESC}
 |=======================
 
-include::insns/cadd_32bit.adoc[]
-include::insns/scaddr_32bit.adoc[]
+include::insns/cadd_32bit.adoc[leveloffset=+1]
+include::insns/scaddr_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Instructions to Manipulate Capabilities
+==== Instructions to Manipulate Capabilities
 
 For security, capabilities can only be modified in restricted ways.
 Special instructions are provided to copy capabilities or derive a new capability using manipulations such as _shrinking_ the bounds (<<SCBNDS>>), _reducing_ the permissions (<<CLRPERM>>) or _authorizing_ a capability with another one which has a superset (or identical) bounds and permissions (<<CBLD>>).
@@ -970,18 +969,18 @@ Among the instructions that use the subset relation, this is only material for t
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>
 
-include::insns/acperm_32bit.adoc[]
-include::insns/cmv_32bit.adoc[]
-include::insns/schi_32bit.adoc[]
-include::insns/scbnds_32bit.adoc[]
-include::insns/scbndsr_32bit.adoc[]
-include::insns/ysunseal_32bit.adoc[]
-include::insns/cbld_32bit.adoc[]
-include::insns/sentry_32bit.adoc[]
+include::insns/acperm_32bit.adoc[leveloffset=+1]
+include::insns/cmv_32bit.adoc[leveloffset=+1]
+include::insns/schi_32bit.adoc[leveloffset=+1]
+include::insns/scbnds_32bit.adoc[leveloffset=+1]
+include::insns/scbndsr_32bit.adoc[leveloffset=+1]
+include::insns/ysunseal_32bit.adoc[leveloffset=+1]
+include::insns/cbld_32bit.adoc[leveloffset=+1]
+include::insns/sentry_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Instructions to Decode Capability Bounds
+==== Instructions to Decode Capability Bounds
 
 The _bounds_ describing the range of addresses the capability gives access to are stored in a compressed format.
 These instructions query the bounds and related information.
@@ -995,13 +994,13 @@ These instructions query the bounds and related information.
 |<<GCTOP>>  | {GCTOP_DESC}
 |=======================
 
-include::insns/gcbase_32bit.adoc[]
-include::insns/gclen_32bit.adoc[]
-include::insns/gctop_32bit.adoc[]
+include::insns/gcbase_32bit.adoc[leveloffset=+1]
+include::insns/gclen_32bit.adoc[leveloffset=+1]
+include::insns/gctop_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Instructions to Extract Capability Fields
+==== Instructions to Extract Capability Fields
 
 These instructions either directly read bit fields from the metadata or {ctag}, or only apply simple transformations on the metadata.
 
@@ -1016,14 +1015,14 @@ These instructions either directly read bit fields from the metadata or {ctag}, 
 |=======================
 
 
-include::insns/gctag_32bit.adoc[]
-include::insns/gcperm_32bit.adoc[]
-include::insns/gctype_32bit.adoc[]
-include::insns/gchi_32bit.adoc[]
+include::insns/gctag_32bit.adoc[leveloffset=+1]
+include::insns/gcperm_32bit.adoc[leveloffset=+1]
+include::insns/gctype_32bit.adoc[leveloffset=+1]
+include::insns/gchi_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Miscellaneous Instructions to Handle Capability Data
+==== Miscellaneous Instructions to Handle Capability Data
 
 .Miscellaneous capability instruction summary in {cheri_base_ext_name}
 [#tab_cap_misc_summary,%autowidth,options=header,align="center",cols="1,4"]
@@ -1034,14 +1033,14 @@ include::insns/gchi_32bit.adoc[]
 |<<CRAM>>   | {CRAM_DESC}
 |=======================
 
-include::insns/sceq_32bit.adoc[]
-include::insns/scss_32bit.adoc[]
-include::insns/cram_32bit.adoc[]
+include::insns/sceq_32bit.adoc[leveloffset=+1]
+include::insns/scss_32bit.adoc[leveloffset=+1]
+include::insns/cram_32bit.adoc[leveloffset=+1]
 
 <<<
 
 [#sec_cap_load_store]
-=== Instructions to Load and Store Capability Data
+==== Instructions to Load and Store Capability Data
 
 New loads and stores are introduced to handle capability data, <<LOAD_CAP>> and <<STORE_CAP>>.
 These capability load and store instructions atomically access YLEN bits of data and the associated {ctag}.
@@ -1086,12 +1085,10 @@ See <<LOAD_CAP>> for details.
 |<<STORE_CAP>>     |Store capability
 |=======================
 
-include::insns/load_32bit_cap.adoc[]
-include::insns/store_32bit_cap.adoc[]
+include::insns/load_32bit_cap.adoc[leveloffset=+1]
+include::insns/store_32bit_cap.adoc[leveloffset=+1]
 
 <<<
-
-:leveloffset: -1
 
 [#section_existing_riscv_insns]
 === Changes to Existing RISC-V Base ISA Instructions
@@ -1467,12 +1464,10 @@ include::{generated_dir}/{rvy_bndsrdw_insn_file_name}.adoc[]
 
 endif::[]
 
-:leveloffset: +1
-
 ifndef::cheri_ratification_v1_only[]
 
 [[rv32y]]
-== {cheri_base32_ext_name} Base Capability Instruction Set, Version 1.0
+=== {cheri_base32_ext_name} Base Capability Instruction Set, Version 1.0
 
 <<rvy>> introduced the CHERI base ISA and the {rv64y_uni_base_name} encoding format, as the only defined {cheri_base64_ext_name} format.
 
@@ -1496,8 +1491,6 @@ The currently defined RV32 capability encoding formats are:
 NOTE: Further domain specialized capability encoding formats are expected in the future.
 
 
-include::rvy32-encoding.adoc[]
+include::rvy32-encoding.adoc[leveloffset=+1]
 
 endif::[]
-
-:leveloffset: -1

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -952,9 +952,7 @@ For the reserved `rs1=rs2` case, `j`/`jal` can be used instead of an always-take
 === {cheri_base_ext_name} Encoding Space and Instructions
 {cheri_base_ext_name} adds new instructions to operate on capabilities, and redefines part of the RVI/RVE custom encoding space for this purpose as shown in <<rvyopcodemap>>.
 
-. *{cheri_base_ext_name}-A* and is used for standard {cheri_base_ext_name} encodings.
-. *{cheri_base_ext_name}-B* and is used for standard {cheri_base_ext_name} encodings.
-. *{cheri_base_ext_name}-C* and is used for standard {cheri_base_ext_name} encodings.
+. *{cheri_base_ext_name}-A*, *{cheri_base_ext_name}-B*, and *{cheri_base_ext_name}-C* are used for standard {cheri_base_ext_name} encodings.
 . _custom_ space is available for custom encodings.
 
 [[rvyopcodemap]]

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -13,8 +13,8 @@ This mechanism is implemented by providing a new primitive, called a *capability
 Capabilities are unforgeable and delegatable tokens of authority that grant software the ability to perform a specific set of operations.
 In CHERI, integer-based pointers are replaced by capabilities to provide memory access control.
 
-Every {cheri_base_ext_name} base ISA requires a _capability encoding format_ to complete the specification, such as <<rv64y_cap_description>>.
-The _capability encoding format_ gives full details of how CHERI capabilities are represented in memory and in registers, and specifies the exact properties such as bounds precision and available combinations of permissions.
+Every {cheri_base_ext_name} base ISA requires a _capability-encoding format_ to complete the specification, such as <<rv64y_cap_description>>.
+The _capability-encoding format_ gives full details of how CHERI capabilities are represented in memory and in registers, and specifies the exact properties such as bounds precision and available combinations of permissions.
 
 For example, in {rv64y_uni_base_name}:
 
@@ -22,12 +22,12 @@ For example, in {rv64y_uni_base_name}:
 . `L` denotes a long base name.
 . When `I` or `E` is omitted, the default is 32 integer registers (`I`); `E` specifies 16 integer registers (e.g., `RV64LEYA`).
 . `Y` denotes a CHERI base.
-. `A` denotes the capability encoding format; the capability encoding format after `Y` is mandatory.
+. `A` denotes the capability-encoding format; the capability-encoding format after `Y` is mandatory.
 
 NOTE: This naming scheme is based on the RISC-V https://lists.riscv.org/g/tech-unprivileged/topic/longer_base_name_proposal/116854896["longer base name" proposal], which allows base ISA names longer than two characters.
-Making the capability encoding format after `Y` mandatory simplifies future long base naming.
+Making the capability-encoding format after `Y` mandatory simplifies future long base naming.
 
-NOTE: Future RV64 CHERI capability encoding formats could be named RV64LYB, RV64LYC, and so on, or they may have more descriptive names after the RV64LY prefix.
+NOTE: Future RV64 CHERI capability-encoding formats could be named RV64LYB, RV64LYC, and so on, or they may have more descriptive names after the RV64LY prefix.
 
 Also see xref:sec_cap_encoding_formats[xrefstyle=full].
 
@@ -69,12 +69,12 @@ improve their security.
 {cheri_base_ext_name} widens all registers that can hold addresses (including the general-purpose registers, {pcc}, and address-holding CSRs) from `XLEN` to `2*XLEN` bits (hereafter referred to as YLEN), adding metadata to protect their integrity, limit how they are manipulated, and control their use.
 In addition to widening to YLEN, each register also gains a one-bit {ctag} which is defined below.
 
-{cheri_base_ext_name} specifies the minimum required fields that the capability encoding format must support, and their semantics.
+{cheri_base_ext_name} specifies the minimum required fields that the capability-encoding format must support, and their semantics.
 This version of {cheri_base_ext_name} defines only little-endian capability memory layouts.
 The memory representation of capabilities is always `2*XLEN` (`YLEN`) bits wide and holds the address in the lower `XLEN` bits of memory and the metadata in the upper `XLEN` bits.
 
-{cheri_base_ext_name} is designed to be highly extensible by allowing different capability encoding formats to exist.
-Specific capability encoding formats may support different ISA extensions and add new architectural permissions.
+{cheri_base_ext_name} is designed to be highly extensible by allowing different capability-encoding formats to exist.
+Specific capability-encoding formats may support different ISA extensions and add new architectural permissions.
 
 .CHERI Capability structure
 [#cap_structure]
@@ -241,7 +241,7 @@ image::../cheri/img/cap-bounds-map.png[width=80%,align=center]
 
 The maximum range of address values that the pointer can take without changing the calculation of the bounds is defined by the <<section_cap_representable_check,representable range>>.
 
-NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability encoding with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
+NOTE: The historic, uncompressed 64-bit CHERI-MIPS CPU had a 256-bit capability-encoding format with separate 64-bit values for the base and top memory bounds, and another for metadata fields.
  This scheme could represent all out-of-bounds pointers with a very high hardware cost.
 
 Since the upper bits of the address are used to calculate the top and base bound addresses, deriving a new capability with a different address could change the resulting bounds.
@@ -281,9 +281,9 @@ This metadata value indicates the type of the capability and determines which op
 For example, the <<sec_cap_type>> can be used to _seal_ capabilities against modification, to provide control flow integrity, and to provide immutable software tokens.
 ifndef::cheri_ratification_v1_only[]
 Which capability types a given CHERI platform supports is a function of the extensions and <<sec_cap_encoding_formats>> in use.
-The capability encoding format specifies a mapping between the CT-field within the encoding and the architectural capability types.
+The capability-encoding format specifies a mapping between the CT-field within the encoding and the architectural capability types.
 
-The capability encoding must be able to encode type `0` (_unsealed_).
+The capability-encoding format must be able to encode type `0` (_unsealed_).
 If any other sealed type exists, then they can be used to provide different levels of control-flow integrity.
 endif::[]
 
@@ -353,7 +353,7 @@ For example, if <<SENTRY>> is available on a given platform,
 the type with which it seals capabilities is considered _ambiently available_.
 endif::[]
 
-The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability encoding formats may add more types.
+The standard capability type mapping is shown in <<table_capability_types>>, extensions and capability-encoding formats may add more types.
 
 [#table_capability_types]
 .Standard capability type mapping
@@ -369,7 +369,7 @@ ifndef::cheri_ratification_v1_only[]
 | Forward-edge  <<sentry_cap>>  | Extension-defined | Immutable _sentry_ type for _forward-edge_ transitions.
 | Backward-edge <<sentry_cap>>  | Extension-defined | Immutable _sentry_ type for _backward-edge_ transitions.
 endif::[]
-| All other values              | Reserved          | Reserved for future standard extensions or capability encoding formats.
+| All other values              | Reserved          | Reserved for future standard extensions or capability-encoding formats.
 |===
 
 ifndef::cheri_ratification_v1_only[]
@@ -381,18 +381,18 @@ NOTE: Other encoding formats may provide different type mappings, but the value 
 ====
 In general, each of sealing and unsealing actions may require *authority*
 to operate on the non-zero type;
-capability encoding formats which define non-zero types will specify how software expresses this authority.
+capability-encoding formats which define non-zero types will specify how software expresses this authority.
 
-Capability encoding formats may also make the set of <<sec_cap_type>> values
+Capability-encoding formats may also make the set of <<sec_cap_type>> values
 that may be used to seal a particular capability
 depend on the permissions granted by that capability.
 For example, it can be a useful space optimization to differentiate
 the <<sec_cap_type>> values for capabilities granting <<x_perm>>
 from those not granting <<x_perm>>;
-the <<x_perm>> in the capability encoding effectively adds
+the <<x_perm>> in the capability-encoding format effectively adds
 an additional bit to the <<sec_cap_type>> field.
 
-Capability encoding formats will explicitly state whether these are relevant to them.
+Capability-encoding formats will explicitly state whether these are relevant to them.
 
 Permission-dependent types are not used by <<rv64y_cap_description>>, but are by the CHERIoT formats.
 ====
@@ -401,7 +401,7 @@ endif::[]
 [NOTE]
 ====
 
-Future extensions and capability encoding formats may declare new <<CT-field>> values, examples of which are:
+Future extensions and capability-encoding formats may declare new <<CT-field>> values, examples of which are:
 
 * Sealed types which cannot be used as a <<sentry_cap>>
 * <<sentry_cap>> types which can be used only for function calls or only for function returns for improved CFI: specific <<CT-field>> values are required for each, in contrast with the current <<sentry_cap>> which can be used for both.
@@ -417,7 +417,7 @@ Permissions grant access subject to the <<cap_valid_tag>> being set to one, the 
 NOTE: Any memory operation is also contingent on requirements imposed by other RISC-V architectural features, such as virtual memory, PMP, and PMAs, even if the capability grants sufficient permissions.
 
 The permissions defined in {cheri_base_ext_name} are listed in <<ap_field_summary>>.
-All capability encoding formats must support at least this set of permissions.
+All capability-encoding formats must support at least this set of permissions.
 Permissions can be cleared when deriving a new capability value (using <<CLRPERM>>) but they can never be added.
 
 .AP-field summary
@@ -523,7 +523,7 @@ ifndef::cheri_ratification_v1_only[]
 . <<section_zyseal>>, see <<zyseal_ap_field>>
 endif::[]
 
-Capability encoding formats may impose additional constraints to reduce the number of bits necessary to represent permissions.
+Capability-encoding formats may impose additional constraints to reduce the number of bits necessary to represent permissions.
 
 [#SDP-field, reftext="SDP-field"]
 ==== Software-Defined Permissions (SDP)
@@ -543,11 +543,11 @@ NOTE: Software is completely free to define the usage of these bits.
 [#root-cap,reftext="Root"]
 Root Capabilities::
 _Root_ capabilities are those provided by the execution environment upon initialization.
-In some capability encoding formats there is a single _Infinite_ capability value,
+In some capability-encoding formats there is a single _Infinite_ capability value,
 which grants all permissions and has bounds covering the whole 2^XLEN^ address space;
 in such systems, _root_ capabilities are often _Infinite_.
 +
-Other capability encoding formats may have a set of _root_ capabilities distinguishing between data and executable capabilities as shown below.
+Other capability-encoding formats may have a set of _root_ capabilities distinguishing between data and executable capabilities as shown below.
 +
 Upon initialization, the execution environment defines how root capabilities are made available to software.
 +
@@ -570,30 +570,30 @@ NULL Capability::
 A capability with all-zero metadata, its {ctag} set to zero, and an address of zero is referred to as the _NULL_ capability.
 This capability grants no permissions and any dereference raises an exception.
 
-[#sec_cap_encoding_formats, reftext="capability encoding format"]
-=== Capability Encoding Formats
-CHERI implementations make trade-offs in their "capability encoding formats", such as the _precision_ of bounds and the _expressible set_ of combinations of permissions, that impact certain behaviors of the ISA.
-The definition of all CHERI base ISAs includes sufficient details of a capability encoding format to precisely define the execution behavior of all base ISA instructions.
+[#sec_cap_encoding_formats, reftext="capability-encoding format"]
+=== Capability-encoding formats
+CHERI implementations make trade-offs in their "capability-encoding formats", such as the _precision_ of bounds and the _expressible set_ of combinations of permissions, that impact certain behaviors of the ISA.
+The definition of all CHERI base ISAs includes sufficient details of a capability-encoding format to precisely define the execution behavior of all base ISA instructions.
 
 Whilst {cheri_base64_ext_name} has enough bits in the encoding format to prevent such trade-offs in general, the concepts are introduced here and {cheri_base32_ext_name} formats will make extensive use of them.
 
 The name {cheri_base_ext_name} refers generically to CHERI base ISAs, which share common semantics but may have different metadata encodings.
-The {cheri_base_ext_name} name on its own does not describe the complete base ISAs, but defines all the _semantics_ of a {cheri_base_ext_name} machine, where certain behavioral parameters must be filled in by the capability encoding.
-For example, the <<SCBNDSR>> instruction yields a capability with new bounds that are rounded differently depending on the number of bits allocated to the bounds in the capability encoding format.
+The {cheri_base_ext_name} name on its own does not describe the complete base ISAs, but defines all the _semantics_ of a {cheri_base_ext_name} machine, where certain behavioral parameters must be filled in by the capability-encoding format.
+For example, the <<SCBNDSR>> instruction yields a capability with new bounds that are rounded differently depending on the number of bits allocated to the bounds in the capability-encoding format.
 Systems with XLEN=64 can allocate more bits towards the mantissa of the bounds than XLEN=32 system and therefore have a larger <<section_cap_representable_check>>.
 
 NOTE: These observable differences in behavior are similar to floating-point numbers where the supported operations and their semantics are the same for all formats, but the exact result depends on the representation (e.g., 16/32/64-bit IEEE-754 or other floating-point formats).
 
 It is possible to generate code for {cheri_base_ext_name} that is compatible with all valid capability encoding formats.
-However, to allow compilers and/or software library authors to make assumptions about encoding-dependent properties such as bounds precisions, each capability encoding format comes with a set of standard parameters.
+However, to allow compilers and/or software library authors to make assumptions about encoding-dependent properties such as bounds precisions, each capability-encoding format comes with a set of standard parameters.
 
-Each capability encoding format also declares a new base ISA.
+Each capability-encoding format also declares a new base ISA.
 
-The documentation for each capability encoding format specifies at least the parameters in <<cap_encoding_param_default_summary>> below where the default is not used.
+The documentation for each capability-encoding format specifies at least the parameters in <<cap_encoding_param_default_summary>> below where the default is not used.
 
 NOTE: The default settings all match <<rv64y_cap_description>>.
 
-.{cheri_base_ext_name} capability encoding format parameters
+.{cheri_base_ext_name} capability-encoding format parameters
 [#cap_encoding_param_default_summary,width="100%",options=header,cols="1,1,1,4"]
 |==============================================================================
 | Parameter   | Legal values | Default Value        | Comment
@@ -615,10 +615,10 @@ Two parameters use non-numeric values:
 AP_ENC::
  Whether permissions in the <<AP-field>> are encoded using a _full_ (`full`) representation allowing all valid combinations of permissions, or a _partial_ (`part`) representation which does not represent all possible combinations and so uses fewer encoding bits.
 REP_RANGE::
- Whether the capability encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
+ Whether the capability-encoding format guarantees representability of out-of-bounds capability values: `rc1`, where the encoding uses one additional bit and a _centered_ out-of-bounds region, or `r0`, where no bits are used for out-of-bounds capabilities and there is no guaranteed <<section_cap_representable_check,representable range>> for out-of-bounds addresses.
 
-NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability encoding ensures sufficient future extensibility and therefore few custom formats are expected to exist.
- {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability encoding formats will exist.
+NOTE: For {cheri_base64_ext_name}, the number of spare bits in the capability-encoding format ensures sufficient future extensibility and therefore few custom formats are expected to exist.
+ {cheri_base32_ext_name}, however, has insufficient bits available to enable features for all target domains, so multiple {cheri_base32_ext_name}-extending capability-encoding formats will exist.
 
 [#section_cap_integrity]
 === Integrity of Capabilities
@@ -1405,14 +1405,14 @@ While the in-memory bit pattern of capabilities across these systems as well as 
 The {rv32y_uni_base_name} follows the same rules as {rv64y_uni_base_name}, and sets different parameter values.
 It also encodes the <<AP-field>> to use fewer bits.
 
-The currently defined RV32 capability encoding formats are:
+The currently defined RV32 capability-encoding formats are:
 
 * <<rv32y_cap_description>>
 * <<rv32y_cheriot_encoding1_description>>
 * <<rv32y_cheriot_encoding2_description>>
 * <<rv32y_cheriot_encoding3_description>>
 
-NOTE: Further domain specialized capability encoding formats are expected in the future.
+NOTE: Further domain specialized capability-encoding formats are expected in the future.
 
 
 include::rvy32-encoding.adoc[leveloffset=+1]

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -1,26 +1,26 @@
 [#rv32y_cap_description, reftext="{rv32y_uni_base_name}"]
 == The {rv32y_uni_base_name} Capability Base for RV32
 
-This section describes an in-memory format and properties of a capability encoding intended for RV32.
+This section describes an in-memory format and properties of a capability-encoding format intended for RV32.
 This format is based upon the <<rv64y_cap_description,{rv64y_uni_base_name}>> format with the following changes:
 
 * The width, or presence, of fields in the encoding are changed as defined in <<rvy32_uni_base_name_param_summary>>.
 * The architectural permissions (AP) field is compressed to save encoding space, and so rules are defined for removing permissions.
 
 [#section_cap_encoding32]
-=== Capability Encoding
+=== Capability-encoding format
 
 The encoding format of the {rv32y_uni_base_name} capability is shown in xref:cap_encoding_xlen32[xrefstyle=short].
 
-.Capability encoding for {rv32y_uni_base_name}
+.Capability-encoding format for {rv32y_uni_base_name}
 [#cap_encoding_xlen32]
 include::img/cap-encoding-xlen32.edn[]
 
-==== Capability Encoding Summary
+==== Capability-encoding format Summary
 
 The bit ranges in <<cap_encoding_xlen32_field_table>> are relative to the XLEN-bit metadata, i.e., the upper half of the in-memory representation.
 
-.{rv32y_uni_base_name} capability encoding format metadata fields
+.{rv32y_uni_base_name} capability-encoding format metadata fields
 [#cap_encoding_xlen32_field_table,width="100%",options=header,cols="1,1,4"]
 |==============================================================================
 | Field      | Bit range | Comment

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -8,7 +8,7 @@ This format is based upon the <<rv64y_cap_description,{rv64y_uni_base_name}>> fo
 * The architectural permissions (AP) field is compressed to save encoding space, and so rules are defined for removing permissions.
 
 [#section_cap_encoding32]
-=== Capability-encoding format
+=== Capability-Encoding Format
 
 The encoding format of the {rv32y_uni_base_name} capability is shown in xref:cap_encoding_xlen32[xrefstyle=short].
 
@@ -16,7 +16,7 @@ The encoding format of the {rv32y_uni_base_name} capability is shown in xref:cap
 [#cap_encoding_xlen32]
 include::img/cap-encoding-xlen32.edn[]
 
-==== Capability-encoding format Summary
+==== Capability-Encoding Format Summary
 
 The bit ranges in <<cap_encoding_xlen32_field_table>> are relative to the XLEN-bit metadata, i.e., the upper half of the in-memory representation.
 
@@ -84,7 +84,7 @@ NOTE: Extensions which allocate new permissions need to specify modifications to
 
 <<<
 [AP-encoding-rv32y]
-===== AP encoding and rules
+===== AP Encoding and Rules
 
 All gaps in <<cap_perms_encoding_nolevels32>> are _reserved_ for future extensions.
 
@@ -207,7 +207,7 @@ The following rules are run once _in order_:
 . `RV32-base-6,7`
 
 [#default-cap-AP-hybrid-zylevels1]
-==== AP encoding and rules summary with {cheri_levels1_ext_name} for {rv32y_uni_base_name}
+==== AP Encoding and Rules Summary with {cheri_levels1_ext_name} for {rv32y_uni_base_name}
 
 This section is non-normative - it summarizes the overall encoded permissions table and <<CLRPERM>> rules when both <<section_cheri_hybrid_ext>> and <<section_zylevels1>> are implemented.
 

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -6,7 +6,7 @@ This section describes the in-memory representation and properties of the capabi
 NOTE: The format is closely modeled upon features from CHERI v9 cite:[cheri-v9-spec], and the bounds encoding scheme is based upon CHERI Concentrate cite:[woodruff2019cheri].
 
 [#section_cap_encoding64]
-=== Capability-encoding format
+=== Capability-Encoding Format
 
 .Capability-encoding format for {rv64y_uni_base_name}
 [#cap_encoding_xlen64]
@@ -48,7 +48,7 @@ The bit ranges in <<cap_encoding_xlen64_field_table>> are relative to the XLEN-b
 
 NOTE: T[13:12], T[2:0] and B[2:0] are not specified by the metadata fields and are calculated as shown in <<section_cap_bounds_decoding>>.
 
-==== Capability-encoding format Parameter Summary
+==== Capability-Encoding Format Parameter Summary
 
 .{rv64y_uni_base_name} capability-encoding format parameters
 [#rvy64_uni_base_name_param_summary,width="100%",options=header,cols="1,1,4"]
@@ -418,7 +418,7 @@ In summary, for either bound:
 * If the bound is above the _s_-aligned boundary and the capability address is below the _s_-aligned boundary, then set the correction factor to +1 to correct the bound upwards.
 
 [#t_bound_msb_inversion]
-===== Top bound address MSB correction
+===== Top Bound Address MSB Correction
 
 A capability has _infinite_ bounds if its bounds cover the entire address space
 such that _base_=0 and _top_{ge}2^XLEN^,

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -1,20 +1,20 @@
 [#rv64y_cap_description, reftext="{rv64y_uni_base_name}"]
 == The {rv64y_uni_base_name} Capability Base for {cheri_base64_ext_name}
 
-This section describes the in-memory format and properties of the capability encoding intended for {cheri_base64_ext_name}.
+This section describes the in-memory representation and properties of the capability-encoding format intended for {cheri_base64_ext_name}.
 
 NOTE: The format is closely modeled upon features from CHERI v9 cite:[cheri-v9-spec], and the bounds encoding scheme is based upon CHERI Concentrate cite:[woodruff2019cheri].
 
 [#section_cap_encoding64]
-=== Capability Encoding
+=== Capability-encoding format
 
-.Capability encoding for {rv64y_uni_base_name}
+.Capability-encoding format for {rv64y_uni_base_name}
 [#cap_encoding_xlen64]
 include::img/cap-encoding-xlen64.edn[]
 
 NOTE: Reserved bits must be 0 in valid capabilities and are available for future extensions to {cheri_base_ext_name}.
 
-The encoding diagram above of the capability encoding format includes some fields which depend upon the presence of extensions:
+The encoding diagram above of the capability-encoding format includes some fields which depend upon the presence of extensions:
 
 <<section_cheri_hybrid_ext>>::
 When <<section_cheri_hybrid_ext>> is implemented
@@ -29,7 +29,7 @@ When <<section_zylevels1>> is implemented:
 
 The bit ranges in <<cap_encoding_xlen64_field_table>> are relative to the XLEN-bit metadata, i.e., the upper half of the in-memory representation.
 
-.{rv64y_uni_base_name} capability encoding format metadata fields
+.{rv64y_uni_base_name} capability-encoding format metadata fields
 [#cap_encoding_xlen64_field_table,width="100%",options=header,cols="1,1,4"]
 |==============================================================================
 | Field      | Bit range | Comment
@@ -48,9 +48,9 @@ The bit ranges in <<cap_encoding_xlen64_field_table>> are relative to the XLEN-b
 
 NOTE: T[13:12], T[2:0] and B[2:0] are not specified by the metadata fields and are calculated as shown in <<section_cap_bounds_decoding>>.
 
-==== Capability Encoding Parameter Summary
+==== Capability-encoding format Parameter Summary
 
-.{rv64y_uni_base_name} capability encoding format parameters
+.{rv64y_uni_base_name} capability-encoding format parameters
 [#rvy64_uni_base_name_param_summary,width="100%",options=header,cols="1,1,4"]
 |==============================================================================
 | Parameter   | Default Value        | Comment
@@ -109,7 +109,7 @@ There are 9 bits in total allocated to the <<AP-field>> and the <<p_bit>>.
 
 Therefore there are 90 valid combinations encoded in 9-bits.
 
-Future extensions or capability encoding formats may leverage these reserved patterns to implement a more compact joint <<AP-field>> and <<p_bit>> encoding that is fully _compatible for all software_ to increase the number of reserved bits.
+Future extensions or capability-encoding formats may leverage these reserved patterns to implement a more compact joint <<AP-field>> and <<p_bit>> encoding that is fully _compatible for all software_ to increase the number of reserved bits.
 
 // The existing encoding is not dense but is beneficial for the timing of reading capability data from data caches, as an implicit <<CLRPERM>> is required to filter loaded permissions.
 // The current encoding removes the need to unpack and repack permissions, which a more compact encoding is likely to need.
@@ -210,7 +210,7 @@ The variables in <<rvy64_uni_base_name_bndsenc_param_summary>> are either taken 
 These variables are used as shown in the <<bounds_variable_usage,pseudo-code>> below.
 
 The bit widths of `T` and `B` are defined in terms of the mantissa width (`MW`) which
-is set depending on capability encoding as shown in
+is set depending on capability-encoding format as shown in
 xref:rvy64_uni_base_name_param_summary[xrefstyle=short].
 
 The exponent `E` indicates the position of `T` and `B` within the capability's
@@ -262,7 +262,7 @@ In the pseudo-code below:
 
 * `EF`, `T`, `TE`, `B` and `BE` are all encoded in the capability metadata, see <<cap_encoding_xlen64_field_table>>
 ** `L8` is also a capability metadata field but only encoded if `enableL8=1`.
-* `EW`, `MW`, `CAP_MAX_E` and `enableL8` are all capability encoding format parameters, see <<rvy64_uni_base_name_param_summary>>.
+* `EW`, `MW`, `CAP_MAX_E` and `enableL8` are all capability-encoding format parameters, see <<rvy64_uni_base_name_param_summary>>.
 * `LCout` and `LMSB` are intermediate values used to reconstitute the top two bits of `T`, see below.
 
 [source]
@@ -446,7 +446,7 @@ equivalent to _base_=0 and _top_{ge}2^XLEN^.
 
 A capability is _malformed_ if its bounds cannot be correctly decoded.
 The following check indicates whether a capability is malformed.
-If `enableL8=1` the `L~8~` bit is available in the capability encoding format for extra precision when `EF=1`.
+If `enableL8=1` the `L~8~` bit is available in the capability-encoding format for extra precision when `EF=1`.
 
 [source]
 ----
@@ -611,7 +611,7 @@ The exponent value causes its bounds to cover the entire address space, but no p
 | Reserved | zeros  | All reserved fields
 |==============================================================================
 
-^1^ Only present if `enableL8=1` as defined by the capability encoding format.
+^1^ Only present if `enableL8=1` as defined by the capability-encoding format.
 
 Permissions added by extensions (such as those of <<section_zylevels1>>) are presumed absent in NULL capabilities.
 
@@ -641,7 +641,7 @@ This infinite capability is both a <<root-rx-cap>> and a <<root-rw-cap>> capabil
 | Reserved      | zeros | All reserved fields
 |==============================================================================
 
-^1^ Only present if `enableL8=1` as defined by the capability encoding format.
+^1^ Only present if `enableL8=1` as defined by the capability-encoding format.
 
 ^2^If an infinite capability is used as a constant in either hardware or software, then the address field will typically be set to zero.
  If the address field is non-zero then it is still referred to as an infinite capability, and it still has the authority to authorize all memory accesses.

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -27,7 +27,7 @@ The fundamental rule for any CHERI system is that the {ctag} and data are always
 
 NOTE: Clearing a {ctag} may be performed without changing the associated data, provided stale tagged data can never be observed.
 
-=== Small CHERI system example
+=== Small CHERI System Example
 
 [#small_cheri_system]
 .Example small CHERI system with local {ctag} storage
@@ -41,7 +41,7 @@ Therefore, the connection between CPU and memory is tag-aware, and the connectio
 
 All writes from the system port to the memory must clear any memory {ctag}s to follow the rules from above.
 
-=== Large CHERI system example
+=== Large CHERI System Example
 
 [#large_cheri_system]
 .Example large CHERI system with {ctag} cache
@@ -71,7 +71,7 @@ For further information on the {ctag} cache see cite:[tagged-memory].
 
 <<<
 
-=== Large CHERI pure-capability system example
+=== Large CHERI Pure-Capability System Example
 
 [#large_cheri_purecap_system]
 .Example large CHERI system with only tag-aware bus masters

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -83,7 +83,7 @@ The <<zylevels1_gl_flag>> is treated as a permission by <<CLRPERM>> and <<GCPERM
 Unlike actual permissions it is not subject to the sealed check, and so <<CLRPERM>> can produce a new capability with its <<zylevels1_gl_flag>> cleared, even if the source capability is sealed.
 
 [#zylevels1-clrperm-rules]
-==== Additional <<CLRPERM>> permission rules
+==== Additional <<CLRPERM>> Permission Rules
 
 The following <<CLRPERM>> permission rules are added:
 


### PR DESCRIPTION
LY and SY appeared before the general description of loads and stores under CHERI which made the text awkward and it had duplicate text.
Introducing the effect on RVI instructions _first_ solves this by introducing basic load/store behaviour and _then_ LY/SY

**beware** this reorders text and so will conflict - best handle this one quickly

The ARC request was to remove the duplicate text from LY/SY, and this restructuring makes that feasible.


Subsequent commits are for ARC feedback which are affected by the reordering in the first commit, all non-normative.