### PR TITLE
Capitalise headings, remove inline :leveloffset: directives

### DIFF
--- a/src/cheri/app-hybrid-usage.adoc
+++ b/src/cheri/app-hybrid-usage.adoc
@@ -205,7 +205,7 @@ These registers hold the capability for the exception vector.
   When an exception or interrupt occurs, the hardware installs this capability into <<pcc>>, thereby setting the mode for the trap handler.
   For example, if <<stvec_y,stvec>> was set up with its <<p_bit>> set to {CAP_MODE_VALUE}, the processor will switch to {cheri_cap_mode_name} on entry to the trap handler.
 
-=== CHERI Enable Bits in Setup (when changing privilege levels)
+=== CHERI Enable Bits in Setup (When Changing Privilege Levels)
 
 In addition to setting up capabilities and mode bits, the execution environment must manage the CHERI enable bits provided by the privileged architecture:
 

--- a/src/cheri/app-standalone-unpriv-refs.adoc
+++ b/src/cheri/app-standalone-unpriv-refs.adoc
@@ -1,6 +1,6 @@
 ifdef::cheri_standalone_spec[]
 
-== Placeholder references to the unprivileged spec
+== Placeholder References to the Unprivileged Spec
 
 WARNING: This chapter only exists for the standalone document to allow references to resolve.
 

--- a/src/cheri/cheri_priv_isa_tables.adoc
+++ b/src/cheri/cheri_priv_isa_tables.adoc
@@ -18,8 +18,8 @@ include::{generated_dir}/{rvy_h_file_name}.adoc[]
 
 endif::[]
 
-[#rvy_m_insn_table, reftext="Machine level ISA for {cheri_base_ext_name}"]
-=== Machine level ISA for {cheri_base_ext_name}
+[#rvy_m_insn_table, reftext="Machine Level ISA for {cheri_base_ext_name}"]
+=== Machine Level ISA for {cheri_base_ext_name}
 
 .Machine level ISA, modified instructions for {cheri_base_ext_name}
 [#rvy_m_isa]
@@ -28,8 +28,8 @@ endif::[]
 include::{generated_dir}/RVY_M_insns_table_body.adoc[]
 |==============================================================================
 
-[#rvy_s_insn_table, reftext="Supervisor level ISA for {cheri_base_ext_name}"]
-=== Supervisor level ISA for {cheri_base_ext_name}
+[#rvy_s_insn_table, reftext="Supervisor Level ISA for {cheri_base_ext_name}"]
+=== Supervisor Level ISA for {cheri_base_ext_name}
 
 .Supervisor level ISA, modified instructions for {cheri_base_ext_name}
 [#rvy_s_isa]

--- a/src/cheri/riscv-cheri.adoc
+++ b/src/cheri/riscv-cheri.adoc
@@ -20,7 +20,7 @@ Assume anything could still change, but limited change should be expected.
 ====
 
 [preface]
-== Copyright and license information
+== Copyright and License Information
 This specification is licensed under the Creative Commons
 Attribution 4.0 International License (CC-BY 4.0). The full
 license text is available at
@@ -37,7 +37,7 @@ include::contributors.adoc[]
 
 include::introduction.adoc[]
 
-= Chapters for the unprivileged specification
+= Chapters for the Unprivileged Specification
 
 include::riscv-unpriv-integration.adoc[]
 include::vector-integration.adoc[]
@@ -53,7 +53,7 @@ endif::[]
 
 include::cheri-unpriv-appendix.adoc[]
 
-= Chapters for the privileged specification
+= Chapters for the Privileged Specification
 
 include::riscv-priv-integration.adoc[]
 include::cheri-pte-ext.adoc[]

--- a/src/cheri/riscv-hybrid-integration.adoc
+++ b/src/cheri/riscv-hybrid-integration.adoc
@@ -165,7 +165,7 @@ The <<p_bit>> of a <<x_perm>>-granting capability can be read and written by the
 NOTE: In addition to the mode switching instructions, the current mode can also be updated by setting the <<p_bit>> of a target capability using <<SCMODE>> followed by a <<JALR_CHERI>>.
 
 [#zyhybrid-clrperm-rules]
-==== Additional <<CLRPERM>> permission rule
+==== Additional <<CLRPERM>> Permission Rule
 
 The following <<CLRPERM>> permission rule is added:
 
@@ -190,7 +190,7 @@ auipc {creg}1, 0
 {gctag_lc} x1, {creg}1
 ----
 
-=== Added instructions
+=== Added Instructions
 
 include::insns/scmode_32bit.adoc[]
 

--- a/src/cheri/riscv-priv-integration.adoc
+++ b/src/cheri/riscv-priv-integration.adoc
@@ -336,7 +336,7 @@ and <<utidc>> CSRs.
 endif::[]
 
 [#sec_cheri_exception_handling]
-=== CHERI Exception handling
+=== CHERI Exception Handling
 
 CHERI faults are typically higher priority than standard RISC-V faults. E.g., CHERI faults on the <<pcc>> are higher priority than any other fault affecting the program counter such as Instruction Access Fault.
 
@@ -384,8 +384,8 @@ NOTE: In the table below `auth_cap` is `{cs1}`, unless {cheri_default_ext_name} 
 
 ^3^ Misaligned capability accesses raise access faults instead of misaligned faults since they cannot be emulated in software.
 
-[#CHERI_SPEC,reftext="CHERI Exceptions and speculative execution"]
-=== CHERI Exceptions and speculative execution
+[#CHERI_SPEC,reftext="CHERI Exceptions and Speculative Execution"]
+=== CHERI Exceptions and Speculative Execution
 
 NOTE: #ARC-NOTE: Please advise whether this section should remain in this chapter, or whether it should be expanded and placed in a supporting document.#
 
@@ -448,7 +448,7 @@ Setting the MBE, SBE, or UBE field to a value that is not the reset value of MBE
 
 endif::support_varxlen[]
 
-=== Machine-mode YLEN CSR Summary
+=== Machine-Mode YLEN CSR Summary
 
 <<all_capability_CSRs_m>> shows all YLEN Machine-mode CSRs added or modified by {cheri_base_ext_name}.
 
@@ -579,7 +579,7 @@ include::img/stidcreg.edn[]
 === Supervisor-Level CSRs modified by {cheri_base_ext_name}
 
 [#senvcfg_y,reftext="senvcfg ({cheri_base_ext_name})"]
-==== Supervisor environment configuration register (senvcfg)
+==== Supervisor Environment Configuration Register (senvcfg)
 
 <<section_cheri_hybrid_ext>> adds the {CRE} bit to *senvcfg*.
 The {CRE} bit can be used to disable or enable {cheri_base_ext_name} for U-mode, as described in xref:section_cheri_disable[xrefstyle=full].
@@ -614,7 +614,7 @@ See <<utidc>> for a description of the usage.
 
 include::insns/mret_sret.adoc[]
 
-=== Supervisor-mode YLEN CSR Summary
+=== Supervisor-Mode YLEN CSR Summary
 
 <<all_capability_CSRs_s>> shows all YLEN Supervisor-mode CSRs added or modified by {cheri_base_ext_name}.
 
@@ -671,7 +671,7 @@ Such sharing through virtual memory is on the page granularity, so preventing ca
 ====
 
 [#section_pte_rvy,reftext="_pte_._rvy_ field"]
-=== The _pte_._{cheri_base_ext_name_lc}_ field for capability flow control
+=== The _pte_._{cheri_base_ext_name_lc}_ Field for Capability Flow Control
 
 [NOTE]
 ====
@@ -756,7 +756,7 @@ If the effective address of the memory access is invalid, and the authorizing ca
 
 ifndef::cheri_standalone_spec[]
 
-==== List of terms defined in the unprivileged manual
+==== List of Terms Defined in the Unprivileged Manual
 
 NOTE: Due to links to the unprivileged manual being broken, this improves readability.
  Once the two manuals are merged the links will work.

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -867,9 +867,7 @@ Standard {cheri_base_ext_name} instructions use the former three, leaving a sing
 In the future parts of *{cheri_base_ext_name}-A/B/C* may be allocated for custom use.
 ====
 
-:leveloffset: +1
-
-=== Instructions to Update The Capability Pointer
+==== Instructions to Update The Capability Pointer
 
 Creating a new capability with a different address (i.e., updating the pointer) requires specific instructions instead of integer ADD/ADDI.
 These instructions all include a check that the resulting address can be <<section_cap_representable_check,represented exactly>> within the new capability.
@@ -883,12 +881,12 @@ These instructions all include a check that the resulting address can be <<secti
 |<<SCADDR>>   | {SCADDR_DESC}
 |=======================
 
-include::insns/cadd_32bit.adoc[]
-include::insns/scaddr_32bit.adoc[]
+include::insns/cadd_32bit.adoc[leveloffset=+1]
+include::insns/scaddr_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Instructions to Manipulate Capabilities
+==== Instructions to Manipulate Capabilities
 
 For security, capabilities can only be modified in restricted ways.
 Special instructions are provided to copy capabilities or derive a new capability using manipulations such as _shrinking_ the bounds (<<SCBNDS>>), _reducing_ the permissions (<<CLRPERM>>) or _authorizing_ a capability with another one which has a superset (or identical) bounds and permissions (<<CBLD>>).
@@ -923,18 +921,18 @@ Among the instructions that use the subset relation, this is only material for t
 
 ^1^ <<SCHI>> is a pseudoinstruction for <<SCHI_BASE>>
 
-include::insns/acperm_32bit.adoc[]
-include::insns/cmv_32bit.adoc[]
-include::insns/schi_32bit.adoc[]
-include::insns/scbnds_32bit.adoc[]
-include::insns/scbndsr_32bit.adoc[]
-include::insns/ysunseal_32bit.adoc[]
-include::insns/cbld_32bit.adoc[]
-include::insns/sentry_32bit.adoc[]
+include::insns/acperm_32bit.adoc[leveloffset=+1]
+include::insns/cmv_32bit.adoc[leveloffset=+1]
+include::insns/schi_32bit.adoc[leveloffset=+1]
+include::insns/scbnds_32bit.adoc[leveloffset=+1]
+include::insns/scbndsr_32bit.adoc[leveloffset=+1]
+include::insns/ysunseal_32bit.adoc[leveloffset=+1]
+include::insns/cbld_32bit.adoc[leveloffset=+1]
+include::insns/sentry_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Instructions to Decode Capability Bounds
+==== Instructions to Decode Capability Bounds
 
 The _bounds_ describing the range of addresses the capability gives access to are stored in a compressed format.
 These instructions query the bounds and related information.
@@ -948,13 +946,13 @@ These instructions query the bounds and related information.
 |<<GCTOP>>  | {GCTOP_DESC}
 |=======================
 
-include::insns/gcbase_32bit.adoc[]
-include::insns/gclen_32bit.adoc[]
-include::insns/gctop_32bit.adoc[]
+include::insns/gcbase_32bit.adoc[leveloffset=+1]
+include::insns/gclen_32bit.adoc[leveloffset=+1]
+include::insns/gctop_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Instructions to Extract Capability Fields
+==== Instructions to Extract Capability Fields
 
 These instructions either directly read bit fields from the metadata or {ctag}, or only apply simple transformations on the metadata.
 
@@ -969,14 +967,14 @@ These instructions either directly read bit fields from the metadata or {ctag}, 
 |=======================
 
 
-include::insns/gctag_32bit.adoc[]
-include::insns/gcperm_32bit.adoc[]
-include::insns/gctype_32bit.adoc[]
-include::insns/gchi_32bit.adoc[]
+include::insns/gctag_32bit.adoc[leveloffset=+1]
+include::insns/gcperm_32bit.adoc[leveloffset=+1]
+include::insns/gctype_32bit.adoc[leveloffset=+1]
+include::insns/gchi_32bit.adoc[leveloffset=+1]
 
 <<<
 
-=== Miscellaneous Instructions to Handle Capability Data
+==== Miscellaneous Instructions to Handle Capability Data
 
 .Miscellaneous capability instruction summary in {cheri_base_ext_name}
 [#tab_cap_misc_summary,%autowidth,options=header,align="center",cols="1,4"]
@@ -987,14 +985,14 @@ include::insns/gchi_32bit.adoc[]
 |<<CRAM>>   | {CRAM_DESC}
 |=======================
 
-include::insns/sceq_32bit.adoc[]
-include::insns/scss_32bit.adoc[]
-include::insns/cram_32bit.adoc[]
+include::insns/sceq_32bit.adoc[leveloffset=+1]
+include::insns/scss_32bit.adoc[leveloffset=+1]
+include::insns/cram_32bit.adoc[leveloffset=+1]
 
 <<<
 
 [#sec_cap_load_store]
-=== Instructions to Load and Store Capability Data
+==== Instructions to Load and Store Capability Data
 
 New loads and stores are introduced to handle capability data, <<LOAD_CAP>> and <<STORE_CAP>>.
 These capability load and store instructions atomically access YLEN bits of data and the associated {ctag}.
@@ -1031,12 +1029,10 @@ See <<LOAD_CAP>> for details.
 |<<STORE_CAP>>     |Store capability
 |=======================
 
-include::insns/load_32bit_cap.adoc[]
-include::insns/store_32bit_cap.adoc[]
+include::insns/load_32bit_cap.adoc[leveloffset=+1]
+include::insns/store_32bit_cap.adoc[leveloffset=+1]
 
 <<<
-
-:leveloffset: -1
 
 [#section_existing_riscv_insns]
 === Changes to Existing RISC-V Base ISA Instructions
@@ -1412,12 +1408,10 @@ include::{generated_dir}/{rvy_bndsrdw_insn_file_name}.adoc[]
 
 endif::[]
 
-:leveloffset: +1
-
 ifndef::cheri_ratification_v1_only[]
 
 [[rv32y]]
-== {cheri_base32_ext_name} Base Capability Instruction Set, Version 1.0
+=== {cheri_base32_ext_name} Base Capability Instruction Set, Version 1.0
 
 <<rvy>> introduced the CHERI base ISA and the {rv64y_uni_base_name} encoding format, as the only defined {cheri_base64_ext_name} format.
 
@@ -1441,8 +1435,6 @@ The currently defined RV32 capability-encoding formats are:
 NOTE: Further domain specialized capability-encoding formats are expected in the future.
 
 
-include::rvy32-encoding.adoc[]
+include::rvy32-encoding.adoc[leveloffset=+1]
 
 endif::[]
-
-:leveloffset: -1

--- a/src/cheri/riscv-unpriv-integration.adoc
+++ b/src/cheri/riscv-unpriv-integration.adoc
@@ -31,7 +31,7 @@ NOTE: Future RV64 CHERI capability-encoding formats could be named RV64LYB, RV64
 
 Also see xref:sec_cap_encoding_formats[xrefstyle=full].
 
-=== CHERI protection model
+=== CHERI Protection Model
 
 The CHERI model is motivated by the _principle of least privilege_, which
 argues that greater security can be obtained by minimizing the privileges
@@ -149,14 +149,14 @@ All capabilities derived from invalid capabilities are themselves invalid, i.e.,
 NOTE: Writing non-capability data into a register or memory location causes the {ctag} to be set to zero.
 When the {ctag} associated with the memory location is zero, the location contains non-capability data.
 
-==== {ctag_cap}s in registers
+==== {ctag_cap}s in Registers
 
 Every YLEN-bit register has a one-bit {ctag}, indicating whether the capability in the register is valid to be dereferenced.
 This {ctag} is set to zero whenever an invalid capability operation is performed.
 
 NOTE: Examples of such invalid operations include writing only the integer portion (the address field) of the register or attempting to increase bounds or permissions.
 
-==== {ctag_cap}s in memory
+==== {ctag_cap}s in Memory
 
 {ctag_cap}s are tracked through the memory subsystem: every naturally aligned YLEN-bit wide region has a non-addressable one-bit {ctag}, which the hardware manages atomically with the data.
 The implementation must set the {ctag} to zero if any byte in the naturally aligned YLEN-bit memory region is ever written using an operation other than a store of a capability operand.
@@ -253,7 +253,8 @@ NOTE: {cheri_base_ext_name} implementations that use a different capability-enco
 Such implementations must still support one-past-the-end pointers as required by the C standard, but are not required to support a representable range larger than that.
 Therefore, the ISA specification uses the phrase *represented exactly* for this check.
 
-==== Memory space
+[#cap_memory_space]
+==== Memory Space
 
 A hart supporting {cheri_base_ext_name} has a single byte-addressable address
 space of 2^XLEN^ bytes for all memory accesses. Each memory region capable of
@@ -570,7 +571,7 @@ A capability with all-zero metadata, its {ctag} set to zero, and an address of z
 This capability grants no permissions and any dereference raises an exception.
 
 [#sec_cap_encoding_formats, reftext="capability-encoding format"]
-=== Capability-encoding Formats
+=== Capability-Encoding Formats
 CHERI implementations make trade-offs in their "capability-encoding formats", such as the _precision_ of bounds and the _expressible set_ of combinations of permissions, that impact certain behaviors of the ISA.
 The definition of all CHERI base ISAs includes sufficient details of a capability-encoding format to precisely define the execution behavior of all base ISA instructions.
 
@@ -643,7 +644,7 @@ NOTE: These checks are much less rigorous than parity or ECC protection, and are
 used to detect simple problems with the capability metadata.
 
 NOTE: While a capability whose decoded bounds exceed 2^XLEN^ also represents a loss of integrity resulting from a fault or incompatible IP, detecting this condition requires full bounds decoding and is not included in the capability integrity checks due to implementation cost.
-As described in <<Memory space>>, hardware instead relies on fail-closed bounds checking and <<CBLD>> subset enforcement.
+As described in xref:cap_memory_space[xrefstyle=short], hardware instead relies on fail-closed bounds checking and <<CBLD>> subset enforcement.
 Detecting such conditions is deferred to future reliability extensions.
 
 Instructions that are defined to accept arbitrary input bit patterns, and can write an output with the {ctag} set to one, _must_ perform an integrity check on the input capability if its {ctag} is set to zero.
@@ -818,7 +819,7 @@ The assembler pseudoinstruction to read a capability CSR `csrr {cd}, csr`, is en
 In <<clen_access_summary_base>>, when there is no read or write width shown, the CSR access is _not_ made and there are no side-effects following standard Zicsr rules.
 
 [#sec_cap_checks]
-=== Capability checks
+=== Capability Checks
 
 Every memory access must be authorized by a valid capability.
 
@@ -1068,7 +1069,7 @@ The rules above apply to the <<rv32,base ISA>> instructions listed in the follow
 Any change to instruction semantics for {cheri_base_ext_name} is called out in the chapter defining the extension.
 
 [#section_cheri_int_load_store_insns]
-==== Changes to load/stores
+==== Changes to Load/Stores
 
 All load and store instructions behave as described in <<ldst>> with one fundamental difference:
 
@@ -1157,10 +1158,10 @@ NOTE: For `beq rs1, rs2, offset` and `bne rs1, rs2, offset`, assemblers must emi
 For example, `beq x1, x2, offset` is emitted as `beq x2, x1, offset`.
 For the reserved `rs1=rs2` case, `j`/`jal` can be used instead of an always-taken `beq rs1, rs1, offset`, and a never-taken `bne rs1, rs1, offset` is equivalent to a `nop`.
 
-=== {cheri_base_ext_name} ISA summary
+=== {cheri_base_ext_name} ISA Summary
 
 [#rvy_insn_table, reftext="{cheri_base_ext_name}"]
-==== {cheri_base_ext_name} added instructions
+==== {cheri_base_ext_name} Added Instructions
 
 .{cheri_base_ext_name} added instructions
 [#{rvy_file_name}]
@@ -1184,7 +1185,7 @@ include::rvy64-encoding.adoc[]
 ifdef::cheri_standalone_spec[]
 
 [#rvy_zca_insn_table, reftext="{rvy_zca_ext_name}"]
-== Zca ({cheri_base_ext_name} added and modified instructions)
+== Zca ({cheri_base_ext_name} Added and Modified Instructions)
 
 ifndef::cheri_ratification_v1_only[]
 Zcf (RV32) and Zcd (RV64) are incompatible with the {cheri_base_ext_name} base ISA, as their encodings are reused for the capability loads and stores below.
@@ -1204,13 +1205,13 @@ include::{generated_dir}/{rvy_zca_file_name}.adoc[]
 
 ifndef::cheri_ratification_v1_only[]
 //this has all been integrated into the relevant chapter
-=== RV32 / {cheri_base32_ext_name} RVC load/store mapping summary
+=== RV32 / {cheri_base32_ext_name} RVC Load/Store Mapping Summary
 
 include::rv32c_mapping_table.adoc[]
 endif::[]
 
 <<<
-=== RV64 / {cheri_base64_ext_name} RVC load/store mapping summary
+=== RV64 / {cheri_base64_ext_name} RVC Load/Store Mapping Summary
 
 include::rv64c_mapping_table.adoc[]
 

--- a/src/cheri/rvy-cheriot-enc1.adoc
+++ b/src/cheri/rvy-cheriot-enc1.adoc
@@ -263,7 +263,7 @@ If this check fails, the resulting capability will have its {ctag} set to zero.
 Note that this means that it is not possible to represent a capability with an address less than the base.
 Depending on the size of the capability some addresses above top may be representable, but in the worst case the highest representable address is equal to top (one byte beyond the end of the dereferenceable region).
 
-===== Encoding bounds
+===== Encoding Bounds
 
 When <<SCBNDS>> is used to set the bounds of a capability the E, B, and T fields are computed from the desired base and length as follows:
 

--- a/src/cheri/rvy32-encoding.adoc
+++ b/src/cheri/rvy32-encoding.adoc
@@ -83,7 +83,7 @@ NOTE: Extensions which allocate new permissions need to specify modifications to
 
 <<<
 [AP-encoding-rv32y]
-===== AP encoding and rules
+===== AP Encoding and Rules
 
 All gaps in <<cap_perms_encoding_nolevels32>> are _reserved_ for future extensions.
 
@@ -206,7 +206,7 @@ The following rules are run once _in order_:
 . `RV32-base-6,7`
 
 [#default-cap-AP-hybrid-zylevels1]
-==== AP encoding and rules summary with {cheri_levels1_ext_name} for {rv32y_uni_base_name}
+==== AP Encoding and Rules Summary with {cheri_levels1_ext_name} for {rv32y_uni_base_name}
 
 This section is non-normative - it summarizes the overall encoded permissions table and <<CLRPERM>> rules when both <<section_cheri_hybrid_ext>> and <<section_zylevels1>> are implemented.
 

--- a/src/cheri/rvy64-encoding.adoc
+++ b/src/cheri/rvy64-encoding.adoc
@@ -419,7 +419,7 @@ In summary, for either bound:
 * If the bound is above the _s_-aligned boundary and the capability address is below the _s_-aligned boundary, then set the correction factor to +1 to correct the bound upwards.
 
 [#t_bound_msb_inversion]
-===== Top bound address MSB correction
+===== Top Bound Address MSB Correction
 
 A capability has _infinite_ bounds if its bounds cover the entire address space
 such that _base_=0 and _top_{ge}2^XLEN^,

--- a/src/cheri/system.adoc
+++ b/src/cheri/system.adoc
@@ -27,7 +27,7 @@ The fundamental rule for any CHERI system is that the {ctag} and data are always
 
 NOTE: Clearing a {ctag} may be performed without changing the associated data, provided stale tagged data can never be observed.
 
-=== Small CHERI system example
+=== Small CHERI System Example
 
 [#small_cheri_system]
 .Example small CHERI system with local {ctag} storage
@@ -41,7 +41,7 @@ Therefore, the connection between CPU and memory is tag-aware, and the connectio
 
 All writes from the system port to the memory must clear any memory {ctag}s to follow the rules from above.
 
-=== Large CHERI system example
+=== Large CHERI System Example
 
 [#large_cheri_system]
 .Example large CHERI system with {ctag} cache
@@ -71,7 +71,7 @@ For further information on the {ctag} cache see cite:[tagged-memory].
 
 <<<
 
-=== Large CHERI pure-capability system example
+=== Large CHERI Pure-Capability System Example
 
 [#large_cheri_purecap_system]
 .Example large CHERI system with only tag-aware bus masters

--- a/src/cheri/zylevels1.adoc
+++ b/src/cheri/zylevels1.adoc
@@ -83,7 +83,7 @@ The <<zylevels1_gl_flag>> is treated as a permission by <<CLRPERM>> and <<GCPERM
 Unlike actual permissions it is not subject to the sealed check, and so <<CLRPERM>> can produce a new capability with its <<zylevels1_gl_flag>> cleared, even if the source capability is sealed.
 
 [#zylevels1-clrperm-rules]
-==== Additional <<CLRPERM>> permission rules
+==== Additional <<CLRPERM>> Permission Rules
 
 The following <<CLRPERM>> permission rules are added:
 

--- a/src/cheri/zylevelsN.adoc
+++ b/src/cheri/zylevelsN.adoc
@@ -119,10 +119,10 @@ ifdef::cheri_v9_annotations[]
 NOTE: The current specification only defines up to two levels, equivalent to _local_ and _global_ capabilities from CHERI v9, Morello, and CHERIoT.
 endif::[]
 
-=== Encoding material (TODO)
+=== Encoding Material (TODO)
 
 [#section_ext_cheri_multiple_levels]
-=== Extending {cheri_1levels_ext_name} to more than two levels
+=== Extending {cheri_1levels_ext_name} to More Than Two Levels
 When `<<cheri_lvlbits>> > 1`, the behavior of <<CLRPERM>> can no longer use masking to adjust the <<zylevelsN_cl_field>> or <<zylevelsN_sl_perm>>, but instead must perform an integer minimum operation on those `<<cheri_lvlbits>>`-wide fields.
 The <<zylevelsN_cl_field,CL>> field of the resulting capability is set to `min(rs2[CL], {cs1}[CL])`  (equivalent to `rs2[CL] & {cs1}[CL]` for `<<cheri_lvlbits>>=1`).
 Similarly, <<zylevelsN_sl_perm>> is set to `min(rs2[SL], {cs1}[SL])` (equivalent to `rs2[SL] & {cs1}[SL]` for `<<cheri_lvlbits>>=1`).


### PR DESCRIPTION
Smarten up the document with consistent headings.
Easier maintenance without :leveloffset: directives so the text can be reordered if necessary. 