### PR TITLE
remove irregular behaviour of BNE, BEQ

### DIFF
--- a/src/cheri/attributes.adoc
+++ b/src/cheri/attributes.adoc
@@ -388,8 +388,6 @@ endif::support_varxlen[]
 
 //these do not have vars for names as they have not (recently) been renamed
 :AUIPC_CHERI_DESC:         Add upper immediate to <<pcc>>
-:BNE_CHERI_DESC:           Immediate offset condition branch, taken if operands are not equal
-:BEQ_CHERI_DESC:           Immediate offset condition branch, taken if operands are equal
 :JAL_CHERI_DESC:           Immediate offset jump, and link to capability register
 :JALR_CHERI_DESC:          Jump to capability register, and link to capability register
 

--- a/src/cheri/csv/CHERI_ISA.csv
+++ b/src/cheri/csv/CHERI_ISA.csv
@@ -6,8 +6,6 @@ C_STORE_CAP_SP,C.SCSP,{rvy_zca_ext_name},✔,✔,✔,,C2,,C.FSWSP,C.FSDSP,{C_STO
 C_LOAD_CAP,C.LC,{rvy_zca_ext_name},✔,✔,✔,,C0,,C.FLW,C.FLD,{C_LOAD_CAP_NAME_DESC},,,,,,,,,v1
 C_STORE_CAP,C.SC,{rvy_zca_ext_name},✔,✔,✔,,C0,,C.FSW,C.FSD,{C_STORE_CAP_NAME_DESC} ,,,,,,,,,v1
 AUIPC_CHERI,AUIPCC,{rvy_i_mod_ext_name},✔,✔,,,,AUIPC,,,{AUIPC_CHERI_DESC},,,,,,,,,v1
-BEQ_CHERI,BEQ,{rvy_i_mod_ext_name},✔,✔,,,BRANCH,B-type,,,{BEQ_CHERI_DESC},,,,,,,,,v1
-BNE_CHERI,BNE,{rvy_i_mod_ext_name},✔,✔,,,BRANCH,B-type,,,{BNE_CHERI_DESC},,,,,,,,,v1
 {CADD},CADD,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{CADD_DESC},,,,,,,,,v1
 {CADDI},CADDI,{cheri_base_ext_name},✔,✔,,,OP,I-type,,,{CADDI_DESC},,,,,,,,,v1
 {SCADDR},SCADDR,{cheri_base_ext_name},✔,✔,,,OP,R-type,,,{SCADDR_DESC},,,,,,,,,v1

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -1136,26 +1136,11 @@ These rules affect the following <<rv32,base ISA>> instructions listed in <<tab_
 |<<AUIPC_CHERI>>            | {AUIPC_CHERI_DESC}
 |<<JAL_CHERI>>              | {JAL_CHERI_DESC}
 |<<JALR_CHERI>>             | {JALR_CHERI_DESC}
-|<<BEQ_CHERI, BEQ ({cheri_base_ext_name})>> | {BEQ_CHERI_DESC}
-|<<BNE_CHERI, BNE ({cheri_base_ext_name})>> | {BNE_CHERI_DESC}
 |=======================
 
 include::insns/auipc_32bit.adoc[]
 include::insns/jal_32bit.adoc[]
 include::insns/jalr_32bit.adoc[]
-
-==== BEQ, BNE ({cheri_base_ext_name})
-anchor:BEQ_CHERI[BEQ ({cheri_base_ext_name})]
-anchor:BNE_CHERI[BNE ({cheri_base_ext_name})]
-
-For `beq` and `bne` only, if `rs1≤rs2` then the encoding is _reserved_.
-This includes all encodings with `rs1=rs2`.
-
-NOTE: The reserved encodings are redundant and may be used by future extensions, suggestions include branching on {ctag} values only, or YLEN-bit compares.
-
-NOTE: For `beq rs1, rs2, offset` and `bne rs1, rs2, offset`, assemblers must emit the operand order whose register-number ordering is not reserved.
-For example, `beq x1, x2, offset` is emitted as `beq x2, x1, offset`.
-For the reserved `rs1=rs2` case, `j`/`jal` can be used instead of an always-taken `beq rs1, rs1, offset`, and a never-taken `bne rs1, rs1, offset` is equivalent to a `nop`.
 
 === {cheri_base_ext_name} ISA summary
 


### PR DESCRIPTION
Fix #1235 

Make branch encodings regular with RVI.
Avoid future pain from haivn girregular branch encodings, as the encoding space restrictions have been eased by reallocating custom space.